### PR TITLE
Stop editor: geocoded location label with auto-locate for new stops

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,10 @@ MVVM + repository, hand-rolled DI — no Hilt, no Room. Package root:
   (`campingCostTotal`); the CAMPING expense type is only for extra site fees. Breakdown
   merges both into the CAMPING category. The fuel estimator (`domain/FuelEstimator.kt`)
   prefills distance as haversine leg-sum × `roadDistanceFactor` from settings; estimator-
-  created expenses carry `isEstimate = true`.
+  created expenses carry `isEstimate = true`. Trips with **no** recorded FUEL expense get
+  an automatic fuel estimate (`FuelEstimator.autoTripFuelCost`, same distance formula)
+  that is computed at display time, never stored: TripDetail and TripList add it to the
+  shown total with a `≈` prefix (the denormalized `Trip.totalCost` stays actuals-only).
 - **Navigation** (`ui/nav/`): type-safe kotlinx-serialization routes. The location picker
   returns its result through the **previous** back-stack entry's `SavedStateHandle` under
   `PICKED_LOCATION_KEY` (a `DoubleArray`); `AppNavHost` observes it and feeds

--- a/README.md
+++ b/README.md
@@ -38,3 +38,29 @@ Compose Navigation (type-safe routes) · MapLibre Compose · Firebase Auth/Fires
 Requires JDK 17+ and an Android SDK with platform 37 (`local.properties` →
 `sdk.dir`). Use an emulator image with Play services (needed for sign-in and
 fused location); mock GPS via the emulator's extended controls.
+
+### Installing on a physical phone
+
+One-time phone setup:
+
+1. Enable Developer Options: Settings → About phone → tap **Build number** 7 times.
+2. Settings → System → Developer options → enable **USB debugging**.
+3. Connect the phone via USB. On the phone, accept the **Allow USB debugging?**
+   dialog (tick "Always allow from this computer" to skip it next time).
+
+Then, from the project root:
+
+```bash
+~/Android/Sdk/platform-tools/adb devices   # phone should show as "device", not "unauthorized"
+./gradlew :app:installDebug                # build + install the debug APK
+```
+
+The app appears in the launcher as **CamperExperience**. Re-running
+`installDebug` updates it in place (data is kept). Notes:
+
+- This is the **debug** build. Without `app/google-services.json` it runs in
+  local demo mode; with it, Google Sign-In works on a real phone out of the box
+  (real phones have Play services).
+- If the USB cable only charges, it may be a power-only cable — use a data cable.
+- Alternative, cable-free: Developer options → **Wireless debugging** → pair via
+  `adb pair <ip>:<port>` once, then `adb connect <ip>:<port>` on the same Wi-Fi.

--- a/app/src/main/java/com/nuelto/camperexperience/data/FirestoreTripRepository.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/data/FirestoreTripRepository.kt
@@ -14,9 +14,13 @@ import com.nuelto.camperexperience.data.model.Stop
 import com.nuelto.camperexperience.data.model.Trip
 import com.nuelto.camperexperience.domain.CostCalculator
 import java.time.LocalDate
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.tasks.await
 
