### PR TITLE
Replace overlapping add buttons with a single FAB menu

### DIFF
--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreen.kt
@@ -16,15 +16,21 @@ import com.nuelto.camperexperience.ui.map.TripMapData
 import com.nuelto.camperexperience.ui.map.tripColor
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.Receipt
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -75,6 +81,9 @@ fun TripDetailScreen(
     var showDeleteDialog by remember { mutableStateOf(false) }
     var showExpenseSheet by remember { mutableStateOf(false) }
     var editingExpense by remember { mutableStateOf<Expense?>(null) }
+    var fabMenuExpanded by remember { mutableStateOf(false) }
+
+    BackHandler(fabMenuExpanded) { fabMenuExpanded = false }
 
     Scaffold(
         topBar = {
@@ -99,11 +108,37 @@ fun TripDetailScreen(
         },
         floatingActionButton = {
             if (trip != null) {
-                ExtendedFloatingActionButton(
-                    onClick = { onAddStop(trip.id) },
-                    icon = { Icon(Icons.Default.Add, contentDescription = null) },
-                    text = { Text("Stop") },
-                )
+                Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    AnimatedVisibility(fabMenuExpanded) {
+                        Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                            ExtendedFloatingActionButton(
+                                onClick = {
+                                    fabMenuExpanded = false
+                                    onAddStop(trip.id)
+                                },
+                                icon = { Icon(Icons.Default.Place, contentDescription = null) },
+                                text = { Text("Stop") },
+                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                            )
+                            ExtendedFloatingActionButton(
+                                onClick = {
+                                    fabMenuExpanded = false
+                                    editingExpense = null
+                                    showExpenseSheet = true
+                                },
+                                icon = { Icon(Icons.Default.Receipt, contentDescription = null) },
+                                text = { Text("Expense") },
+                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                            )
+                        }
+                    }
+                    FloatingActionButton(onClick = { fabMenuExpanded = !fabMenuExpanded }) {
+                        Icon(
+                            if (fabMenuExpanded) Icons.Default.Close else Icons.Default.Add,
+                            contentDescription = if (fabMenuExpanded) "Close add menu" else "Add",
+                        )
+                    }
+                }
             }
         },
     ) { padding ->
@@ -111,7 +146,7 @@ fun TripDetailScreen(
 
         LazyColumn(
             modifier = Modifier.fillMaxSize().padding(padding),
-            contentPadding = PaddingValues(16.dp),
+            contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 96.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             item {
@@ -186,19 +221,7 @@ fun TripDetailScreen(
             }
 
             item {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text("Expenses", style = MaterialTheme.typography.titleMedium)
-                    IconButton(onClick = {
-                        editingExpense = null
-                        showExpenseSheet = true
-                    }) {
-                        Icon(Icons.Default.Add, contentDescription = "Add expense")
-                    }
-                }
+                Text("Expenses", style = MaterialTheme.typography.titleMedium)
             }
             if (state.expenses.isEmpty()) {
                 item {


### PR DESCRIPTION
## What

- Replaces the "+ Stop" extended FAB on the trip detail screen with a single "+" FAB that expands into labeled **Stop** / **Expense** actions (button flips to × while open; back press closes it).
- Removes the add-expense "+" icon from the Expenses header — the FAB menu is now the single add-entry point.
- Adds 96dp bottom content padding so the list always scrolls clear of the FAB.

## Why

The floating "+ Stop" button sat directly on top of the add-expense icon, making expenses nearly impossible to add. Fixes #2.

## Notes for review

- Material 3's built-in `FloatingActionButtonMenu` isn't in the stable 1.4.0 that BOM 2026.08.00 resolves to (1.5.0 alphas only), so this is a small hand-rolled equivalent on stable APIs (`AnimatedVisibility` + two `ExtendedFloatingActionButton`s). Drop-in swap later if M3 stabilizes the component.
- Verified on the Pixel_9a emulator (local-only build): menu expands, Expense opens the sheet, Stop opens the editor, expense rows scroll clear of the FAB, no crashes in logcat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)