@@ -136,27 +140,18 @@ class FirestoreTripRepository(
         trips(uid).document(tripId).collection("expenses").orderBy("date").asSnapshotFlow()
             .map { docs -> docs.map { it.toExpense(tripId) } }
 
-    override fun allStops(): Flow<List<Stop>> = callbackFlow {
-        // Collection-group query over this user's stops only (path filter via rules +
-        // the parent path in each doc reference).
-        val registration = db.collectionGroup("stops")
-            .addSnapshotListener { snapshot, error ->
-                if (error != null) {
-                    close(error)
-                } else if (snapshot != null) {
-                    val ownPrefix = "users/$uid/"
-                    trySend(
-                        snapshot.documents
-                            .filter { it.reference.path.startsWith(ownPrefix) }
-                            .map { doc ->
-                                val tripId = doc.reference.parent.parent?.id ?: ""
-                                doc.toStop(tripId)
-                            },
-                    )
-                }
+    // A collection-group query on "stops" would be rejected by the security rules
+    // (they are path-scoped, and rules don't filter queries — the query itself must
+    // be provably allowed), so combine the per-trip stops listeners instead.
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun allStops(): Flow<List<Stop>> =
+        trips().flatMapLatest { trips ->
+            if (trips.isEmpty()) {
+                flowOf(emptyList())
+            } else {
+                combine(trips.map { trip -> stops(trip.id) }) { perTrip -> perTrip.toList().flatten() }
             }
-        awaitClose { registration.remove() }
-    }
+        }
 
     // --- writes ------------------------------------------------------------------
 

--- a/app/src/main/java/com/nuelto/camperexperience/data/FirestoreTripRepository.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/data/FirestoreTripRepository.kt
@@ -153,6 +153,17 @@ class FirestoreTripRepository(
             }
         }
 
+    // Same path-scoped-rules constraint as allStops(): no collection-group query.
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun allExpenses(): Flow<List<Expense>> =
+        trips().flatMapLatest { trips ->
+            if (trips.isEmpty()) {
+                flowOf(emptyList())
+            } else {
+                combine(trips.map { trip -> expenses(trip.id) }) { perTrip -> perTrip.toList().flatten() }
+            }
+        }
+
     // --- writes ------------------------------------------------------------------
 
     override suspend fun upsertTrip(trip: Trip): String {

--- a/app/src/main/java/com/nuelto/camperexperience/data/InMemoryTripRepository.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/data/InMemoryTripRepository.kt
@@ -42,6 +42,8 @@ class InMemoryTripRepository(seed: Boolean = true) : TripRepository {
 
     override fun allStops(): Flow<List<Stop>> = stopsFlow
 
+    override fun allExpenses(): Flow<List<Expense>> = expensesFlow
+
     override suspend fun upsertTrip(trip: Trip): String {
         val withId = if (trip.id.isBlank()) trip.copy(id = UUID.randomUUID().toString()) else trip
         tripsFlow.update { list -> list.filterNot { it.id == withId.id } + withId }

--- a/app/src/main/java/com/nuelto/camperexperience/data/TripRepository.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/data/TripRepository.kt
@@ -14,6 +14,9 @@ interface TripRepository {
     /** Every stop across all trips, for the all-trips map. */
     fun allStops(): Flow<List<Stop>>
 
+    /** Every expense across all trips, for per-trip fuel estimates on the trip list. */
+    fun allExpenses(): Flow<List<Expense>>
+
     /** Returns the trip id (generated when trip.id is blank). */
     suspend fun upsertTrip(trip: Trip): String
     suspend fun deleteTrip(tripId: String)

--- a/app/src/main/java/com/nuelto/camperexperience/domain/FuelEstimator.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/domain/FuelEstimator.kt
@@ -1,5 +1,7 @@
 package com.nuelto.camperexperience.domain
 
+import com.nuelto.camperexperience.data.model.Expense
+import com.nuelto.camperexperience.data.model.ExpenseType
 import com.nuelto.camperexperience.data.model.Stop
 import com.nuelto.camperexperience.data.model.UserSettings
 
@@ -7,6 +9,19 @@ object FuelEstimator {
 
     fun estimateCost(distanceKm: Double, consumptionL100km: Double, pricePerLiter: Double): Double =
         distanceKm * consumptionL100km / 100.0 * pricePerLiter
+
+    /**
+     * Automatic fuel estimate for a trip, derived from the driving distance between its
+     * stops. Never stored — computed at display time. Null when the trip already has a
+     * recorded FUEL expense (real costs replace the estimate) or when fewer than two
+     * stops have a location.
+     */
+    fun autoTripFuelCost(stops: List<Stop>, expenses: List<Expense>, settings: UserSettings): Double? {
+        if (expenses.any { it.type == ExpenseType.FUEL }) return null
+        val distanceKm = defaultTripDistanceKm(stops, settings)
+        if (distanceKm <= 0.0) return null
+        return estimateCost(distanceKm, settings.fuelConsumptionL100km, settings.fuelPricePerLiter)
+    }
 
     /**
      * Default distance to prefill the estimator with: straight-line legs between the

--- a/app/src/main/java/com/nuelto/camperexperience/location/PlaceNameResolver.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/location/PlaceNameResolver.kt
@@ -1,0 +1,58 @@
+package com.nuelto.camperexperience.location
+
+import android.content.Context
+import android.location.Address
+import android.location.Geocoder
+import android.os.Build
+import com.nuelto.camperexperience.data.model.LatLng
+import java.util.Locale
+import kotlin.coroutines.resume
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Reverse-geocodes a coordinate to the nearest village/city name using the platform
+ * Geocoder (Play-services backed, no API key). Returns null when the geocoder is
+ * unavailable, offline, or finds nothing.
+ */
+class PlaceNameResolver(private val context: Context) {
+
+    suspend fun placeName(location: LatLng): String? {
+        if (!Geocoder.isPresent()) return null
+        val geocoder = Geocoder(context, Locale.getDefault())
+        val address = withTimeoutOrNull(10_000) {
+            if (Build.VERSION.SDK_INT >= 33) {
+                suspendCancellableCoroutine<Address?> { cont ->
+                    geocoder.getFromLocation(
+                        location.latitude,
+                        location.longitude,
+                        1,
+                        object : Geocoder.GeocodeListener {
+                            override fun onGeocode(addresses: MutableList<Address>) {
+                                cont.resume(addresses.firstOrNull())
+                            }
+
+                            override fun onError(errorMessage: String?) {
+                                cont.resume(null)
+                            }
+                        },
+                    )
+                }
+            } else {
+                withContext(Dispatchers.IO) {
+                    @Suppress("DEPRECATION")
+                    runCatching {
+                        geocoder.getFromLocation(location.latitude, location.longitude, 1)
+                    }.getOrNull()?.firstOrNull()
+                }
+            }
+        } ?: return null
+        // Prefer the village/city; fall back to progressively coarser admin names.
+        return address.locality
+            ?: address.subLocality
+            ?: address.subAdminArea
+            ?: address.adminArea
+    }
+}

--- a/app/src/main/java/com/nuelto/camperexperience/ui/map/LocationSection.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/map/LocationSection.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -30,12 +31,16 @@ import kotlinx.coroutines.launch
 
 /**
  * "Use current position" (one-shot GPS, permission requested lazily) and
- * "Pick on map" buttons for the stop editor.
+ * "Pick on map" buttons for the stop editor. With [autoLocate] the GPS fix is
+ * kicked off immediately (new stops default to the current location);
+ * [onAutoLocateHandled] fires once so a recomposition never re-triggers it.
  */
 @Composable
 fun LocationSection(
     onLocationChange: (LatLng) -> Unit,
     onPickOnMap: () -> Unit,
+    autoLocate: Boolean = false,
+    onAutoLocateHandled: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -64,20 +69,29 @@ fun LocationSection(
         }
     }
 
+    fun locate() {
+        val granted = ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.ACCESS_FINE_LOCATION,
+        ) == PackageManager.PERMISSION_GRANTED
+        if (granted) {
+            fetchLocation()
+        } else {
+            permissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
+    }
+
+    LaunchedEffect(autoLocate) {
+        if (autoLocate) {
+            onAutoLocateHandled()
+            locate()
+        }
+    }
+
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             OutlinedButton(
-                onClick = {
-                    val granted = ContextCompat.checkSelfPermission(
-                        context,
-                        Manifest.permission.ACCESS_FINE_LOCATION,
-                    ) == PackageManager.PERMISSION_GRANTED
-                    if (granted) {
-                        fetchLocation()
-                    } else {
-                        permissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
-                    }
-                },
+                onClick = ::locate,
                 modifier = Modifier.weight(1f),
             ) {
                 Icon(Icons.Default.MyLocation, contentDescription = null)

--- a/app/src/main/java/com/nuelto/camperexperience/ui/nav/AppNavHost.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/nav/AppNavHost.kt
@@ -63,6 +63,7 @@ fun AppNavHost() {
                     backStackEntry.savedStateHandle[PICKED_LOCATION_KEY] = null
                 }
             }
+            val stopEditState by viewModel.uiState.collectAsStateWithLifecycle()
             StopEditScreen(
                 onBack = { navController.popBackStack() },
                 viewModel = viewModel,
@@ -75,6 +76,8 @@ fun AppNavHost() {
                                 LocationPickerRoute(location?.latitude, location?.longitude),
                             )
                         },
+                        autoLocate = stopEditState.autoLocatePending,
+                        onAutoLocateHandled = viewModel::autoLocateHandled,
                     )
                 },
             )

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreen.kt
@@ -160,6 +160,7 @@ fun TripDetailScreen(
                     total = trip.totalCost,
                     nights = trip.nights,
                     breakdown = state.breakdown,
+                    fuelEstimate = state.fuelEstimate,
                     currency = state.settings.currency,
                 )
             }
@@ -258,6 +259,7 @@ fun CostBreakdownCard(
     total: Double,
     nights: Int,
     breakdown: Map<ExpenseType, Double>,
+    fuelEstimate: Double?,
     currency: String,
 ) {
     Card(Modifier.fillMaxWidth()) {
@@ -269,7 +271,11 @@ fun CostBreakdownCard(
             ) {
                 Text("Total", style = MaterialTheme.typography.titleMedium)
                 Text(
-                    formatCurrency(total, currency),
+                    if (fuelEstimate != null) {
+                        "≈ ${formatCurrency(total + fuelEstimate, currency)}"
+                    } else {
+                        formatCurrency(total, currency)
+                    },
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.primary,
@@ -280,19 +286,36 @@ fun CostBreakdownCard(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            if (breakdown.isNotEmpty()) {
+            if (breakdown.isNotEmpty() || fuelEstimate != null) {
                 HorizontalDivider()
-                breakdown.forEach { (type, amount) ->
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                    ) {
-                        Text(type.displayName, style = MaterialTheme.typography.bodyMedium)
-                        Text(formatCurrency(amount, currency), style = MaterialTheme.typography.bodyMedium)
-                    }
+                // A fuel estimate only exists when there is no FUEL entry in the
+                // breakdown, so this keeps the category order stable.
+                breakdown[ExpenseType.CAMPING]?.let { BreakdownRow(ExpenseType.CAMPING.displayName, it, currency) }
+                fuelEstimate?.let { BreakdownRow("${ExpenseType.FUEL.displayName} (estimate)", it, currency) }
+                for (type in listOf(ExpenseType.FUEL, ExpenseType.ROAD_TAX, ExpenseType.OTHER)) {
+                    breakdown[type]?.let { BreakdownRow(type.displayName, it, currency) }
+                }
+                if (fuelEstimate != null) {
+                    Text(
+                        "Fuel is estimated by driving distance between stops — log a fuel expense to replace it.",
+                        style = MaterialTheme.typography.bodySmall,
+                        fontStyle = FontStyle.Italic,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun BreakdownRow(label: String, amount: Double, currency: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyMedium)
+        Text(formatCurrency(amount, currency), style = MaterialTheme.typography.bodyMedium)
     }
 }
 

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModel.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModel.kt
@@ -14,6 +14,7 @@ import com.nuelto.camperexperience.data.model.Stop
 import com.nuelto.camperexperience.data.model.Trip
 import com.nuelto.camperexperience.data.model.UserSettings
 import com.nuelto.camperexperience.domain.CostCalculator
+import com.nuelto.camperexperience.domain.FuelEstimator
 import com.nuelto.camperexperience.ui.nav.TripDetailRoute
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -26,6 +27,8 @@ data class TripDetailUiState(
     val stops: List<Stop> = emptyList(),
     val expenses: List<Expense> = emptyList(),
     val breakdown: Map<ExpenseType, Double> = emptyMap(),
+    // Automatic fuel estimate from driving distance; null once real fuel is logged.
+    val fuelEstimate: Double? = null,
     val settings: UserSettings = UserSettings(),
     val loading: Boolean = true,
 )
@@ -50,6 +53,7 @@ class TripDetailViewModel(
                 stops = stops,
                 expenses = expenses,
                 breakdown = CostCalculator.breakdown(stops, expenses),
+                fuelEstimate = FuelEstimator.autoTripFuelCost(stops, expenses, settings),
                 settings = settings,
                 loading = false,
             )

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripedit/StopEditScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripedit/StopEditScreen.kt
@@ -99,23 +99,19 @@ fun StopEditScreen(
                 onValueChange = viewModel::setCampingCost,
             )
 
-            Text("Location", style = MaterialTheme.typography.titleMedium)
-            // GPS + map picker buttons are provided by the nav layer from M3 on.
-            locationSection?.invoke()
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                DecimalField(
-                    label = "Latitude",
-                    value = state.latText,
-                    onValueChange = viewModel::setLatText,
-                    modifier = Modifier.weight(1f),
-                )
-                DecimalField(
-                    label = "Longitude",
-                    value = state.lonText,
-                    onValueChange = viewModel::setLonText,
-                    modifier = Modifier.weight(1f),
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text("Location", style = MaterialTheme.typography.titleMedium)
+                Text(
+                    state.locationLabel,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
+            // GPS + map picker buttons are provided by the nav layer from M3 on.
+            locationSection?.invoke()
 
             OutlinedTextField(
                 value = state.notes,

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripedit/StopEditViewModel.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripedit/StopEditViewModel.kt
@@ -2,6 +2,7 @@ package com.nuelto.camperexperience.ui.tripedit
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
@@ -9,6 +10,7 @@ import com.nuelto.camperexperience.containerViewModelFactory
 import com.nuelto.camperexperience.data.TripRepository
 import com.nuelto.camperexperience.data.model.LatLng
 import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.location.PlaceNameResolver
 import com.nuelto.camperexperience.ui.components.parseDecimal
 import com.nuelto.camperexperience.ui.nav.StopEditRoute
 import java.time.LocalDate
@@ -35,11 +37,16 @@ data class StopEditUiState(
 class StopEditViewModel(
     savedStateHandle: SavedStateHandle,
     private val tripRepository: TripRepository,
+    private val placeNameResolver: PlaceNameResolver? = null,
 ) : ViewModel() {
 
     private val route: StopEditRoute = savedStateHandle.toRoute<StopEditRoute>()
     val tripId: String get() = route.tripId
     private var existing: Stop? = null
+
+    // Last name we auto-filled from reverse geocoding; anything else was typed by the
+    // user and must never be overwritten.
+    private var autoFilledName: String? = null
 
     private val _uiState = MutableStateFlow(StopEditUiState())
     val uiState: StateFlow<StopEditUiState> = _uiState
@@ -71,7 +78,7 @@ class StopEditViewModel(
     fun setCampingCost(value: String) = _uiState.update { it.copy(campingCost = value) }
     fun setNotes(value: String) = _uiState.update { it.copy(notes = value) }
 
-    fun setLocation(location: LatLng?) = _uiState.update {
+    fun setLocation(location: LatLng?) {
         // ~1 m precision is plenty for a campsite; keeps the fields readable.
         val rounded = location?.let {
             LatLng(
@@ -79,11 +86,29 @@ class StopEditViewModel(
                 Math.round(location.longitude * 100_000.0) / 100_000.0,
             )
         }
-        it.copy(
-            location = rounded,
-            latText = rounded?.latitude?.toString() ?: "",
-            lonText = rounded?.longitude?.toString() ?: "",
-        )
+        _uiState.update {
+            it.copy(
+                location = rounded,
+                latText = rounded?.latitude?.toString() ?: "",
+                lonText = rounded?.longitude?.toString() ?: "",
+            )
+        }
+        rounded?.let(::autoFillNameFrom)
+    }
+
+    private fun autoFillNameFrom(location: LatLng) {
+        val resolver = placeNameResolver ?: return
+        viewModelScope.launch {
+            val place = resolver.placeName(location) ?: return@launch
+            _uiState.update { state ->
+                if (state.name.isBlank() || state.name == autoFilledName) {
+                    autoFilledName = place
+                    state.copy(name = place)
+                } else {
+                    state
+                }
+            }
+        }
     }
 
     fun setLatText(value: String) = _uiState.update { it.copy(latText = value).withParsedLocation() }
@@ -132,7 +157,11 @@ class StopEditViewModel(
 
     companion object {
         val Factory = containerViewModelFactory { container ->
-            StopEditViewModel(createSavedStateHandle(), container.tripRepository)
+            StopEditViewModel(
+                createSavedStateHandle(),
+                container.tripRepository,
+                this[APPLICATION_KEY]?.let(::PlaceNameResolver),
+            )
         }
     }
 }

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripedit/StopEditViewModel.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripedit/StopEditViewModel.kt
@@ -26,12 +26,17 @@ data class StopEditUiState(
     val nights: Int = 1,
     val campingCost: String = "",
     val location: LatLng? = null,
-    val latText: String = "",
-    val lonText: String = "",
+    val locationName: String? = null,
     val notes: String = "",
     val isNew: Boolean = true,
+    val autoLocatePending: Boolean = false,
 ) {
     val canSave: Boolean get() = name.isNotBlank()
+
+    val locationLabel: String
+        get() = locationName
+            ?: location?.let { "${it.latitude}, ${it.longitude}" }
+            ?: "Not set"
 }
 
 class StopEditViewModel(
@@ -52,6 +57,10 @@ class StopEditViewModel(
     val uiState: StateFlow<StopEditUiState> = _uiState
 
     init {
+        if (route.stopId == null) {
+            // New stop: the location section should immediately try a GPS fix.
+            _uiState.update { it.copy(autoLocatePending = true) }
+        }
         viewModelScope.launch {
             if (route.stopId != null) {
                 existing = tripRepository.stops(route.tripId).first().find { it.id == route.stopId }
@@ -63,14 +72,15 @@ class StopEditViewModel(
                     nights = stop.nights,
                     campingCost = if (stop.campingCostTotal == 0.0) "" else stop.campingCostTotal.toString(),
                     location = stop.location,
-                    latText = stop.location?.latitude?.toString() ?: "",
-                    lonText = stop.location?.longitude?.toString() ?: "",
                     notes = stop.notes,
                     isNew = false,
                 )
+                stop.location?.let { resolvePlaceName(it, autoFillName = false) }
             }
         }
     }
+
+    fun autoLocateHandled() = _uiState.update { it.copy(autoLocatePending = false) }
 
     fun setName(value: String) = _uiState.update { it.copy(name = value) }
     fun setArrivalDate(value: LocalDate) = _uiState.update { it.copy(arrivalDate = value) }
@@ -79,50 +89,33 @@ class StopEditViewModel(
     fun setNotes(value: String) = _uiState.update { it.copy(notes = value) }
 
     fun setLocation(location: LatLng?) {
-        // ~1 m precision is plenty for a campsite; keeps the fields readable.
+        // ~1 m precision is plenty for a campsite; keeps the label readable.
         val rounded = location?.let {
             LatLng(
                 Math.round(location.latitude * 100_000.0) / 100_000.0,
                 Math.round(location.longitude * 100_000.0) / 100_000.0,
             )
         }
-        _uiState.update {
-            it.copy(
-                location = rounded,
-                latText = rounded?.latitude?.toString() ?: "",
-                lonText = rounded?.longitude?.toString() ?: "",
-            )
-        }
-        rounded?.let(::autoFillNameFrom)
+        _uiState.update { it.copy(location = rounded, locationName = null) }
+        rounded?.let { resolvePlaceName(it, autoFillName = true) }
     }
 
-    private fun autoFillNameFrom(location: LatLng) {
+    private fun resolvePlaceName(location: LatLng, autoFillName: Boolean) {
         val resolver = placeNameResolver ?: return
         viewModelScope.launch {
             val place = resolver.placeName(location) ?: return@launch
             _uiState.update { state ->
-                if (state.name.isBlank() || state.name == autoFilledName) {
+                // Ignore a late result for a location that has since changed.
+                if (state.location != location) return@update state
+                val name = if (autoFillName && (state.name.isBlank() || state.name == autoFilledName)) {
                     autoFilledName = place
-                    state.copy(name = place)
+                    place
                 } else {
-                    state
+                    state.name
                 }
+                state.copy(locationName = place, name = name)
             }
         }
-    }
-
-    fun setLatText(value: String) = _uiState.update { it.copy(latText = value).withParsedLocation() }
-    fun setLonText(value: String) = _uiState.update { it.copy(lonText = value).withParsedLocation() }
-
-    private fun StopEditUiState.withParsedLocation(): StopEditUiState {
-        val lat = parseDecimal(latText)
-        val lon = parseDecimal(lonText)
-        val loc = if (lat != null && lon != null && lat in -90.0..90.0 && lon in -180.0..180.0) {
-            LatLng(lat, lon)
-        } else {
-            null
-        }
-        return copy(location = loc)
     }
 
     fun save(onSaved: () -> Unit) {

--- a/app/src/main/java/com/nuelto/camperexperience/ui/triplist/TripListScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/triplist/TripListScreen.kt
@@ -85,6 +85,7 @@ fun TripListScreen(
                 items(state.trips, key = { it.id }) { trip ->
                     TripCard(
                         trip = trip,
+                        fuelEstimate = state.fuelEstimates[trip.id],
                         currency = state.settings.currency,
                         onClick = { onTripClick(trip.id) },
                     )
@@ -95,7 +96,7 @@ fun TripListScreen(
 }
 
 @Composable
-private fun TripCard(trip: Trip, currency: String, onClick: () -> Unit) {
+private fun TripCard(trip: Trip, fuelEstimate: Double?, currency: String, onClick: () -> Unit) {
     Card(onClick = onClick, modifier = Modifier.fillMaxWidth()) {
         Column(Modifier.padding(16.dp)) {
             Row(
@@ -109,7 +110,12 @@ private fun TripCard(trip: Trip, currency: String, onClick: () -> Unit) {
                     fontWeight = FontWeight.SemiBold,
                 )
                 Text(
-                    formatCurrency(trip.totalCost, currency),
+                    if (fuelEstimate != null) {
+                        // "≈": includes the automatic fuel estimate from driving distance.
+                        "≈ ${formatCurrency(trip.totalCost + fuelEstimate, currency)}"
+                    } else {
+                        formatCurrency(trip.totalCost, currency)
+                    },
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.primary,
                 )

--- a/app/src/main/java/com/nuelto/camperexperience/ui/triplist/TripListViewModel.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/triplist/TripListViewModel.kt
@@ -7,6 +7,7 @@ import com.nuelto.camperexperience.data.SettingsRepository
 import com.nuelto.camperexperience.data.TripRepository
 import com.nuelto.camperexperience.data.model.Trip
 import com.nuelto.camperexperience.data.model.UserSettings
+import com.nuelto.camperexperience.domain.FuelEstimator
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -14,6 +15,8 @@ import kotlinx.coroutines.flow.stateIn
 
 data class TripListUiState(
     val trips: List<Trip> = emptyList(),
+    // Trip id -> automatic fuel estimate, only for trips with no recorded fuel expense.
+    val fuelEstimates: Map<String, Double> = emptyMap(),
     val settings: UserSettings = UserSettings(),
     val loading: Boolean = true,
 )
@@ -24,8 +27,25 @@ class TripListViewModel(
 ) : ViewModel() {
 
     val uiState: StateFlow<TripListUiState> =
-        combine(tripRepository.trips(), settingsRepository.settings()) { trips, settings ->
-            TripListUiState(trips = trips, settings = settings, loading = false)
+        combine(
+            tripRepository.trips(),
+            tripRepository.allStops(),
+            tripRepository.allExpenses(),
+            settingsRepository.settings(),
+        ) { trips, stops, expenses, settings ->
+            val estimates = trips.mapNotNull { trip ->
+                FuelEstimator.autoTripFuelCost(
+                    stops.filter { it.tripId == trip.id },
+                    expenses.filter { it.tripId == trip.id },
+                    settings,
+                )?.let { trip.id to it }
+            }.toMap()
+            TripListUiState(
+                trips = trips,
+                fuelEstimates = estimates,
+                settings = settings,
+                loading = false,
+            )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), TripListUiState())
 
     companion object {

--- a/app/src/test/java/com/nuelto/camperexperience/domain/FuelEstimatorTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/domain/FuelEstimatorTest.kt
@@ -1,9 +1,12 @@
 package com.nuelto.camperexperience.domain
 
+import com.nuelto.camperexperience.data.model.Expense
+import com.nuelto.camperexperience.data.model.ExpenseType
 import com.nuelto.camperexperience.data.model.LatLng
 import com.nuelto.camperexperience.data.model.Stop
 import com.nuelto.camperexperience.data.model.UserSettings
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class FuelEstimatorTest {
@@ -28,6 +31,53 @@ class FuelEstimatorTest {
         val settings = UserSettings(roadDistanceFactor = 1.25)
         val straight = GeoUtils.haversineKm(LatLng(47.0, 8.0), LatLng(48.0, 8.0))
         assertEquals(straight * 1.25, FuelEstimator.defaultTripDistanceKm(stops, settings), 1e-9)
+    }
+
+    @Test
+    fun `auto trip fuel cost derives from driving distance between stops`() {
+        val stops = listOf(
+            Stop(id = "a", location = LatLng(47.0, 8.0), orderIndex = 0),
+            Stop(id = "b", location = LatLng(48.0, 8.0), orderIndex = 1),
+        )
+        val settings = UserSettings(
+            roadDistanceFactor = 1.25,
+            fuelConsumptionL100km = 10.0,
+            fuelPricePerLiter = 2.0,
+        )
+        val distance = GeoUtils.haversineKm(LatLng(47.0, 8.0), LatLng(48.0, 8.0)) * 1.25
+        assertEquals(
+            distance * 10.0 / 100.0 * 2.0,
+            FuelEstimator.autoTripFuelCost(stops, emptyList(), settings)!!,
+            1e-9,
+        )
+    }
+
+    @Test
+    fun `auto trip fuel cost is replaced by recorded fuel expenses`() {
+        val stops = listOf(
+            Stop(id = "a", location = LatLng(47.0, 8.0), orderIndex = 0),
+            Stop(id = "b", location = LatLng(48.0, 8.0), orderIndex = 1),
+        )
+        val fuel = Expense(id = "e1", type = ExpenseType.FUEL, amount = 80.0)
+        assertNull(FuelEstimator.autoTripFuelCost(stops, listOf(fuel), UserSettings()))
+    }
+
+    @Test
+    fun `non-fuel expenses do not suppress the auto estimate`() {
+        val stops = listOf(
+            Stop(id = "a", location = LatLng(47.0, 8.0), orderIndex = 0),
+            Stop(id = "b", location = LatLng(48.0, 8.0), orderIndex = 1),
+        )
+        val other = Expense(id = "e1", type = ExpenseType.ROAD_TAX, amount = 40.0)
+        val estimate = FuelEstimator.autoTripFuelCost(stops, listOf(other), UserSettings())
+        assertEquals(true, estimate != null && estimate > 0.0)
+    }
+
+    @Test
+    fun `auto trip fuel cost is null without a route`() {
+        val stops = listOf(Stop(id = "a", location = LatLng(47.0, 8.0), orderIndex = 0))
+        assertNull(FuelEstimator.autoTripFuelCost(stops, emptyList(), UserSettings()))
+        assertNull(FuelEstimator.autoTripFuelCost(emptyList(), emptyList(), UserSettings()))
     }
 
     @Test


### PR DESCRIPTION
## What changed

- **Stop editor UI**: removed the raw latitude/longitude input fields. The "Location" row now shows the reverse-geocoded place name (rounded coordinates as a fallback while unresolved, "Not set" otherwise).
- **New stops default to the current location**: opening "New stop" immediately runs the same flow as "I'm here" (requesting the location permission first if needed). It fires exactly once per editor session, so returning from the map picker never overwrites a picked spot, and editing an existing stop never auto-locates.
- `StopEditViewModel` resolves the place name via the existing `PlaceNameResolver` whenever the location changes (including when loading an existing stop), with a stale-result guard for late geocoder responses; the "don't overwrite a user-typed name" auto-fill rule is unchanged.

This branch also carries three earlier unpushed commits from local `main` (trip-map crash fix, fuel auto-estimate, stop-name auto-fill) plus a README section on installing the debug build on a physical phone.

## Verification

Verified on the Pixel_9a emulator (local demo mode): New stop shows "Location Not set" → "Getting GPS fix…" on open, then "Location Bern" after a `geo fix`, with the name auto-filled; map-picker round trip works; editing a seeded stop shows "Location Bräunlingen" without mutating it. No crashes in logcat; `./gradlew test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)