### PR TITLE
Testing harness: full test suite, 100% coverage gate, mutation testing, PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Unit & UI tests with 100% line-coverage gate
+        run: ./gradlew :app:testDebugUnitTest :app:coverageVerify
+
+      - name: Mutation tests (threshold 80%)
+        run: ./gradlew :app:pitest
+
+      - name: Build debug APK
+        run: ./gradlew :app:assembleDebug
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports
+          path: |
+            app/build/reports/tests/testDebugUnitTest
+            app/build/reports/jacoco/coverageReport
+            app/build/reports/pitest
+          retention-days: 14

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,14 @@ adding new ones.
 
 ```bash
 ./gradlew :app:assembleDebug    # build
-./gradlew test                  # unit tests (domain logic only)
+./gradlew test                  # all unit + Robolectric/Compose UI tests
+./gradlew :app:coverageVerify   # JaCoCo gate: 100% line coverage (device-only code excluded)
+./gradlew :app:pitest           # mutation tests over JVM-pure logic, threshold 80%
 ./gradlew :app:installDebug     # install on connected device/emulator
 ./gradlew test --tests "com.nuelto.camperexperience.domain.CostCalculatorTest"  # one test class
 ```
+
+CI (`.github/workflows/ci.yml`) runs tests + both gates + assembleDebug on every PR.
 
 Emulator workflow (AVD `Pixel_9a` exists locally; needs Play services image for
 sign-in/fused location/reverse geocoding — `location/PlaceNameResolver.kt` uses the
@@ -91,9 +95,21 @@ MVVM + repository, hand-rolled DI — no Hilt, no Room. Package root:
   `tripColor(trip.id.hashCode())` so they're stable across screens. `AllTripsMapScreen`
   doubles as the single-trip fullscreen map via its nullable `tripId` filter.
 
+## Testing conventions
+
+UI tests run on the JVM: Robolectric + Compose test APIs (`robolectric.properties`
+pins sdk/graphics/screen). `TestCamperApp` forces the in-memory container regardless
+of a local google-services.json; `LocalMapEnabled provides false` swaps MapLibre for
+a placeholder (`ui/map/TripMap.kt`). Fakes live in `testutil/`. The coverage gate is
+100% of non-excluded lines (`coverageExcludes` in app/build.gradle.kts lists the
+device-only code) — new code needs tests or, if genuinely untestable on the JVM, an
+exclusion entry. pitest mutates domain/data/format/plain-JVM ViewModels only
+(Robolectric tests don't survive pitest minions); keep its 80% threshold green.
+
 ## Verification expectations
 
-Domain changes: `./gradlew test`. UI/map/location changes: verify in the emulator
+Logic/UI changes: `./gradlew test :app:coverageVerify` (+ `:app:pitest` for domain/
+data changes). Map/location changes: verify in the emulator
 (screenshots via `adb exec-out screencap -p`); map tiles need network, GPS needs a
 `geo fix` plus the in-app permission grant. Firebase-mode changes can only be fully
 tested after the FIREBASE_SETUP.md console steps; sign-in additionally needs a Google

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.kover)
 }
 
 // Firebase is optional at build time: the app runs in local-only mode until
@@ -66,12 +67,92 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true // Robolectric
+        }
+    }
 }
 
 kotlin {
     compilerOptions {
         jvmTarget = JvmTarget.JVM_17
     }
+}
+
+// Coverage gate: 100% line coverage on everything that can run on the JVM. Excluded:
+// code needing a real device/backend (MapLibre GL surface, Play services location,
+// Firebase/Firestore, Credential Manager) — that's covered by the emulator workflow.
+kover {
+    reports {
+        filters {
+            excludes {
+                classes(
+                    "com.nuelto.camperexperience.BuildConfig",
+                    "com.nuelto.camperexperience.FirebaseBackendKt",
+                    "com.nuelto.camperexperience.data.FirebaseAuthRepository*",
+                    "com.nuelto.camperexperience.data.Firestore*",
+                    "com.nuelto.camperexperience.location.*",
+                    "com.nuelto.camperexperience.ui.map.*",
+                )
+            }
+        }
+        variant("debug") {
+            verify {
+                rule("line coverage") {
+                    minBound(100, kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE)
+                }
+            }
+        }
+    }
+}
+
+// Mutation testing (PIT) over the JVM-pure logic: domain, in-memory data layer,
+// formatting, and the ViewModels that don't need Robolectric. Compose UI is out of
+// scope for PIT (Robolectric classloaders don't survive pitest's minions).
+val pitest: Configuration by configurations.creating
+
+tasks.register<JavaExec>("pitest") {
+    group = "verification"
+    description = "PIT mutation testing over the JVM-pure logic (threshold 80%)."
+    dependsOn("testDebugUnitTest")
+    classpath = pitest
+    mainClass.set("org.pitest.mutationtest.commandline.MutationCoverageReport")
+    val cpFile = layout.buildDirectory.file("pitest/classpath.txt")
+    doFirst {
+        val testClasspath = tasks.named<Test>("testDebugUnitTest").get().classpath
+        cpFile.get().asFile.apply {
+            parentFile.mkdirs()
+            writeText(testClasspath.filter { it.exists() }.joinToString("\n") { it.absolutePath })
+        }
+    }
+    args(
+        "--classPathFile", cpFile.get().asFile.absolutePath,
+        "--targetClasses",
+        listOf(
+            "com.nuelto.camperexperience.domain.*",
+            "com.nuelto.camperexperience.data.InMemory*",
+            "com.nuelto.camperexperience.ui.FormatKt",
+            "com.nuelto.camperexperience.ui.triplist.TripListViewModel",
+            "com.nuelto.camperexperience.ui.settings.SettingsViewModel",
+        ).joinToString(","),
+        "--excludedClasses", "*\$Companion",
+        "--targetTests",
+        listOf(
+            "com.nuelto.camperexperience.domain.*",
+            "com.nuelto.camperexperience.data.*",
+            "com.nuelto.camperexperience.ui.FormatTest",
+            "com.nuelto.camperexperience.ui.triplist.TripListViewModelTest",
+            "com.nuelto.camperexperience.ui.settings.SettingsViewModelTest",
+        ).joinToString(","),
+        "--sourceDirs", "src/main/java",
+        "--reportDir", layout.buildDirectory.dir("reports/pitest").get().asFile.absolutePath,
+        "--timestampedReports", "false",
+        "--outputFormats", "HTML,XML",
+        "--mutationThreshold", "80",
+        "--threads", "4",
+    )
 }
 
 dependencies {
@@ -106,4 +187,10 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.test.ext.junit)
+    testImplementation(libs.compose.ui.test.junit4)
+    debugImplementation(libs.compose.ui.test.manifest)
+
+    pitest(libs.pitest.command.line)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.kover)
+    jacoco
 }
 
 // Firebase is optional at build time: the app runs in local-only mode until
@@ -41,6 +41,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            enableUnitTestCoverage = true
+        }
         release {
             isMinifyEnabled = false
             proguardFiles(
@@ -84,25 +87,59 @@ kotlin {
 // Coverage gate: 100% line coverage on everything that can run on the JVM. Excluded:
 // code needing a real device/backend (MapLibre GL surface, Play services location,
 // Firebase/Firestore, Credential Manager) — that's covered by the emulator workflow.
-kover {
+jacoco {
+    toolVersion = "0.8.13"
+}
+
+// Without this, coverage of classes loaded through Robolectric's classloader is dropped.
+tasks.withType<Test>().configureEach {
+    configure<JacocoTaskExtension> {
+        isIncludeNoLocationClasses = true
+        excludes = listOf("jdk.internal.*")
+    }
+}
+
+val coverageExcludes = listOf(
+    "com/nuelto/camperexperience/BuildConfig*",
+    "com/nuelto/camperexperience/FirebaseBackendKt*",
+    "com/nuelto/camperexperience/data/FirebaseAuthRepository*",
+    "com/nuelto/camperexperience/data/Firestore*",
+    "com/nuelto/camperexperience/location/**",
+    "com/nuelto/camperexperience/ui/map/**",
+)
+
+val coverageClassDirs = layout.buildDirectory.dir("tmp/kotlin-classes/debug").map { dir ->
+    fileTree(dir) { exclude(coverageExcludes) }
+}
+val coverageExecData =
+    layout.buildDirectory.file("outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
+
+val coverageReport = tasks.register<JacocoReport>("coverageReport") {
+    group = "verification"
+    description = "JaCoCo coverage report for debug unit tests."
+    dependsOn("testDebugUnitTest")
+    classDirectories.setFrom(coverageClassDirs)
+    sourceDirectories.setFrom(files("src/main/java"))
+    executionData.setFrom(coverageExecData)
     reports {
-        filters {
-            excludes {
-                classes(
-                    "com.nuelto.camperexperience.BuildConfig",
-                    "com.nuelto.camperexperience.FirebaseBackendKt",
-                    "com.nuelto.camperexperience.data.FirebaseAuthRepository*",
-                    "com.nuelto.camperexperience.data.Firestore*",
-                    "com.nuelto.camperexperience.location.*",
-                    "com.nuelto.camperexperience.ui.map.*",
-                )
-            }
-        }
-        variant("debug") {
-            verify {
-                rule("line coverage") {
-                    minBound(100, kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE)
-                }
+        xml.required = true
+        html.required = true
+    }
+}
+
+tasks.register<JacocoCoverageVerification>("coverageVerify") {
+    group = "verification"
+    description = "Fails unless line coverage is 100% (excluded: device-only code)."
+    dependsOn("testDebugUnitTest", coverageReport)
+    classDirectories.setFrom(coverageClassDirs)
+    sourceDirectories.setFrom(files("src/main/java"))
+    executionData.setFrom(coverageExecData)
+    violationRules {
+        rule {
+            limit {
+                counter = "LINE"
+                value = "COVEREDRATIO"
+                minimum = "1.00".toBigDecimal()
             }
         }
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -157,15 +157,20 @@ tasks.register<JavaExec>("pitest") {
     classpath = pitest
     mainClass.set("org.pitest.mutationtest.commandline.MutationCoverageReport")
     val cpFile = layout.buildDirectory.file("pitest/classpath.txt")
+    // The unit-test classpath carries app code as a jar; pitest only mutates class
+    // directories, so the raw kotlin output dir is added as the mutable code path.
+    val mainClassesDir = layout.buildDirectory.dir("tmp/kotlin-classes/debug")
     doFirst {
         val testClasspath = tasks.named<Test>("testDebugUnitTest").get().classpath
         cpFile.get().asFile.apply {
             parentFile.mkdirs()
-            writeText(testClasspath.filter { it.exists() }.joinToString("\n") { it.absolutePath })
+            val entries = listOf(mainClassesDir.get().asFile) + testClasspath.filter { it.exists() }
+            writeText(entries.joinToString("\n") { it.absolutePath })
         }
     }
     args(
         "--classPathFile", cpFile.get().asFile.absolutePath,
+        "--mutableCodePaths", mainClassesDir.get().asFile.absolutePath,
         "--targetClasses",
         listOf(
             "com.nuelto.camperexperience.domain.*",
@@ -174,7 +179,9 @@ tasks.register<JavaExec>("pitest") {
             "com.nuelto.camperexperience.ui.triplist.TripListViewModel",
             "com.nuelto.camperexperience.ui.settings.SettingsViewModel",
         ).joinToString(","),
-        "--excludedClasses", "*\$Companion",
+        // $$inlined$: synthetic coroutine/flow machinery; avoidCallsTo: compiler null-check noise.
+        "--excludedClasses", "*\$Companion,*Test,*Test\$*,*\$\$inlined\$*",
+        "--avoidCallsTo", "kotlin.jvm.internal,kotlin.ResultKt",
         "--targetTests",
         listOf(
             "com.nuelto.camperexperience.domain.*",

--- a/app/src/main/java/com/nuelto/camperexperience/CamperApp.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/CamperApp.kt
@@ -7,14 +7,7 @@ import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.AP
 import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import com.google.firebase.FirebaseApp
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.firestoreSettings
-import com.google.firebase.firestore.persistentCacheSettings
 import com.nuelto.camperexperience.data.AuthRepository
-import com.nuelto.camperexperience.data.FirestoreSettingsRepository
-import com.nuelto.camperexperience.data.FirestoreTripRepository
 import com.nuelto.camperexperience.data.InMemorySettingsRepository
 import com.nuelto.camperexperience.data.InMemoryTripRepository
 import com.nuelto.camperexperience.data.SettingsRepository
@@ -22,52 +15,32 @@ import com.nuelto.camperexperience.data.TripRepository
 
 /**
  * Hand-rolled DI. When Firebase is configured (google-services.json present at build
- * time -> FirebaseApp.initializeApp succeeds) everything is backed by Firestore with
- * offline persistence; otherwise the app runs fully local with in-memory data.
+ * time) everything is backed by Firestore with offline persistence; otherwise the app
+ * runs fully local with in-memory data. Tests inject their own container.
  */
-class AppContainer(firebaseApp: FirebaseApp?) {
+class AppContainer(
+    val authRepository: AuthRepository?,
+    val tripRepository: TripRepository,
+    val settingsRepository: SettingsRepository,
+) {
+    val firebaseEnabled: Boolean get() = authRepository != null
 
-    val firebaseEnabled: Boolean = firebaseApp != null
-
-    val authRepository: AuthRepository? = if (firebaseApp != null) {
-        AuthRepository(FirebaseAuth.getInstance(), BuildConfig.WEB_CLIENT_ID)
-    } else {
-        null
-    }
-
-    val tripRepository: TripRepository
-    val settingsRepository: SettingsRepository
-
-    init {
-        if (firebaseApp != null) {
-            val db = FirebaseFirestore.getInstance()
-            db.firestoreSettings = firestoreSettings {
-                setLocalCacheSettings(
-                    persistentCacheSettings {
-                        setSizeBytes(com.google.firebase.firestore.FirebaseFirestoreSettings.CACHE_SIZE_UNLIMITED)
-                    },
-                )
-            }
-            val auth = FirebaseAuth.getInstance()
-            tripRepository = FirestoreTripRepository(db, auth)
-            settingsRepository = FirestoreSettingsRepository(db, auth)
-        } else {
-            tripRepository = InMemoryTripRepository()
-            settingsRepository = InMemorySettingsRepository()
-        }
+    companion object {
+        fun inMemory() = AppContainer(null, InMemoryTripRepository(), InMemorySettingsRepository())
     }
 }
 
-class CamperApp : Application() {
+open class CamperApp : Application() {
     lateinit var container: AppContainer
         private set
 
     override fun onCreate() {
         super.onCreate()
-        // Returns null when no google-services config is baked into the build.
-        val firebaseApp = FirebaseApp.initializeApp(this)
-        container = AppContainer(firebaseApp)
+        container = createContainer()
     }
+
+    protected open fun createContainer(): AppContainer =
+        firebaseContainer(this) ?: AppContainer.inMemory()
 }
 
 val CreationExtras.appContainer: AppContainer

--- a/app/src/main/java/com/nuelto/camperexperience/CamperApp.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/CamperApp.kt
@@ -32,7 +32,7 @@ class AppContainer(
 
 open class CamperApp : Application() {
     lateinit var container: AppContainer
-        private set
+        internal set // tests swap in their own repositories
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/com/nuelto/camperexperience/FirebaseBackend.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/FirebaseBackend.kt
@@ -1,0 +1,31 @@
+package com.nuelto.camperexperience
+
+import android.app.Application
+import com.google.firebase.FirebaseApp
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.FirebaseFirestoreSettings
+import com.google.firebase.firestore.firestoreSettings
+import com.google.firebase.firestore.persistentCacheSettings
+import com.nuelto.camperexperience.data.FirebaseAuthRepository
+import com.nuelto.camperexperience.data.FirestoreSettingsRepository
+import com.nuelto.camperexperience.data.FirestoreTripRepository
+
+/** Firestore-backed container, or null when no google-services config is baked into the build. */
+fun firebaseContainer(app: Application): AppContainer? {
+    val firebaseApp = FirebaseApp.initializeApp(app) ?: return null
+    val db = FirebaseFirestore.getInstance()
+    db.firestoreSettings = firestoreSettings {
+        setLocalCacheSettings(
+            persistentCacheSettings {
+                setSizeBytes(FirebaseFirestoreSettings.CACHE_SIZE_UNLIMITED)
+            },
+        )
+    }
+    val auth = FirebaseAuth.getInstance()
+    return AppContainer(
+        authRepository = FirebaseAuthRepository(auth, BuildConfig.WEB_CLIENT_ID),
+        tripRepository = FirestoreTripRepository(db, auth),
+        settingsRepository = FirestoreSettingsRepository(db, auth),
+    )
+}

--- a/app/src/main/java/com/nuelto/camperexperience/MainActivity.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/MainActivity.kt
@@ -25,7 +25,7 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-private fun AppRoot(container: AppContainer) {
+internal fun AppRoot(container: AppContainer) {
     val authRepository = container.authRepository
     if (authRepository == null) {
         // Local-only mode: Firebase not configured in this build.

--- a/app/src/main/java/com/nuelto/camperexperience/data/AuthRepository.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/data/AuthRepository.kt
@@ -9,31 +9,38 @@ import androidx.credentials.exceptions.NoCredentialException
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.auth.GoogleAuthProvider
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.tasks.await
 
-class AuthRepository(
+data class AuthUser(val uid: String)
+
+interface AuthRepository {
+    val authState: Flow<AuthUser?>
+    val currentUser: AuthUser?
+
+    /** Returns null on success, or a user-displayable error message. */
+    suspend fun signInWithGoogle(activityContext: Context): String?
+    fun signOut()
+}
+
+/** Google Sign-In via Credential Manager, backed by Firebase Auth. */
+class FirebaseAuthRepository(
     private val auth: FirebaseAuth,
     private val webClientId: String,
-) {
+) : AuthRepository {
 
-    val authState: Flow<FirebaseUser?> = callbackFlow {
-        val listener = FirebaseAuth.AuthStateListener { trySend(it.currentUser) }
+    override val authState: Flow<AuthUser?> = callbackFlow {
+        val listener = FirebaseAuth.AuthStateListener { trySend(it.currentUser?.let { u -> AuthUser(u.uid) }) }
         auth.addAuthStateListener(listener)
         awaitClose { auth.removeAuthStateListener(listener) }
     }
 
-    val currentUser: FirebaseUser? get() = auth.currentUser
+    override val currentUser: AuthUser? get() = auth.currentUser?.let { AuthUser(it.uid) }
 
-    /**
-     * Google Sign-In via Credential Manager. Returns null on success, or a
-     * user-displayable error message.
-     */
-    suspend fun signInWithGoogle(activityContext: Context): String? {
+    override suspend fun signInWithGoogle(activityContext: Context): String? {
         if (webClientId.isBlank()) {
             return "Missing webClientId in local.properties — see FIREBASE_SETUP.md"
         }
@@ -66,7 +73,7 @@ class AuthRepository(
         }
     }
 
-    fun signOut() {
+    override fun signOut() {
         auth.signOut()
     }
 }

--- a/app/src/main/java/com/nuelto/camperexperience/location/PlaceNameResolver.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/location/PlaceNameResolver.kt
@@ -17,9 +17,9 @@ import kotlinx.coroutines.withTimeoutOrNull
  * Geocoder (Play-services backed, no API key). Returns null when the geocoder is
  * unavailable, offline, or finds nothing.
  */
-class PlaceNameResolver(private val context: Context) {
+open class PlaceNameResolver(private val context: Context) {
 
-    suspend fun placeName(location: LatLng): String? {
+    open suspend fun placeName(location: LatLng): String? {
         if (!Geocoder.isPresent()) return null
         val geocoder = Geocoder(context, Locale.getDefault())
         val address = withTimeoutOrNull(10_000) {

--- a/app/src/main/java/com/nuelto/camperexperience/ui/map/LocationPickerScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/map/LocationPickerScreen.kt
@@ -66,11 +66,13 @@ fun LocationPickerScreen(
         },
     ) { padding ->
         Box(Modifier.fillMaxSize().padding(padding)) {
-            MaplibreMap(
-                modifier = Modifier.fillMaxSize(),
-                baseStyle = BaseStyle.Uri(MAP_STYLE_URL),
-                cameraState = cameraState,
-            )
+            if (LocalMapEnabled.current) {
+                MaplibreMap(
+                    modifier = Modifier.fillMaxSize(),
+                    baseStyle = BaseStyle.Uri(MAP_STYLE_URL),
+                    cameraState = cameraState,
+                )
+            }
             Crosshair(Modifier.align(Alignment.Center))
         }
     }

--- a/app/src/main/java/com/nuelto/camperexperience/ui/map/TripMap.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/map/TripMap.kt
@@ -1,9 +1,12 @@
 package com.nuelto.camperexperience.ui.map
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.nuelto.camperexperience.data.model.Stop
@@ -30,6 +33,12 @@ import org.maplibre.spatialk.geojson.Point
 import org.maplibre.spatialk.geojson.Position
 
 const val MAP_STYLE_URL = "https://tiles.openfreemap.org/styles/liberty"
+
+/**
+ * Test seam: MapLibre needs a native GL surface that doesn't exist under Robolectric,
+ * so UI tests provide `false` to swap the map for an empty placeholder.
+ */
+val LocalMapEnabled = staticCompositionLocalOf { true }
 
 /** Distinct marker/route color per trip, cycling through a fixed palette. */
 val tripColorPalette = listOf(
@@ -62,12 +71,18 @@ private fun Stop.position(): Position? =
 fun TripMap(
     data: List<TripMapData>,
     modifier: Modifier = Modifier,
-    cameraState: CameraState = rememberCameraState(
-        firstPosition = CameraPosition(target = Position(longitude = 8.2, latitude = 46.8), zoom = 6.0),
-    ),
+    cameraState: CameraState? = null,
     fitToStops: Boolean = true,
     onStopClick: ((tripId: String, stopId: String) -> Unit)? = null,
 ) {
+    if (!LocalMapEnabled.current) {
+        Box(modifier.testTag("map-placeholder"))
+        return
+    }
+    @Suppress("NAME_SHADOWING")
+    val cameraState = cameraState ?: rememberCameraState(
+        firstPosition = CameraPosition(target = Position(longitude = 8.2, latitude = 46.8), zoom = 6.0),
+    )
     val allPositions = data.flatMap { it.stops.sortedBy { s -> s.orderIndex }.mapNotNull { s -> s.position() } }
 
     if (fitToStops) {

--- a/app/src/main/java/com/nuelto/camperexperience/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/settings/SettingsScreen.kt
@@ -42,7 +42,6 @@ import com.nuelto.camperexperience.ui.components.DecimalField
 import com.nuelto.camperexperience.ui.components.parseDecimal
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -52,7 +51,7 @@ class SettingsViewModel(
 ) : ViewModel() {
 
     val settings: StateFlow<UserSettings?> =
-        settingsRepository.settings().map { it }
+        settingsRepository.settings()
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
     fun update(settings: UserSettings) {

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripedit/StopEditScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripedit/StopEditScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.nuelto.camperexperience.ui.components.DateField
 import com.nuelto.camperexperience.ui.components.DecimalField
 
@@ -36,7 +35,8 @@ import com.nuelto.camperexperience.ui.components.DecimalField
 @Composable
 fun StopEditScreen(
     onBack: () -> Unit,
-    viewModel: StopEditViewModel = viewModel(factory = StopEditViewModel.Factory),
+    // No factory default: the nav layer owns the instance to feed it picker results.
+    viewModel: StopEditViewModel,
     locationSection: (@Composable () -> Unit)? = null,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()

--- a/app/src/test/java/com/nuelto/camperexperience/AppWiringTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/AppWiringTest.kt
@@ -1,0 +1,86 @@
+package com.nuelto.camperexperience
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.camperexperience.data.AuthUser
+import com.nuelto.camperexperience.data.InMemorySettingsRepository
+import com.nuelto.camperexperience.data.InMemoryTripRepository
+import com.nuelto.camperexperience.testutil.FakeAuthRepository
+import com.nuelto.camperexperience.testutil.TestCamperApp
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = TestCamperApp::class)
+class AppContainerTest {
+
+    @Test
+    fun `in-memory container has no auth and local repositories`() {
+        val container = AppContainer.inMemory()
+        assertFalse(container.firebaseEnabled)
+        assertTrue(container.tripRepository is InMemoryTripRepository)
+        assertTrue(container.settingsRepository is InMemorySettingsRepository)
+    }
+
+    @Test
+    fun `an auth repository marks the container as firebase-backed`() {
+        val container = AppContainer(
+            FakeAuthRepository(),
+            InMemoryTripRepository(seed = false),
+            InMemorySettingsRepository(),
+        )
+        assertTrue(container.firebaseEnabled)
+    }
+
+    @Test
+    fun `application initializes its container on create`() {
+        val app = ApplicationProvider.getApplicationContext<CamperApp>()
+        assertFalse(app.container.firebaseEnabled)
+        assertTrue(app.container.tripRepository is InMemoryTripRepository)
+    }
+}
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = TestCamperApp::class)
+class AppRootTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private fun firebaseContainerWith(auth: FakeAuthRepository) =
+        AppContainer(auth, InMemoryTripRepository(seed = false), InMemorySettingsRepository())
+
+    @Test
+    fun `local mode goes straight to the trip list`() {
+        compose.setContent { AppRoot(AppContainer.inMemory()) }
+        compose.onNodeWithText("Trips").assertIsDisplayed()
+    }
+
+    @Test
+    fun `firebase mode without a user shows sign-in`() {
+        compose.setContent { AppRoot(firebaseContainerWith(FakeAuthRepository())) }
+        compose.onNodeWithText("Sign in with Google").assertIsDisplayed()
+    }
+
+    @Test
+    fun `firebase mode with a signed-in user shows the app`() {
+        compose.setContent { AppRoot(firebaseContainerWith(FakeAuthRepository(AuthUser("u1")))) }
+        compose.onNodeWithText("Trips").assertIsDisplayed()
+    }
+
+    @Test
+    fun `signing out drops back to the sign-in screen`() {
+        val auth = FakeAuthRepository(AuthUser("u1"))
+        compose.setContent { AppRoot(firebaseContainerWith(auth)) }
+        compose.onNodeWithText("Trips").assertIsDisplayed()
+        auth.signOut()
+        compose.onNodeWithText("Sign in with Google").assertIsDisplayed()
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/MainActivityTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/MainActivityTest.kt
@@ -1,0 +1,26 @@
+package com.nuelto.camperexperience
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.camperexperience.testutil.TestCamperApp
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = TestCamperApp::class)
+class MainActivityTest {
+
+    @get:Rule
+    val compose = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun `launches into the trip list with seeded demo trips`() {
+        compose.onNodeWithText("Trips").assertIsDisplayed()
+        compose.onNodeWithText("Provence").assertIsDisplayed()
+        compose.onNodeWithText("Schwarzwald").assertIsDisplayed()
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/data/InMemorySettingsRepositoryTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/data/InMemorySettingsRepositoryTest.kt
@@ -1,0 +1,29 @@
+package com.nuelto.camperexperience.data
+
+import com.nuelto.camperexperience.data.model.UserSettings
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class InMemorySettingsRepositoryTest {
+
+    @Test
+    fun `starts with defaults`() = runTest {
+        assertEquals(UserSettings(), InMemorySettingsRepository().settings().first())
+        assertEquals("CHF", UserSettings().currency)
+    }
+
+    @Test
+    fun `update replaces the settings`() = runTest {
+        val repo = InMemorySettingsRepository()
+        val changed = UserSettings(
+            currency = "EUR",
+            fuelConsumptionL100km = 12.5,
+            fuelPricePerLiter = 1.65,
+            roadDistanceFactor = 1.4,
+        )
+        repo.update(changed)
+        assertEquals(changed, repo.settings().first())
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/data/InMemoryTripRepositoryTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/data/InMemoryTripRepositoryTest.kt
@@ -1,0 +1,158 @@
+package com.nuelto.camperexperience.data
+
+import com.nuelto.camperexperience.data.model.Expense
+import com.nuelto.camperexperience.data.model.ExpenseType
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.Trip
+import java.time.LocalDate
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class InMemoryTripRepositoryTest {
+
+    private val repo = InMemoryTripRepository(seed = false)
+
+    private suspend fun addTrip(id: String = "", name: String = "Trip"): String =
+        repo.upsertTrip(Trip(id = id, name = name, startDate = LocalDate.of(2026, 6, 1)))
+
+    @Test
+    fun `upsert generates an id for a blank one and keeps a given one`() = runTest {
+        val generated = addTrip()
+        assertTrue(generated.isNotBlank())
+        assertEquals("fixed", repo.upsertTrip(Trip(id = "fixed", name = "Kept")))
+    }
+
+    @Test
+    fun `upsert with existing id replaces instead of duplicating`() = runTest {
+        val id = addTrip(name = "Old")
+        repo.upsertTrip(repo.trip(id).first()!!.copy(name = "New"))
+        assertEquals(listOf("New"), repo.trips().first().map { it.name })
+    }
+
+    @Test
+    fun `trips are sorted by start date descending`() = runTest {
+        repo.upsertTrip(Trip(id = "older", name = "Older", startDate = LocalDate.of(2025, 1, 1)))
+        repo.upsertTrip(Trip(id = "newer", name = "Newer", startDate = LocalDate.of(2026, 1, 1)))
+        assertEquals(listOf("newer", "older"), repo.trips().first().map { it.id })
+    }
+
+    @Test
+    fun `trip flow finds by id and emits null for unknown`() = runTest {
+        val id = addTrip(name = "Found")
+        assertEquals("Found", repo.trip(id).first()!!.name)
+        assertNull(repo.trip("nope").first())
+    }
+
+    @Test
+    fun `stops are filtered by trip and sorted by order index`() = runTest {
+        val id = addTrip()
+        repo.upsertStop(Stop(id = "b", tripId = id, name = "Second", orderIndex = 1))
+        repo.upsertStop(Stop(id = "a", tripId = id, name = "First", orderIndex = 0))
+        repo.upsertStop(Stop(id = "x", tripId = "other-trip", name = "Elsewhere"))
+        assertEquals(listOf("First", "Second"), repo.stops(id).first().map { it.name })
+    }
+
+    @Test
+    fun `expenses are filtered by trip and sorted by date`() = runTest {
+        val id = addTrip()
+        repo.upsertExpense(Expense(id = "late", tripId = id, amount = 2.0, date = LocalDate.of(2026, 6, 5)))
+        repo.upsertExpense(Expense(id = "early", tripId = id, amount = 1.0, date = LocalDate.of(2026, 6, 2)))
+        repo.upsertExpense(Expense(id = "other", tripId = "other-trip", amount = 9.0))
+        assertEquals(listOf("early", "late"), repo.expenses(id).first().map { it.id })
+    }
+
+    @Test
+    fun `upsert stop and expense generate ids and replace on same id`() = runTest {
+        val id = addTrip()
+        repo.upsertStop(Stop(tripId = id, name = "Generated"))
+        val stopId = repo.stops(id).first().single().id
+        assertTrue(stopId.isNotBlank())
+        repo.upsertStop(Stop(id = stopId, tripId = id, name = "Replaced"))
+        assertEquals(listOf("Replaced"), repo.stops(id).first().map { it.name })
+
+        repo.upsertExpense(Expense(tripId = id, amount = 5.0))
+        val expenseId = repo.expenses(id).first().single().id
+        assertTrue(expenseId.isNotBlank())
+        repo.upsertExpense(Expense(id = expenseId, tripId = id, amount = 6.0))
+        assertEquals(6.0, repo.expenses(id).first().single().amount, 1e-9)
+    }
+
+    @Test
+    fun `totals are recomputed on stop and expense mutations`() = runTest {
+        val id = addTrip()
+        repo.upsertStop(Stop(id = "s1", tripId = id, nights = 3, campingCostTotal = 90.0))
+        repo.upsertExpense(Expense(id = "e1", tripId = id, type = ExpenseType.FUEL, amount = 50.0))
+        assertEquals(140.0, repo.trip(id).first()!!.totalCost, 1e-9)
+        assertEquals(3, repo.trip(id).first()!!.nights)
+
+        repo.deleteExpense(id, "e1")
+        assertEquals(90.0, repo.trip(id).first()!!.totalCost, 1e-9)
+
+        repo.deleteStop(id, "s1")
+        assertEquals(0.0, repo.trip(id).first()!!.totalCost, 1e-9)
+        assertEquals(0, repo.trip(id).first()!!.nights)
+    }
+
+    @Test
+    fun `totals of other trips are untouched`() = runTest {
+        val a = addTrip(id = "a")
+        val b = addTrip(id = "b")
+        repo.upsertStop(Stop(id = "sa", tripId = a, nights = 1, campingCostTotal = 10.0))
+        repo.upsertStop(Stop(id = "sb", tripId = b, nights = 2, campingCostTotal = 20.0))
+        assertEquals(10.0, repo.trip(a).first()!!.totalCost, 1e-9)
+        assertEquals(20.0, repo.trip(b).first()!!.totalCost, 1e-9)
+    }
+
+    @Test
+    fun `delete trip cascades to its stops and expenses`() = runTest {
+        val id = addTrip(id = "gone")
+        val keep = addTrip(id = "keep")
+        repo.upsertStop(Stop(id = "s1", tripId = id))
+        repo.upsertExpense(Expense(id = "e1", tripId = id, amount = 1.0))
+        repo.upsertStop(Stop(id = "s2", tripId = keep))
+        repo.deleteTrip(id)
+        assertNull(repo.trip(id).first())
+        assertTrue(repo.allStops().first().none { it.tripId == id })
+        assertTrue(repo.allExpenses().first().none { it.tripId == id })
+        assertEquals(1, repo.allStops().first().size)
+    }
+
+    @Test
+    fun `all stops and all expenses span trips`() = runTest {
+        repo.upsertStop(Stop(id = "s1", tripId = "t1"))
+        repo.upsertStop(Stop(id = "s2", tripId = "t2"))
+        repo.upsertExpense(Expense(id = "e1", tripId = "t1", amount = 1.0))
+        repo.upsertExpense(Expense(id = "e2", tripId = "t2", amount = 2.0))
+        assertEquals(setOf("s1", "s2"), repo.allStops().first().map { it.id }.toSet())
+        assertEquals(setOf("e1", "e2"), repo.allExpenses().first().map { it.id }.toSet())
+    }
+
+    @Test
+    fun `seeded repository has consistent demo data`() = runTest {
+        val seeded = InMemoryTripRepository(seed = true)
+        val trips = seeded.trips().first()
+        assertEquals(2, trips.size)
+        // Schwarzwald (2026) starts after Provence (2025) -> sorted first.
+        assertEquals("Schwarzwald", trips[0].name)
+        assertEquals("Provence", trips[1].name)
+        for (trip in trips) {
+            val stops = seeded.stops(trip.id).first()
+            val expenses = seeded.expenses(trip.id).first()
+            assertTrue(stops.isNotEmpty())
+            assertEquals(stops.sumOf { it.nights }, trip.nights)
+            assertEquals(
+                stops.sumOf { it.campingCostTotal } + expenses.sumOf { it.amount },
+                trip.totalCost,
+                1e-9,
+            )
+            assertTrue(stops.all { it.location != null })
+        }
+        assertNotEquals(LatLng(0.0, 0.0), seeded.stops(trips[0].id).first().first().location)
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/data/InMemoryTripRepositoryTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/data/InMemoryTripRepositoryTest.kt
@@ -100,6 +100,17 @@ class InMemoryTripRepositoryTest {
     }
 
     @Test
+    fun `upserting a trip recomputes totals from its stops and expenses`() = runTest {
+        val id = addTrip()
+        repo.upsertStop(Stop(id = "s1", tripId = id, nights = 2, campingCostTotal = 50.0))
+        // A fresh Trip object with stale zero totals must come back recomputed.
+        repo.upsertTrip(Trip(id = id, name = "Renamed", startDate = LocalDate.of(2026, 6, 1)))
+        val trip = repo.trip(id).first()!!
+        assertEquals(50.0, trip.totalCost, 1e-9)
+        assertEquals(2, trip.nights)
+    }
+
+    @Test
     fun `totals of other trips are untouched`() = runTest {
         val a = addTrip(id = "a")
         val b = addTrip(id = "b")
@@ -141,10 +152,14 @@ class InMemoryTripRepositoryTest {
         // Schwarzwald (2026) starts after Provence (2025) -> sorted first.
         assertEquals("Schwarzwald", trips[0].name)
         assertEquals("Provence", trips[1].name)
+        // Exact seeded totals: dropping seeded stops or expenses must be caught.
+        assertEquals(84.0 + 128.0 + 30.0 + 145.30 + 98.60 + 61.40, trips[1].totalCost, 1e-9)
+        assertEquals(9, trips[1].nights)
         for (trip in trips) {
             val stops = seeded.stops(trip.id).first()
             val expenses = seeded.expenses(trip.id).first()
             assertTrue(stops.isNotEmpty())
+            assertTrue(expenses.isNotEmpty())
             assertEquals(stops.sumOf { it.nights }, trip.nights)
             assertEquals(
                 stops.sumOf { it.campingCostTotal } + expenses.sumOf { it.amount },

--- a/app/src/test/java/com/nuelto/camperexperience/domain/CostCalculatorTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/domain/CostCalculatorTest.kt
@@ -44,6 +44,30 @@ class CostCalculatorTest {
     }
 
     @Test
+    fun `zero-cost categories are omitted, not listed as zero`() {
+        assertEquals(emptyMap<ExpenseType, Double>(), CostCalculator.breakdown(emptyList(), emptyList()))
+        val freeStop = Stop(id = "s1", campingCostTotal = 0.0)
+        assertEquals(
+            setOf(ExpenseType.FUEL),
+            CostCalculator.breakdown(listOf(freeStop), listOf(Expense(id = "e", type = ExpenseType.FUEL, amount = 5.0))).keys,
+        )
+    }
+
+    @Test
+    fun `breakdown lists categories in fixed order`() {
+        val all = listOf(
+            Expense(id = "o", type = ExpenseType.OTHER, amount = 1.0),
+            Expense(id = "r", type = ExpenseType.ROAD_TAX, amount = 2.0),
+            Expense(id = "f", type = ExpenseType.FUEL, amount = 3.0),
+            Expense(id = "c", type = ExpenseType.CAMPING, amount = 4.0),
+        )
+        assertEquals(
+            listOf(ExpenseType.CAMPING, ExpenseType.FUEL, ExpenseType.ROAD_TAX, ExpenseType.OTHER),
+            CostCalculator.breakdown(emptyList(), all).keys.toList(),
+        )
+    }
+
+    @Test
     fun `empty trip totals zero`() {
         assertEquals(0.0, CostCalculator.tripTotal(emptyList(), emptyList()), 1e-9)
         assertEquals(0, CostCalculator.tripNights(emptyList()))

--- a/app/src/test/java/com/nuelto/camperexperience/domain/FuelEstimatorTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/domain/FuelEstimatorTest.kt
@@ -60,6 +60,9 @@ class FuelEstimatorTest {
         )
         val fuel = Expense(id = "e1", type = ExpenseType.FUEL, amount = 80.0)
         assertNull(FuelEstimator.autoTripFuelCost(stops, listOf(fuel), UserSettings()))
+        // Fuel logged after other expense types must suppress the estimate too.
+        val tax = Expense(id = "e2", type = ExpenseType.ROAD_TAX, amount = 10.0)
+        assertNull(FuelEstimator.autoTripFuelCost(stops, listOf(tax, fuel), UserSettings()))
     }
 
     @Test
@@ -78,6 +81,20 @@ class FuelEstimatorTest {
         val stops = listOf(Stop(id = "a", location = LatLng(47.0, 8.0), orderIndex = 0))
         assertNull(FuelEstimator.autoTripFuelCost(stops, emptyList(), UserSettings()))
         assertNull(FuelEstimator.autoTripFuelCost(emptyList(), emptyList(), UserSettings()))
+    }
+
+    @Test
+    fun `stops are routed by order index, not list order`() {
+        val a = Stop(id = "a", location = LatLng(47.0, 8.0), orderIndex = 0)
+        val b = Stop(id = "b", location = LatLng(47.0, 9.0), orderIndex = 1)
+        val c = Stop(id = "c", location = LatLng(48.0, 8.0), orderIndex = 2)
+        val ordered = GeoUtils.routeLengthKm(listOf(a.location!!, b.location!!, c.location!!))
+        // Shuffled input must still be routed a -> b -> c.
+        assertEquals(
+            ordered * 1.25,
+            FuelEstimator.defaultTripDistanceKm(listOf(c, a, b), UserSettings(roadDistanceFactor = 1.25)),
+            1e-9,
+        )
     }
 
     @Test

--- a/app/src/test/java/com/nuelto/camperexperience/testutil/TestCamperApp.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/testutil/TestCamperApp.kt
@@ -1,0 +1,13 @@
+package com.nuelto.camperexperience.testutil
+
+import com.nuelto.camperexperience.AppContainer
+import com.nuelto.camperexperience.CamperApp
+
+/**
+ * Test application: deterministic in-memory container regardless of whether
+ * google-services.json is present in the local build. Tests that need custom
+ * repositories assign `container` before composing anything.
+ */
+class TestCamperApp : CamperApp() {
+    public override fun createContainer(): AppContainer = AppContainer.inMemory()
+}

--- a/app/src/test/java/com/nuelto/camperexperience/testutil/TestSupport.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/testutil/TestSupport.kt
@@ -1,0 +1,72 @@
+package com.nuelto.camperexperience.testutil
+
+import android.content.Context
+import com.nuelto.camperexperience.data.AuthRepository
+import com.nuelto.camperexperience.data.AuthUser
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.location.PlaceNameResolver
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/** Replaces Dispatchers.Main for viewModelScope in JVM tests. */
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    private val dispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: Description) = Dispatchers.setMain(dispatcher)
+    override fun finished(description: Description) = Dispatchers.resetMain()
+}
+
+class FakeAuthRepository(
+    initialUser: AuthUser? = null,
+    private val signInResult: String? = null,
+) : AuthRepository {
+    val state = MutableStateFlow(initialUser)
+    var signInCalls = 0
+    var signOutCalls = 0
+
+    /** When set, signInWithGoogle suspends until the deferred completes. */
+    var gate: CompletableDeferred<Unit>? = null
+
+    override val authState: Flow<AuthUser?> = state
+    override val currentUser: AuthUser? get() = state.value
+
+    override suspend fun signInWithGoogle(activityContext: Context): String? {
+        signInCalls++
+        gate?.await()
+        if (signInResult == null) state.value = AuthUser("test-uid")
+        return signInResult
+    }
+
+    override fun signOut() {
+        signOutCalls++
+        state.value = null
+    }
+}
+
+/** Resolves "Place@<lat>"; each call can be individually gated for late-result tests. */
+class FakePlaceNameResolver(context: Context) : PlaceNameResolver(context) {
+    val gates = mutableListOf<CompletableDeferred<Unit>>()
+    val requests = mutableListOf<LatLng>()
+    var gated = false
+    var result: (LatLng) -> String? = { "Place@${it.latitude}" }
+
+    override suspend fun placeName(location: LatLng): String? {
+        requests += location
+        if (gated) {
+            val gate = CompletableDeferred<Unit>()
+            gates += gate
+            gate.await()
+        }
+        return result(location)
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/FormatTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/FormatTest.kt
@@ -1,0 +1,57 @@
+package com.nuelto.camperexperience.ui
+
+import java.time.LocalDate
+import java.util.Locale
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class FormatTest {
+
+    private lateinit var originalLocale: Locale
+
+    @Before
+    fun setUp() {
+        originalLocale = Locale.getDefault()
+        Locale.setDefault(Locale.US)
+    }
+
+    @After
+    fun tearDown() {
+        Locale.setDefault(originalLocale)
+    }
+
+
+    @Test
+    fun `formats amount with requested currency`() {
+        assertEquals("$1,234.50", formatCurrency(1234.5, "USD"))
+        assertEquals("CHF10.00", formatCurrency(10.0, "CHF"))
+    }
+
+    @Test
+    fun `invalid currency code falls back to locale currency`() {
+        assertEquals("$10.00", formatCurrency(10.0, "NOPE"))
+    }
+
+    @Test
+    fun `date format contains day month and year`() {
+        val formatted = formatDate(LocalDate.of(2026, 9, 12))
+        assertTrue(formatted, formatted.contains("12"))
+        assertTrue(formatted, formatted.contains("2026"))
+    }
+
+    @Test
+    fun `date range joins start and end`() {
+        val start = LocalDate.of(2026, 9, 12)
+        val end = LocalDate.of(2026, 9, 21)
+        assertEquals("${formatDate(start)} – ${formatDate(end)}", formatDateRange(start, end))
+    }
+
+    @Test
+    fun `open ended range says ongoing`() {
+        val start = LocalDate.of(2026, 9, 12)
+        assertEquals("${formatDate(start)} – ongoing", formatDateRange(start, null))
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/auth/SignInScreenTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/auth/SignInScreenTest.kt
@@ -1,0 +1,53 @@
+package com.nuelto.camperexperience.ui.auth
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.camperexperience.testutil.FakeAuthRepository
+import com.nuelto.camperexperience.testutil.TestCamperApp
+import kotlinx.coroutines.CompletableDeferred
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = TestCamperApp::class)
+class SignInScreenTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun `failed sign-in shows the error message`() {
+        val auth = FakeAuthRepository(signInResult = "Sign-in failed")
+        compose.setContent { SignInScreen(auth) }
+        compose.onNodeWithText("CamperExperience").assertIsDisplayed()
+        compose.onNodeWithText("Sign in with Google").performClick()
+        compose.onNodeWithText("Sign-in failed").assertIsDisplayed()
+        assertEquals(1, auth.signInCalls)
+    }
+
+    @Test
+    fun `while signing in the button is replaced by a spinner`() {
+        val auth = FakeAuthRepository()
+        auth.gate = CompletableDeferred()
+        compose.setContent { SignInScreen(auth) }
+        compose.onNodeWithText("Sign in with Google").performClick()
+        compose.onNodeWithText("Sign in with Google").assertDoesNotExist()
+        auth.gate!!.complete(Unit)
+        compose.onNodeWithText("Sign in with Google").assertIsDisplayed()
+    }
+
+    @Test
+    fun `successful sign-in shows no error`() {
+        val auth = FakeAuthRepository()
+        compose.setContent { SignInScreen(auth) }
+        compose.onNodeWithText("Sign in with Google").performClick()
+        compose.onNodeWithText("Sign in with Google").assertIsDisplayed()
+        assertEquals(1, auth.signInCalls)
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/components/FieldsTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/components/FieldsTest.kt
@@ -1,0 +1,85 @@
+package com.nuelto.camperexperience.ui.components
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.camperexperience.testutil.TestCamperApp
+import com.nuelto.camperexperience.ui.formatDate
+import java.time.LocalDate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = TestCamperApp::class)
+class FieldsTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun `decimal field renders label suffix and forwards input`() {
+        var value by mutableStateOf("")
+        compose.setContent {
+            DecimalField(label = "Amount", value = value, onValueChange = { value = it }, suffix = "km")
+        }
+        compose.onNodeWithText("Amount").performTextInput("12,5")
+        assertEquals("12,5", value)
+        compose.onNodeWithText("km").assertIsDisplayed() // suffix shows once the field has content
+    }
+
+    @Test
+    fun `date field shows placeholder when empty`() {
+        compose.setContent {
+            DateField(label = "End date", date = null, onDateChange = {}, placeholder = "Ongoing")
+        }
+        compose.onNodeWithText("Ongoing").assertIsDisplayed()
+    }
+
+    @Test
+    fun `tapping the field opens the picker and cancel keeps the date`() {
+        val date = LocalDate.of(2026, 7, 1)
+        var changed = false
+        compose.setContent {
+            DateField(label = "Start date", date = date, onDateChange = { changed = true })
+        }
+        compose.onNodeWithText(formatDate(date)).performClick()
+        compose.onNodeWithText("Cancel").assertIsDisplayed()
+        compose.onNodeWithText("Cancel").performClick()
+        compose.onNodeWithText("Cancel").assertDoesNotExist()
+        assertEquals(false, changed)
+    }
+
+    @Test
+    fun `confirming the picker reports the selected date`() {
+        val date = LocalDate.of(2026, 7, 1)
+        var picked: LocalDate? = null
+        compose.setContent {
+            DateField(label = "Start date", date = date, onDateChange = { picked = it })
+        }
+        compose.onNodeWithText(formatDate(date)).performClick()
+        compose.onNodeWithText("OK").performClick()
+        // The picker opens preselected on the current value; OK confirms it.
+        assertEquals(date, picked)
+    }
+
+    @Test
+    fun `picker for an empty date defaults to today`() {
+        var picked: LocalDate? = null
+        compose.setContent {
+            DateField(label = "Date", date = null, onDateChange = { picked = it }, placeholder = "Pick")
+        }
+        compose.onNodeWithText("Pick").performClick()
+        compose.onNodeWithText("OK").performClick()
+        assertTrue(picked != null)
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/components/ParseDecimalTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/components/ParseDecimalTest.kt
@@ -1,0 +1,27 @@
+package com.nuelto.camperexperience.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ParseDecimalTest {
+
+    @Test
+    fun `parses dot and comma separators`() {
+        assertEquals(12.5, parseDecimal("12.5")!!, 1e-9)
+        assertEquals(12.5, parseDecimal("12,5")!!, 1e-9)
+        assertEquals(7.0, parseDecimal("7")!!, 1e-9)
+    }
+
+    @Test
+    fun `trims whitespace`() {
+        assertEquals(3.25, parseDecimal("  3.25 ")!!, 1e-9)
+    }
+
+    @Test
+    fun `rejects non numbers`() {
+        assertNull(parseDecimal(""))
+        assertNull(parseDecimal("abc"))
+        assertNull(parseDecimal("1.2.3"))
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/map/TripColorTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/map/TripColorTest.kt
@@ -1,0 +1,19 @@
+package com.nuelto.camperexperience.ui.map
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TripColorTest {
+
+    @Test
+    fun `cycles through the palette`() {
+        assertEquals(tripColorPalette[0], tripColor(0))
+        assertEquals(tripColorPalette[1], tripColor(1))
+        assertEquals(tripColorPalette[0], tripColor(tripColorPalette.size))
+    }
+
+    @Test
+    fun `negative hash codes still map into the palette`() {
+        assertEquals(tripColorPalette[tripColorPalette.size - 1], tripColor(-1))
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/nav/AppNavHostTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/nav/AppNavHostTest.kt
@@ -1,0 +1,140 @@
+package com.nuelto.camperexperience.ui.nav
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.camperexperience.testutil.TestCamperApp
+import com.nuelto.camperexperience.ui.map.LocalMapEnabled
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * End-to-end navigation through the real NavHost, backed by the TestCamperApp's
+ * seeded in-memory container. Maps render as placeholders (LocalMapEnabled=false).
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(application = TestCamperApp::class)
+class AppNavHostTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private fun setContent() {
+        compose.setContent {
+            CompositionLocalProvider(LocalMapEnabled provides false) {
+                AppNavHost()
+            }
+        }
+    }
+
+    @Test
+    fun `starts on the trip list with demo data`() {
+        setContent()
+        compose.onNodeWithText("Trips").assertIsDisplayed()
+        compose.onNodeWithText("Provence").assertIsDisplayed()
+    }
+
+    @Test
+    fun `trip card opens the detail and back returns`() {
+        setContent()
+        compose.onNodeWithText("Schwarzwald").performClick()
+        compose.onNodeWithText("Camping Kirnbergsee").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Back").performClick()
+        compose.onNodeWithText("Trips").assertIsDisplayed()
+    }
+
+    @Test
+    fun `trip edit opens from the detail and cancels back`() {
+        setContent()
+        compose.onNodeWithText("Schwarzwald").performClick()
+        compose.onNodeWithContentDescription("Edit trip").performClick()
+        compose.onNodeWithText("Edit trip").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Cancel").performClick()
+        compose.onNodeWithText("Camping Kirnbergsee").assertIsDisplayed()
+    }
+
+    @Test
+    fun `new trip is created and opened`() {
+        setContent()
+        compose.onNodeWithContentDescription("New trip").performClick()
+        compose.onNodeWithText("Trip name").performTextInput("Ticino")
+        compose.onNodeWithText("Save").performClick()
+        // Saved -> pops the editor and navigates into the new trip.
+        compose.onNodeWithText("Ticino").assertIsDisplayed()
+        compose.onNodeWithText("No stops yet — add where you camped.").assertIsDisplayed()
+    }
+
+    @Test
+    fun `stop editor opens with the location section injected`() {
+        setContent()
+        compose.onNodeWithText("Schwarzwald").performClick()
+        compose.onNodeWithContentDescription("Add").performClick()
+        compose.onNodeWithText("Stop", useUnmergedTree = true).performClick()
+        compose.onNodeWithText("New stop").assertIsDisplayed()
+        compose.onNodeWithText("  Pick on map").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Cancel").performClick()
+        compose.onNodeWithText("Camping Kirnbergsee").assertIsDisplayed()
+    }
+
+    @Test
+    fun `picking a location on the map feeds the stop editor`() {
+        setContent()
+        compose.onNodeWithText("Schwarzwald").performClick()
+        compose.onNodeWithContentDescription("Add").performClick()
+        compose.onNodeWithText("Stop", useUnmergedTree = true).performClick()
+        compose.onNodeWithText("  Pick on map").performClick()
+        compose.onNodeWithText("Pick location").assertIsDisplayed()
+        compose.onNodeWithText("Use this spot", useUnmergedTree = true).performClick()
+        // Back on the stop editor with the picked map center as location.
+        compose.onNodeWithText("New stop").assertIsDisplayed()
+        compose.onNodeWithText("46.8, 8.2").assertIsDisplayed()
+    }
+
+    @Test
+    fun `location picker can be cancelled`() {
+        setContent()
+        compose.onNodeWithText("Schwarzwald").performClick()
+        compose.onNodeWithContentDescription("Add").performClick()
+        compose.onNodeWithText("Stop", useUnmergedTree = true).performClick()
+        compose.onNodeWithText("  Pick on map").performClick()
+        compose.onNodeWithContentDescription("Cancel").performClick()
+        compose.onNodeWithText("New stop").assertIsDisplayed()
+        compose.onNodeWithText("Not set").assertIsDisplayed()
+    }
+
+    @Test
+    fun `all trips map opens from the list`() {
+        setContent()
+        compose.onNodeWithContentDescription("All trips map").performClick()
+        compose.onNodeWithText("All trips").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Back").performClick()
+        compose.onNodeWithText("Trips").assertIsDisplayed()
+    }
+
+    @Test
+    fun `single trip map opens from the detail mini map`() {
+        setContent()
+        compose.onNodeWithText("Schwarzwald").performClick()
+        compose.onNodeWithTag("map-placeholder").performClick()
+        // Fullscreen map of just this trip carries the trip name as title.
+        compose.onAllNodesWithText("Schwarzwald")[0].assertIsDisplayed()
+    }
+
+    @Test
+    fun `settings open and return`() {
+        setContent()
+        compose.onNodeWithContentDescription("Settings").performClick()
+        compose.onNodeWithText("Settings").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Back").performClick()
+        compose.onNodeWithText("Trips").assertIsDisplayed()
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/settings/SettingsScreenTest.kt
@@ -1,0 +1,96 @@
+package com.nuelto.camperexperience.ui.settings
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.camperexperience.data.InMemorySettingsRepository
+import com.nuelto.camperexperience.testutil.FakeAuthRepository
+import com.nuelto.camperexperience.testutil.TestCamperApp
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = TestCamperApp::class)
+class SettingsScreenTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val settingsRepository = InMemorySettingsRepository()
+    private val events = mutableListOf<String>()
+
+    private fun setContent(auth: FakeAuthRepository? = null) {
+        val viewModel = SettingsViewModel(settingsRepository, auth)
+        compose.setContent {
+            SettingsScreen(onBack = { events += "back" }, viewModel = viewModel)
+        }
+    }
+
+    @Test
+    fun `shows the stored defaults`() {
+        setContent()
+        compose.onNodeWithText("Settings").assertIsDisplayed()
+        compose.onNodeWithText("CHF").assertIsDisplayed()
+        compose.onNodeWithText("10.0").assertIsDisplayed() // consumption
+        compose.onNodeWithText("1.8").assertIsDisplayed() // fuel price
+        compose.onNodeWithText("1.25").assertIsDisplayed() // road factor
+    }
+
+    @Test
+    fun `picking a currency persists it`() {
+        setContent()
+        compose.onNodeWithText("CHF").performClick()
+        compose.onNodeWithText("EUR").performClick()
+        runBlocking { assertEquals("EUR", settingsRepository.settings().first().currency) }
+    }
+
+    @Test
+    fun `valid consumption edits are committed while typing`() {
+        setContent()
+        compose.onNodeWithText("10.0").performTextReplacement("12.5")
+        runBlocking {
+            assertEquals(12.5, settingsRepository.settings().first().fuelConsumptionL100km, 1e-9)
+        }
+    }
+
+    @Test
+    fun `invalid or non-positive numbers are not committed`() {
+        setContent()
+        compose.onNodeWithText("10.0").performTextReplacement("abc")
+        compose.onNodeWithText("1.25").performTextReplacement("0")
+        runBlocking {
+            assertEquals(10.0, settingsRepository.settings().first().fuelConsumptionL100km, 1e-9)
+            assertEquals(1.25, settingsRepository.settings().first().roadDistanceFactor, 1e-9)
+        }
+    }
+
+    @Test
+    fun `sign out is hidden in local mode`() {
+        setContent()
+        compose.onNodeWithText("Sign out").assertDoesNotExist()
+    }
+
+    @Test
+    fun `sign out delegates to the auth repository`() {
+        val auth = FakeAuthRepository()
+        setContent(auth)
+        compose.onNodeWithText("Sign out").performClick()
+        assertEquals(1, auth.signOutCalls)
+    }
+
+    @Test
+    fun `back arrow navigates back`() {
+        setContent()
+        compose.onNodeWithContentDescription("Back").performClick()
+        assertEquals(listOf("back"), events)
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/settings/SettingsViewModelTest.kt
@@ -1,0 +1,51 @@
+package com.nuelto.camperexperience.ui.settings
+
+import app.cash.turbine.test
+import com.nuelto.camperexperience.data.InMemorySettingsRepository
+import com.nuelto.camperexperience.data.model.UserSettings
+import com.nuelto.camperexperience.testutil.FakeAuthRepository
+import com.nuelto.camperexperience.testutil.MainDispatcherRule
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+
+class SettingsViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val settingsRepository = InMemorySettingsRepository()
+
+    @Test
+    fun `starts with null until settings arrive`() = runTest {
+        val vm = SettingsViewModel(settingsRepository, null)
+        assertNull(vm.settings.value)
+        vm.settings.test {
+            assertEquals(UserSettings(), awaitItem())
+        }
+    }
+
+    @Test
+    fun `update writes through to the repository`() = runTest {
+        val vm = SettingsViewModel(settingsRepository, null)
+        vm.settings.test {
+            awaitItem()
+            vm.update(UserSettings(currency = "EUR"))
+            assertEquals("EUR", awaitItem()!!.currency)
+        }
+    }
+
+    @Test
+    fun `sign out delegates to the auth repository`() {
+        val auth = FakeAuthRepository()
+        SettingsViewModel(settingsRepository, auth).signOut()
+        assertEquals(1, auth.signOutCalls)
+    }
+
+    @Test
+    fun `sign out without auth repository is a no-op`() {
+        SettingsViewModel(settingsRepository, null).signOut() // must not throw
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/settings/SettingsViewModelTest.kt
@@ -40,7 +40,9 @@ class SettingsViewModelTest {
     @Test
     fun `sign out delegates to the auth repository`() {
         val auth = FakeAuthRepository()
-        SettingsViewModel(settingsRepository, auth).signOut()
+        val vm = SettingsViewModel(settingsRepository, auth)
+        assertEquals(auth, vm.authRepository)
+        vm.signOut()
         assertEquals(1, auth.signOutCalls)
     }
 

--- a/app/src/test/java/com/nuelto/camperexperience/ui/theme/ThemeTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/theme/ThemeTest.kt
@@ -1,0 +1,57 @@
+package com.nuelto.camperexperience.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.camperexperience.testutil.TestCamperApp
+import org.junit.Assert.assertNotEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = TestCamperApp::class)
+class ThemeTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private fun colorsFor(darkTheme: Boolean): Color {
+        var primary = Color.Unspecified
+        compose.setContent {
+            CamperTheme(darkTheme = darkTheme) {
+                primary = MaterialTheme.colorScheme.primary
+                Text("themed")
+            }
+        }
+        compose.onNodeWithText("themed").assertIsDisplayed()
+        return primary
+    }
+
+    @Test
+    fun `dynamic colors are used on modern android`() {
+        assertNotEquals(Color.Unspecified, colorsFor(darkTheme = false))
+    }
+
+    @Test
+    fun `dynamic dark colors are used on modern android`() {
+        assertNotEquals(Color.Unspecified, colorsFor(darkTheme = true))
+    }
+
+    @Test
+    @Config(sdk = [30])
+    fun `static light palette is used before android 12`() {
+        assertNotEquals(Color.Unspecified, colorsFor(darkTheme = false))
+    }
+
+    @Test
+    @Config(sdk = [30])
+    fun `static dark palette differs from light before android 12`() {
+        assertNotEquals(Color.Unspecified, colorsFor(darkTheme = true))
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/ExpenseEditSheetTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/ExpenseEditSheetTest.kt
@@ -1,0 +1,147 @@
+package com.nuelto.camperexperience.ui.tripdetail
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextReplacement
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.camperexperience.data.model.Expense
+import com.nuelto.camperexperience.data.model.ExpenseType
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.UserSettings
+import com.nuelto.camperexperience.testutil.TestCamperApp
+import java.time.LocalDate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = TestCamperApp::class)
+class ExpenseEditSheetTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val saved = mutableListOf<Expense>()
+    private var dismissed = 0
+
+    private val locatedStops = listOf(
+        Stop(id = "s1", tripId = "t1", location = LatLng(47.0, 7.0), orderIndex = 0),
+        Stop(id = "s2", tripId = "t1", location = LatLng(47.5, 7.5), orderIndex = 1),
+    )
+
+    private fun setContent(initial: Expense? = null, stops: List<Stop> = locatedStops) {
+        compose.setContent {
+            ExpenseEditSheet(
+                initial = initial,
+                stops = stops,
+                settings = UserSettings(),
+                onSave = { saved += it },
+                onDismiss = { dismissed++ },
+            )
+        }
+    }
+
+    @Test
+    fun `new expense defaults to fuel with a disabled save`() {
+        setContent()
+        compose.onNodeWithText("New expense").assertIsDisplayed()
+        compose.onNodeWithText("Estimate from distance…").assertIsDisplayed()
+        compose.onNodeWithText("Save").assertIsNotEnabled()
+    }
+
+    @Test
+    fun `save passes the parsed amount type and trimmed label`() {
+        setContent()
+        compose.onNodeWithText("Road tax").performClick()
+        compose.onNodeWithText("Amount").performTextInput("61,40")
+        compose.onNodeWithText("Label (optional)").performTextInput(" Vignette ")
+        compose.onNodeWithText("Save").performClick()
+        val expense = saved.single()
+        assertEquals(ExpenseType.ROAD_TAX, expense.type)
+        assertEquals(61.40, expense.amount, 1e-9)
+        assertEquals("Vignette", expense.label)
+        assertFalse(expense.isEstimate)
+    }
+
+    @Test
+    fun `estimator link is only offered for fuel`() {
+        setContent()
+        compose.onNodeWithText("Other").performClick()
+        compose.onNodeWithText("Estimate from distance…").assertDoesNotExist()
+        compose.onNodeWithText("Fuel").performClick()
+        compose.onNodeWithText("Estimate from distance…").assertIsDisplayed()
+    }
+
+    @Test
+    fun `estimator prefills distance and fills the amount as estimate`() {
+        setContent()
+        compose.onNodeWithText("Estimate from distance…").performClick()
+        compose.onNodeWithText("Fuel estimate").assertIsDisplayed()
+        compose.onNodeWithText("Use this amount").assertIsEnabled()
+        compose.onNodeWithText("Use this amount").performClick()
+        compose.onNodeWithText("Save").performClick()
+        val expense = saved.single()
+        assertTrue(expense.isEstimate)
+        assertTrue(expense.amount > 0.0)
+    }
+
+    @Test
+    fun `editing the amount by hand clears the estimate flag`() {
+        setContent()
+        compose.onNodeWithText("Estimate from distance…").performClick()
+        compose.onNodeWithText("Use this amount").performClick()
+        compose.onNodeWithText("Amount").performTextReplacement("99")
+        compose.onNodeWithText("Save").performClick()
+        assertFalse(saved.single().isEstimate)
+        assertEquals(99.0, saved.single().amount, 1e-9)
+    }
+
+    @Test
+    fun `estimator without a route offers no amount`() {
+        setContent(stops = emptyList())
+        compose.onNodeWithText("Estimate from distance…").performClick()
+        compose.onNodeWithText("—").assertExists()
+        compose.onNodeWithText("Use this amount").assertIsNotEnabled()
+    }
+
+    @Test
+    fun `broken estimator input disables the use button`() {
+        setContent()
+        compose.onNodeWithText("Estimate from distance…").performClick()
+        compose.onNodeWithText("Distance").performTextReplacement("abc")
+        compose.onNodeWithText("—").assertExists()
+        compose.onNodeWithText("Use this amount").assertIsNotEnabled()
+    }
+
+    @Test
+    fun `existing expense is prefilled for editing`() {
+        setContent(
+            Expense(
+                id = "e1", tripId = "t1", type = ExpenseType.OTHER, amount = 24.0,
+                date = LocalDate.of(2026, 5, 16), label = "Seilbahn",
+            ),
+        )
+        compose.onNodeWithText("Edit expense").assertIsDisplayed()
+        compose.onNodeWithText("24.0").assertIsDisplayed()
+        compose.onNodeWithText("Seilbahn").assertIsDisplayed()
+        compose.onNodeWithText("Save").performClick()
+        assertEquals("e1", saved.single().id)
+        assertEquals(24.0, saved.single().amount, 1e-9)
+    }
+
+    @Test
+    fun `zero amount on an existing expense shows an empty field`() {
+        setContent(Expense(id = "e1", tripId = "t1", amount = 0.0))
+        compose.onNodeWithText("Save").assertIsNotEnabled()
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreenTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreenTest.kt
@@ -1,0 +1,254 @@
+package com.nuelto.camperexperience.ui.tripdetail
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.camperexperience.data.InMemorySettingsRepository
+import com.nuelto.camperexperience.data.InMemoryTripRepository
+import com.nuelto.camperexperience.data.model.Expense
+import com.nuelto.camperexperience.data.model.ExpenseType
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.Trip
+import com.nuelto.camperexperience.testutil.TestCamperApp
+import com.nuelto.camperexperience.ui.map.LocalMapEnabled
+import java.time.LocalDate
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = TestCamperApp::class)
+class TripDetailScreenTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val tripRepository = InMemoryTripRepository(seed = false)
+    private val settingsRepository = InMemorySettingsRepository()
+    private val events = mutableListOf<String>()
+
+    private fun seed(withLocations: Boolean = false, withExpenses: Boolean = true) = runBlocking {
+        tripRepository.upsertTrip(
+            Trip(
+                id = "t1", name = "Jura", startDate = LocalDate.of(2026, 7, 1),
+                endDate = LocalDate.of(2026, 7, 4), notes = "Rainy but great",
+            ),
+        )
+        tripRepository.upsertStop(
+            Stop(
+                id = "s1", tripId = "t1", name = "Camp A", nights = 2, campingCostTotal = 40.0,
+                location = if (withLocations) LatLng(47.0, 7.0) else null, orderIndex = 0,
+            ),
+        )
+        if (withExpenses) {
+            tripRepository.upsertExpense(
+                Expense(
+                    id = "e1", tripId = "t1", type = ExpenseType.ROAD_TAX, amount = 30.0,
+                    date = LocalDate.of(2026, 7, 2), label = "Vignette",
+                ),
+            )
+            tripRepository.upsertExpense(
+                Expense(
+                    id = "e2", tripId = "t1", type = ExpenseType.OTHER, amount = 5.0,
+                    date = LocalDate.of(2026, 7, 3), isEstimate = true,
+                ),
+            )
+        }
+    }
+
+    private fun setContent(tripId: String = "t1") {
+        val viewModel = TripDetailViewModel(
+            SavedStateHandle(mapOf("tripId" to tripId)),
+            tripRepository,
+            settingsRepository,
+        )
+        compose.setContent {
+            CompositionLocalProvider(LocalMapEnabled provides false) {
+                TripDetailScreen(
+                    onBack = { events += "back" },
+                    onEditTrip = { events += "edit:$it" },
+                    onAddStop = { events += "addStop:$it" },
+                    onEditStop = { tripId2, stopId -> events += "editStop:$tripId2:$stopId" },
+                    onOpenTripMap = { events += "map:$it" },
+                    viewModel = viewModel,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `shows trip header stops expenses and cost breakdown`() {
+        seed()
+        setContent()
+        compose.onNodeWithText("Jura").assertIsDisplayed()
+        compose.onNodeWithText("Rainy but great").assertIsDisplayed()
+        compose.onNodeWithText("Camp A").assertIsDisplayed()
+        compose.onNodeWithText("Vignette").assertIsDisplayed()
+        compose.onNodeWithText("Total").assertIsDisplayed()
+        compose.onNodeWithText("2 nights").assertIsDisplayed()
+        // Camping 40 + road tax 30 + other 5
+        compose.onNodeWithText("Camping").assertIsDisplayed()
+        compose.onNodeWithText("Road tax").assertIsDisplayed()
+        // The OTHER expense has no label -> falls back to type name; "(estimate)" tag shown.
+        compose.onNodeWithText("  (estimate)").assertIsDisplayed()
+    }
+
+    @Test
+    fun `empty trip prompts for stops and expenses`() {
+        runBlocking {
+            tripRepository.upsertTrip(Trip(id = "t1", name = "Empty", startDate = LocalDate.of(2026, 7, 1)))
+        }
+        setContent()
+        compose.onNodeWithText("No stops yet — add where you camped.").assertIsDisplayed()
+        compose.onNodeWithText("No expenses yet.").assertIsDisplayed()
+    }
+
+    @Test
+    fun `unknown trip renders nothing but the scaffold`() {
+        setContent("nope")
+        compose.onNodeWithText("Stops").assertDoesNotExist()
+    }
+
+    @Test
+    fun `mini map appears only when a stop has a location`() {
+        seed(withLocations = false)
+        setContent()
+        compose.onNodeWithTag("map-placeholder").assertDoesNotExist()
+    }
+
+    @Test
+    fun `tapping the mini map opens the fullscreen trip map`() {
+        seed(withLocations = true)
+        setContent()
+        compose.onNodeWithTag("map-placeholder").assertExists()
+        compose.onNodeWithTag("map-placeholder").performClick()
+        assertEquals(listOf("map:t1"), events)
+    }
+
+    @Test
+    fun `fuel estimate row and disclaimer show when no fuel is logged`() {
+        runBlocking {
+            seed(withLocations = true, withExpenses = false)
+            tripRepository.upsertStop(
+                Stop(id = "s2", tripId = "t1", name = "Camp B", location = LatLng(47.5, 7.5), orderIndex = 1),
+            )
+        }
+        setContent()
+        compose.onNodeWithText("Fuel (estimate)").assertIsDisplayed()
+        compose.onNodeWithText(
+            "Fuel is estimated by driving distance between stops — log a fuel expense to replace it.",
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun `top bar actions navigate`() {
+        seed()
+        setContent()
+        compose.onNodeWithContentDescription("Back").performClick()
+        compose.onNodeWithContentDescription("Edit trip").performClick()
+        assertEquals(listOf("back", "edit:t1"), events)
+    }
+
+    @Test
+    fun `delete dialog cancel keeps the trip`() {
+        seed()
+        setContent()
+        compose.onNodeWithContentDescription("Delete trip").performClick()
+        compose.onNodeWithText("Delete trip?").assertIsDisplayed()
+        compose.onNodeWithText("Cancel").performClick()
+        compose.onNodeWithText("Delete trip?").assertDoesNotExist()
+        runBlocking { assertEquals(1, tripRepository.trips().first().size) }
+    }
+
+    @Test
+    fun `delete dialog confirm deletes and navigates back`() {
+        seed()
+        setContent()
+        compose.onNodeWithContentDescription("Delete trip").performClick()
+        compose.onNodeWithText("Delete").performClick()
+        assertEquals(listOf("back"), events)
+        runBlocking { assertTrue(tripRepository.trips().first().isEmpty()) }
+    }
+
+    @Test
+    fun `fab menu adds a stop`() {
+        seed()
+        setContent()
+        compose.onNodeWithContentDescription("Add").performClick()
+        compose.onNodeWithText("Stop", useUnmergedTree = true).performClick()
+        assertEquals(listOf("addStop:t1"), events)
+    }
+
+    @Test
+    fun `fab menu toggles closed again`() {
+        seed()
+        setContent()
+        compose.onNodeWithContentDescription("Add").performClick()
+        compose.onNodeWithContentDescription("Close add menu").performClick()
+        compose.onNodeWithContentDescription("Add").assertIsDisplayed()
+    }
+
+    @Test
+    fun `fab menu opens the new expense sheet`() {
+        seed()
+        setContent()
+        compose.onNodeWithContentDescription("Add").performClick()
+        compose.onNodeWithText("Expense", useUnmergedTree = true).performClick()
+        compose.onNodeWithText("New expense").assertIsDisplayed()
+    }
+
+    @Test
+    fun `tapping a stop opens its editor`() {
+        seed()
+        setContent()
+        compose.onNodeWithText("Camp A").performClick()
+        assertEquals(listOf("editStop:t1:s1"), events)
+    }
+
+    @Test
+    fun `tapping an expense opens the edit sheet`() {
+        seed()
+        setContent()
+        compose.onNodeWithText("Vignette").performClick()
+        compose.onNodeWithText("Edit expense").assertIsDisplayed()
+    }
+
+    @Test
+    fun `expense delete icon removes the expense`() {
+        seed()
+        setContent()
+        compose.onAllNodesWithContentDescription("Delete expense")[0].performClick()
+        runBlocking {
+            assertEquals(listOf("e2"), tripRepository.expenses("t1").first().map { it.id })
+        }
+    }
+
+    @Test
+    fun `saving an expense from the sheet stores it on the trip`() {
+        seed()
+        setContent()
+        compose.onNodeWithContentDescription("Add").performClick()
+        compose.onNodeWithText("Expense", useUnmergedTree = true).performClick()
+        compose.onNodeWithText("Amount").performClick()
+        compose.onNodeWithText("Amount").performTextInput("42.50")
+        compose.onNodeWithText("Save").performClick()
+        runBlocking {
+            val saved = tripRepository.expenses("t1").first().single { it.amount == 42.5 }
+            assertEquals("t1", saved.tripId)
+        }
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModelTest.kt
@@ -1,0 +1,101 @@
+package com.nuelto.camperexperience.ui.tripdetail
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.nuelto.camperexperience.data.InMemorySettingsRepository
+import com.nuelto.camperexperience.data.InMemoryTripRepository
+import com.nuelto.camperexperience.data.model.Expense
+import com.nuelto.camperexperience.data.model.ExpenseType
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.Trip
+import com.nuelto.camperexperience.testutil.MainDispatcherRule
+import java.time.LocalDate
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TripDetailViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val tripRepository = InMemoryTripRepository(seed = false)
+    private val settingsRepository = InMemorySettingsRepository()
+
+    private fun viewModel(tripId: String = "t1") = TripDetailViewModel(
+        SavedStateHandle(mapOf("tripId" to tripId)),
+        tripRepository,
+        settingsRepository,
+    )
+
+    private suspend fun seedTrip() {
+        tripRepository.upsertTrip(Trip(id = "t1", name = "Jura", startDate = LocalDate.of(2026, 7, 1)))
+        tripRepository.upsertStop(
+            Stop(id = "s1", tripId = "t1", name = "A", nights = 2, campingCostTotal = 40.0, location = LatLng(47.0, 7.0), orderIndex = 0),
+        )
+        tripRepository.upsertStop(
+            Stop(id = "s2", tripId = "t1", name = "B", nights = 1, campingCostTotal = 20.0, location = LatLng(47.5, 7.5), orderIndex = 1),
+        )
+        tripRepository.upsertExpense(
+            Expense(id = "e1", tripId = "t1", type = ExpenseType.ROAD_TAX, amount = 30.0, date = LocalDate.of(2026, 7, 2)),
+        )
+    }
+
+    @Test
+    fun `state combines trip stops expenses breakdown and estimate`() = runTest {
+        seedTrip()
+        viewModel().uiState.test {
+            val state = awaitItem()
+            assertEquals("Jura", state.trip!!.name)
+            assertEquals(listOf("s1", "s2"), state.stops.map { it.id })
+            assertEquals(listOf("e1"), state.expenses.map { it.id })
+            assertEquals(60.0, state.breakdown.getValue(ExpenseType.CAMPING), 1e-9)
+            assertEquals(30.0, state.breakdown.getValue(ExpenseType.ROAD_TAX), 1e-9)
+            assertNotNull(state.fuelEstimate) // no fuel logged, route exists
+            assertEquals("CHF", state.settings.currency)
+            assertTrue(!state.loading)
+        }
+    }
+
+    @Test
+    fun `unknown trip yields null trip`() = runTest {
+        viewModel("nope").uiState.test {
+            assertNull(awaitItem().trip)
+        }
+    }
+
+    @Test
+    fun `delete stop and expense write through`() = runTest {
+        seedTrip()
+        val vm = viewModel()
+        vm.deleteStop("s1")
+        vm.deleteExpense("e1")
+        assertEquals(listOf("s2"), tripRepository.stops("t1").first().map { it.id })
+        assertTrue(tripRepository.expenses("t1").first().isEmpty())
+    }
+
+    @Test
+    fun `upsert expense forces the trip id`() = runTest {
+        seedTrip()
+        viewModel().upsertExpense(Expense(id = "e9", tripId = "other", type = ExpenseType.OTHER, amount = 5.0))
+        assertEquals("t1", tripRepository.expenses("t1").first().first { it.id == "e9" }.tripId)
+    }
+
+    @Test
+    fun `delete trip removes it and notifies`() = runTest {
+        seedTrip()
+        var deleted = false
+        viewModel().deleteTrip { deleted = true }
+        assertTrue(deleted)
+        assertNull(tripRepository.trip("t1").first())
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/StopEditScreenTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/StopEditScreenTest.kt
@@ -1,0 +1,104 @@
+package com.nuelto.camperexperience.ui.tripedit
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.camperexperience.data.InMemoryTripRepository
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.testutil.TestCamperApp
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = TestCamperApp::class)
+class StopEditScreenTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val tripRepository = InMemoryTripRepository(seed = false)
+    private val events = mutableListOf<String>()
+
+    private fun setContent(stopId: String? = null, withLocationSection: Boolean = false) {
+        val args = if (stopId == null) mapOf("tripId" to "t1") else mapOf("tripId" to "t1", "stopId" to stopId)
+        val viewModel = StopEditViewModel(SavedStateHandle(args), tripRepository, null)
+        compose.setContent {
+            StopEditScreen(
+                onBack = { events += "back" },
+                viewModel = viewModel,
+                locationSection = if (withLocationSection) {
+                    { Text("Location section slot") }
+                } else {
+                    null
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `new stop with nights stepper and save`() {
+        setContent()
+        compose.onNodeWithText("New stop").assertIsDisplayed()
+        compose.onNodeWithText("Save").assertIsNotEnabled()
+        compose.onNodeWithContentDescription("Delete stop").assertDoesNotExist()
+
+        compose.onNodeWithText("More nights").assertDoesNotExist()
+        compose.onNodeWithText("1").assertIsDisplayed()
+        compose.onNodeWithContentDescription("More nights").performClick()
+        compose.onNodeWithText("2").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Fewer nights").performClick()
+        compose.onNodeWithText("1").assertIsDisplayed()
+
+        compose.onNodeWithText("Campsite / place").performTextInput("Aire")
+        compose.onNodeWithText("Camping cost (total for stay)").performTextInput("25")
+        compose.onNodeWithText("Save").performClick()
+        assertEquals(listOf("back"), events)
+        runBlocking {
+            val stop = tripRepository.stops("t1").first().single()
+            assertEquals("Aire", stop.name)
+            assertEquals(25.0, stop.campingCostTotal, 1e-9)
+        }
+    }
+
+    @Test
+    fun `location label defaults to not set and the slot is rendered`() {
+        setContent(withLocationSection = true)
+        compose.onNodeWithText("Not set").assertIsDisplayed()
+        compose.onNodeWithText("Location section slot").assertIsDisplayed()
+    }
+
+    @Test
+    fun `existing stop can be deleted from the top bar`() {
+        runBlocking {
+            tripRepository.upsertStop(Stop(id = "s1", tripId = "t1", name = "Camp", location = LatLng(46.0, 7.0)))
+        }
+        setContent("s1")
+        compose.onNodeWithText("Edit stop").assertIsDisplayed()
+        compose.onNodeWithText("Camp").assertIsDisplayed()
+        compose.onNodeWithText("46.0, 7.0").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Delete stop").performClick()
+        assertEquals(listOf("back"), events)
+        runBlocking { assertTrue(tripRepository.stops("t1").first().isEmpty()) }
+    }
+
+    @Test
+    fun `cancel navigates back`() {
+        setContent()
+        compose.onNodeWithContentDescription("Cancel").performClick()
+        assertEquals(listOf("back"), events)
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/StopEditScreenTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/StopEditScreenTest.kt
@@ -37,15 +37,15 @@ class StopEditScreenTest {
         val args = if (stopId == null) mapOf("tripId" to "t1") else mapOf("tripId" to "t1", "stopId" to stopId)
         val viewModel = StopEditViewModel(SavedStateHandle(args), tripRepository, null)
         compose.setContent {
-            StopEditScreen(
-                onBack = { events += "back" },
-                viewModel = viewModel,
-                locationSection = if (withLocationSection) {
-                    { Text("Location section slot") }
-                } else {
-                    null
-                },
-            )
+            if (withLocationSection) {
+                StopEditScreen(
+                    onBack = { events += "back" },
+                    viewModel = viewModel,
+                    locationSection = { Text("Location section slot") },
+                )
+            } else {
+                StopEditScreen(onBack = { events += "back" }, viewModel = viewModel)
+            }
         }
     }
 

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/StopEditViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/StopEditViewModelTest.kt
@@ -1,0 +1,220 @@
+package com.nuelto.camperexperience.ui.tripedit
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.camperexperience.data.InMemoryTripRepository
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.testutil.FakePlaceNameResolver
+import com.nuelto.camperexperience.testutil.MainDispatcherRule
+import java.time.LocalDate
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class StopEditViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val tripRepository = InMemoryTripRepository(seed = false)
+    private val resolver = FakePlaceNameResolver(ApplicationProvider.getApplicationContext())
+
+    private fun newStopViewModel() = StopEditViewModel(
+        SavedStateHandle(mapOf("tripId" to "t1")),
+        tripRepository,
+        resolver,
+    )
+
+    private fun editViewModel(stopId: String) = StopEditViewModel(
+        SavedStateHandle(mapOf("tripId" to "t1", "stopId" to stopId)),
+        tripRepository,
+        resolver,
+    )
+
+    @Test
+    fun `new stop wants an immediate GPS fix exactly once`() {
+        val vm = newStopViewModel()
+        assertTrue(vm.uiState.value.autoLocatePending)
+        vm.autoLocateHandled()
+        assertFalse(vm.uiState.value.autoLocatePending)
+        assertEquals("t1", vm.tripId)
+    }
+
+    @Test
+    fun `location label falls back from place name to coordinates to not set`() {
+        assertEquals("Not set", StopEditUiState().locationLabel)
+        assertEquals("46.5, 7.5", StopEditUiState(location = LatLng(46.5, 7.5)).locationLabel)
+        assertEquals("Thun", StopEditUiState(location = LatLng(46.5, 7.5), locationName = "Thun").locationLabel)
+    }
+
+    @Test
+    fun `setters update state and nights are clamped`() {
+        val vm = newStopViewModel()
+        vm.setName("Aire")
+        vm.setArrivalDate(LocalDate.of(2026, 7, 2))
+        vm.setCampingCost("12,50")
+        vm.setNotes("ok")
+        vm.setNights(-3)
+        assertEquals(0, vm.uiState.value.nights)
+        vm.setNights(400)
+        assertEquals(365, vm.uiState.value.nights)
+        val state = vm.uiState.value
+        assertEquals("Aire", state.name)
+        assertEquals(LocalDate.of(2026, 7, 2), state.arrivalDate)
+        assertEquals("12,50", state.campingCost)
+        assertEquals("ok", state.notes)
+    }
+
+    @Test
+    fun `set location rounds to five decimals and resolves the place name`() {
+        val vm = newStopViewModel()
+        vm.setLocation(LatLng(46.123456789, 7.987654321))
+        val location = vm.uiState.value.location!!
+        assertEquals(46.12346, location.latitude, 1e-9)
+        assertEquals(7.98765, location.longitude, 1e-9)
+        assertEquals("Place@46.12346", vm.uiState.value.locationName)
+    }
+
+    @Test
+    fun `clearing the location clears the name label`() {
+        val vm = newStopViewModel()
+        vm.setLocation(LatLng(46.0, 7.0))
+        vm.setLocation(null)
+        assertNull(vm.uiState.value.location)
+        assertNull(vm.uiState.value.locationName)
+    }
+
+    @Test
+    fun `blank stop name is auto-filled from the place and follows relocation`() {
+        val vm = newStopViewModel()
+        vm.setLocation(LatLng(46.0, 7.0))
+        assertEquals("Place@46.0", vm.uiState.value.name)
+        // Still auto-filled -> a new location may overwrite it.
+        vm.setLocation(LatLng(47.0, 7.0))
+        assertEquals("Place@47.0", vm.uiState.value.name)
+    }
+
+    @Test
+    fun `a name typed by the user is never overwritten`() {
+        val vm = newStopViewModel()
+        vm.setName("My spot")
+        vm.setLocation(LatLng(46.0, 7.0))
+        assertEquals("My spot", vm.uiState.value.name)
+        assertEquals("Place@46.0", vm.uiState.value.locationName)
+    }
+
+    @Test
+    fun `late place result for an outdated location is ignored`() {
+        resolver.gated = true
+        val vm = newStopViewModel()
+        vm.setLocation(LatLng(46.0, 7.0))
+        vm.setLocation(LatLng(47.0, 7.0))
+        assertEquals(2, resolver.gates.size)
+        resolver.gates[1].complete(Unit) // current location resolves first
+        assertEquals("Place@47.0", vm.uiState.value.name)
+        resolver.gates[0].complete(Unit) // stale result must not win
+        assertEquals("Place@47.0", vm.uiState.value.name)
+        assertEquals("Place@47.0", vm.uiState.value.locationName)
+    }
+
+    @Test
+    fun `save appends a new stop with the next order index`() = runTest {
+        tripRepository.upsertStop(Stop(id = "s0", tripId = "t1", name = "First", orderIndex = 0))
+        val vm = newStopViewModel()
+        vm.setName("  Aire ")
+        vm.setCampingCost("30")
+        vm.setNotes(" n ")
+        vm.setNights(2)
+        var saved = false
+        vm.save { saved = true }
+        assertTrue(saved)
+        val stop = tripRepository.stops("t1").first().single { it.name == "Aire" }
+        assertEquals(1, stop.orderIndex)
+        assertEquals(30.0, stop.campingCostTotal, 1e-9)
+        assertEquals(2, stop.nights)
+        assertEquals("n", stop.notes)
+    }
+
+    @Test
+    fun `save without a name is refused`() = runTest {
+        var saved = false
+        newStopViewModel().save { saved = true }
+        assertFalse(saved)
+        assertTrue(tripRepository.stops("t1").first().isEmpty())
+    }
+
+    @Test
+    fun `unparseable camping cost saves as zero`() = runTest {
+        val vm = newStopViewModel()
+        vm.setName("Aire")
+        vm.setCampingCost("abc")
+        vm.save {}
+        assertEquals(0.0, tripRepository.stops("t1").first().single().campingCostTotal, 1e-9)
+    }
+
+    @Test
+    fun `existing stop is loaded and its place name resolved without renaming`() = runTest {
+        tripRepository.upsertStop(
+            Stop(
+                id = "s1", tripId = "t1", name = "Camp", arrivalDate = LocalDate.of(2026, 7, 3),
+                nights = 3, campingCostTotal = 45.0, location = LatLng(46.0, 7.0), notes = "x",
+            ),
+        )
+        val vm = editViewModel("s1")
+        val state = vm.uiState.value
+        assertFalse(state.isNew)
+        assertEquals("Camp", state.name) // not overwritten by "Place@46.0"
+        assertEquals("45.0", state.campingCost)
+        assertEquals("Place@46.0", state.locationName)
+        assertEquals(3, state.nights)
+        assertEquals("x", state.notes)
+    }
+
+    @Test
+    fun `zero camping cost shows as empty field`() = runTest {
+        tripRepository.upsertStop(Stop(id = "s1", tripId = "t1", name = "Camp", campingCostTotal = 0.0))
+        assertEquals("", editViewModel("s1").uiState.value.campingCost)
+    }
+
+    @Test
+    fun `saving an existing stop keeps id and order`() = runTest {
+        tripRepository.upsertStop(Stop(id = "s1", tripId = "t1", name = "Camp", orderIndex = 4))
+        val vm = editViewModel("s1")
+        vm.setName("Renamed")
+        vm.save {}
+        val stop = tripRepository.stops("t1").first().single()
+        assertEquals("s1", stop.id)
+        assertEquals(4, stop.orderIndex)
+        assertEquals("Renamed", stop.name)
+    }
+
+    @Test
+    fun `delete removes an existing stop and is a no-op for new ones`() = runTest {
+        tripRepository.upsertStop(Stop(id = "s1", tripId = "t1", name = "Camp"))
+        var deleted = false
+        editViewModel("s1").delete { deleted = true }
+        assertTrue(deleted)
+        assertTrue(tripRepository.stops("t1").first().isEmpty())
+
+        var newDeleted = false
+        newStopViewModel().delete { newDeleted = true }
+        assertFalse(newDeleted)
+    }
+
+    @Test
+    fun `works without a place name resolver`() {
+        val vm = StopEditViewModel(SavedStateHandle(mapOf("tripId" to "t1")), tripRepository, null)
+        vm.setLocation(LatLng(46.0, 7.0))
+        assertNull(vm.uiState.value.locationName)
+        assertEquals("46.0, 7.0", vm.uiState.value.locationLabel)
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/StopEditViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/StopEditViewModelTest.kt
@@ -212,7 +212,7 @@ class StopEditViewModelTest {
 
     @Test
     fun `works without a place name resolver`() {
-        val vm = StopEditViewModel(SavedStateHandle(mapOf("tripId" to "t1")), tripRepository, null)
+        val vm = StopEditViewModel(SavedStateHandle(mapOf("tripId" to "t1")), tripRepository)
         vm.setLocation(LatLng(46.0, 7.0))
         assertNull(vm.uiState.value.locationName)
         assertEquals("46.0, 7.0", vm.uiState.value.locationLabel)

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/TripEditScreenTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/TripEditScreenTest.kt
@@ -1,0 +1,91 @@
+package com.nuelto.camperexperience.ui.tripedit
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.camperexperience.data.InMemoryTripRepository
+import com.nuelto.camperexperience.data.model.Trip
+import com.nuelto.camperexperience.testutil.TestCamperApp
+import java.time.LocalDate
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = TestCamperApp::class)
+class TripEditScreenTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val tripRepository = InMemoryTripRepository(seed = false)
+    private val events = mutableListOf<String>()
+
+    private fun setContent(tripId: String? = null) {
+        val handle = if (tripId == null) SavedStateHandle() else SavedStateHandle(mapOf("tripId" to tripId))
+        val viewModel = TripEditViewModel(handle, tripRepository)
+        compose.setContent {
+            TripEditScreen(
+                onBack = { events += "back" },
+                onSaved = { id, isNew -> events += "saved:$id:$isNew" },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    @Test
+    fun `new trip cannot be saved until it has a name`() {
+        setContent()
+        compose.onNodeWithText("New trip").assertIsDisplayed()
+        compose.onNodeWithText("Save").assertIsNotEnabled()
+        compose.onNodeWithText("Trip name").performTextInput("Jura")
+        compose.onNodeWithText("Save").assertIsEnabled()
+        compose.onNodeWithText("Save").performClick()
+        runBlocking {
+            val trip = tripRepository.trips().first().single()
+            assertEquals("Jura", trip.name)
+            assertEquals(listOf("saved:${trip.id}:true"), events)
+        }
+    }
+
+    @Test
+    fun `cancel goes back without saving`() {
+        setContent()
+        compose.onNodeWithContentDescription("Cancel").performClick()
+        assertEquals(listOf("back"), events)
+        runBlocking { assertEquals(0, tripRepository.trips().first().size) }
+    }
+
+    @Test
+    fun `existing trip shows its data and clear removes the end date`() {
+        runBlocking {
+            tripRepository.upsertTrip(
+                Trip(
+                    id = "t1", name = "Old", startDate = LocalDate.of(2026, 5, 1),
+                    endDate = LocalDate.of(2026, 5, 3), notes = "n",
+                ),
+            )
+        }
+        setContent("t1")
+        compose.onNodeWithText("Edit trip").assertIsDisplayed()
+        compose.onNodeWithText("Old").assertIsDisplayed()
+        compose.onNodeWithText("Clear").performClick()
+        compose.onNodeWithText("Clear").assertDoesNotExist()
+        compose.onNodeWithText("Save").performClick()
+        runBlocking {
+            assertEquals(null, tripRepository.trip("t1").first()!!.endDate)
+        }
+        assertEquals(listOf("saved:t1:false"), events)
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/TripEditViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/TripEditViewModelTest.kt
@@ -1,0 +1,110 @@
+package com.nuelto.camperexperience.ui.tripedit
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.camperexperience.data.InMemoryTripRepository
+import com.nuelto.camperexperience.data.model.Trip
+import com.nuelto.camperexperience.testutil.MainDispatcherRule
+import java.time.LocalDate
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TripEditViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val tripRepository = InMemoryTripRepository(seed = false)
+
+    private fun newTripViewModel() =
+        TripEditViewModel(SavedStateHandle(), tripRepository)
+
+    private fun editViewModel(tripId: String) =
+        TripEditViewModel(SavedStateHandle(mapOf("tripId" to tripId)), tripRepository)
+
+    @Test
+    fun `new trip starts blank and savable only with a name`() {
+        val state = newTripViewModel().uiState.value
+        assertTrue(state.isNew)
+        assertTrue(state.loaded)
+        assertEquals("", state.name)
+        assertNull(state.endDate)
+        assertFalse(state.canSave)
+    }
+
+    @Test
+    fun `setters update the state`() {
+        val vm = newTripViewModel()
+        vm.setName("Jura")
+        vm.setStartDate(LocalDate.of(2026, 7, 1))
+        vm.setEndDate(LocalDate.of(2026, 7, 5))
+        vm.setNotes("wet")
+        val state = vm.uiState.value
+        assertEquals("Jura", state.name)
+        assertEquals(LocalDate.of(2026, 7, 1), state.startDate)
+        assertEquals(LocalDate.of(2026, 7, 5), state.endDate)
+        assertEquals("wet", state.notes)
+        assertTrue(state.canSave)
+        vm.setEndDate(null)
+        assertNull(vm.uiState.value.endDate)
+    }
+
+    @Test
+    fun `save creates a new trip with trimmed fields`() = runTest {
+        val vm = newTripViewModel()
+        vm.setName("  Jura ")
+        vm.setNotes(" note ")
+        var saved: Pair<String, Boolean>? = null
+        vm.save { id, isNew -> saved = id to isNew }
+        assertTrue(saved!!.second)
+        val trip = tripRepository.trip(saved!!.first).first()!!
+        assertEquals("Jura", trip.name)
+        assertEquals("note", trip.notes)
+    }
+
+    @Test
+    fun `save without a name is refused`() = runTest {
+        var called = false
+        newTripViewModel().save { _, _ -> called = true }
+        assertFalse(called)
+        assertTrue(tripRepository.trips().first().isEmpty())
+    }
+
+    @Test
+    fun `existing trip is loaded and updated in place`() = runTest {
+        tripRepository.upsertTrip(
+            Trip(
+                id = "t1", name = "Old", startDate = LocalDate.of(2026, 5, 1),
+                endDate = LocalDate.of(2026, 5, 3), notes = "n",
+            ),
+        )
+        val vm = editViewModel("t1")
+        val loadedState = vm.uiState.value
+        assertFalse(loadedState.isNew)
+        assertTrue(loadedState.loaded)
+        assertEquals("Old", loadedState.name)
+        assertEquals(LocalDate.of(2026, 5, 3), loadedState.endDate)
+        assertEquals("n", loadedState.notes)
+
+        vm.setName("New")
+        var saved: Pair<String, Boolean>? = null
+        vm.save { id, isNew -> saved = id to isNew }
+        assertEquals("t1" to false, saved)
+        assertEquals(listOf("New"), tripRepository.trips().first().map { it.name })
+    }
+
+    @Test
+    fun `editing an id that vanished behaves like a new trip`() {
+        val state = editViewModel("gone").uiState.value
+        assertTrue(state.isNew)
+        assertTrue(state.loaded)
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/triplist/TripListScreenTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/triplist/TripListScreenTest.kt
@@ -1,0 +1,84 @@
+package com.nuelto.camperexperience.ui.triplist
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.camperexperience.data.InMemorySettingsRepository
+import com.nuelto.camperexperience.data.InMemoryTripRepository
+import com.nuelto.camperexperience.data.model.Expense
+import com.nuelto.camperexperience.data.model.ExpenseType
+import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.Trip
+import java.time.LocalDate
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import com.nuelto.camperexperience.testutil.TestCamperApp
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = TestCamperApp::class)
+class TripListScreenTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val tripRepository = InMemoryTripRepository(seed = false)
+    private val settingsRepository = InMemorySettingsRepository()
+
+    private val clicks = mutableListOf<String>()
+
+    private fun setContent() {
+        val viewModel = TripListViewModel(tripRepository, settingsRepository)
+        compose.setContent {
+            TripListScreen(
+                onTripClick = { clicks += "trip:$it" },
+                onAddTrip = { clicks += "add" },
+                onOpenMap = { clicks += "map" },
+                onOpenSettings = { clicks += "settings" },
+                viewModel = viewModel,
+            )
+        }
+    }
+
+    @Test
+    fun `empty state prompts for the first trip`() {
+        setContent()
+        compose.onNodeWithText("No trips yet.\nTap + to log your first one.").assertIsDisplayed()
+    }
+
+    @Test
+    fun `trip card shows name dates nights and actual total`() = runBlocking<Unit> {
+        tripRepository.upsertTrip(
+            Trip(id = "t1", name = "Provence", startDate = LocalDate.of(2026, 9, 12), endDate = LocalDate.of(2026, 9, 21)),
+        )
+        tripRepository.upsertStop(Stop(id = "s1", tripId = "t1", nights = 3, campingCostTotal = 90.0))
+        tripRepository.upsertExpense(Expense(id = "e1", tripId = "t1", type = ExpenseType.FUEL, amount = 10.0))
+        setContent()
+        compose.onNodeWithText("Provence").assertIsDisplayed()
+        compose.onNodeWithText("3 nights").assertIsDisplayed()
+        compose.onNodeWithText("CHF100.00").assertIsDisplayed()
+    }
+
+    @Test
+    fun `top bar and fab fire navigation callbacks`() {
+        setContent()
+        compose.onNodeWithContentDescription("All trips map").performClick()
+        compose.onNodeWithContentDescription("Settings").performClick()
+        compose.onNodeWithContentDescription("New trip").performClick()
+        assertEquals(listOf("map", "settings", "add"), clicks)
+    }
+
+    @Test
+    fun `tapping a card opens the trip`() = runBlocking<Unit> {
+        tripRepository.upsertTrip(Trip(id = "t1", name = "Jura", startDate = LocalDate.of(2026, 7, 1)))
+        setContent()
+        compose.onNodeWithText("Jura").performClick()
+        assertEquals(listOf("trip:t1"), clicks)
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/triplist/TripListScreenTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/triplist/TripListScreenTest.kt
@@ -1,6 +1,7 @@
 package com.nuelto.camperexperience.ui.triplist
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -10,6 +11,7 @@ import com.nuelto.camperexperience.data.InMemorySettingsRepository
 import com.nuelto.camperexperience.data.InMemoryTripRepository
 import com.nuelto.camperexperience.data.model.Expense
 import com.nuelto.camperexperience.data.model.ExpenseType
+import com.nuelto.camperexperience.data.model.LatLng
 import com.nuelto.camperexperience.data.model.Stop
 import com.nuelto.camperexperience.data.model.Trip
 import java.time.LocalDate
@@ -63,6 +65,15 @@ class TripListScreenTest {
         compose.onNodeWithText("Provence").assertIsDisplayed()
         compose.onNodeWithText("3 nights").assertIsDisplayed()
         compose.onNodeWithText("CHF100.00").assertIsDisplayed()
+    }
+
+    @Test
+    fun `trips without logged fuel show an approximate total`() = runBlocking<Unit> {
+        tripRepository.upsertTrip(Trip(id = "t1", name = "Jura", startDate = LocalDate.of(2026, 7, 1)))
+        tripRepository.upsertStop(Stop(id = "s1", tripId = "t1", location = LatLng(47.0, 7.0), orderIndex = 0))
+        tripRepository.upsertStop(Stop(id = "s2", tripId = "t1", location = LatLng(47.5, 7.5), orderIndex = 1))
+        setContent()
+        compose.onNode(hasText("≈", substring = true)).assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/java/com/nuelto/camperexperience/ui/triplist/TripListViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/triplist/TripListViewModelTest.kt
@@ -1,0 +1,91 @@
+package com.nuelto.camperexperience.ui.triplist
+
+import app.cash.turbine.test
+import com.nuelto.camperexperience.data.InMemorySettingsRepository
+import com.nuelto.camperexperience.data.InMemoryTripRepository
+import com.nuelto.camperexperience.data.model.Expense
+import com.nuelto.camperexperience.data.model.ExpenseType
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.Trip
+import com.nuelto.camperexperience.data.model.UserSettings
+import com.nuelto.camperexperience.testutil.MainDispatcherRule
+import java.time.LocalDate
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class TripListViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val tripRepository = InMemoryTripRepository(seed = false)
+    private val settingsRepository = InMemorySettingsRepository()
+
+    private fun viewModel() = TripListViewModel(tripRepository, settingsRepository)
+
+    @Test
+    fun `initial state is loading with no trips`() {
+        val state = viewModel().uiState.value
+        assertTrue(state.loading)
+        assertTrue(state.trips.isEmpty())
+    }
+
+    @Test
+    fun `emits trips settings and fuel estimates`() = runTest {
+        tripRepository.upsertTrip(Trip(id = "t1", name = "Jura", startDate = LocalDate.of(2026, 7, 1)))
+        tripRepository.upsertStop(Stop(id = "s1", tripId = "t1", location = LatLng(47.0, 7.0), orderIndex = 0))
+        tripRepository.upsertStop(Stop(id = "s2", tripId = "t1", location = LatLng(47.5, 7.5), orderIndex = 1))
+        settingsRepository.update(UserSettings(currency = "EUR"))
+
+        viewModel().uiState.test {
+            val state = awaitItem()
+            assertFalse(state.loading)
+            assertEquals(listOf("Jura"), state.trips.map { it.name })
+            assertEquals("EUR", state.settings.currency)
+            assertTrue(state.fuelEstimates.getValue("t1") > 0.0)
+        }
+    }
+
+    @Test
+    fun `trips with recorded fuel get no estimate`() = runTest {
+        tripRepository.upsertTrip(Trip(id = "t1", name = "Jura", startDate = LocalDate.of(2026, 7, 1)))
+        tripRepository.upsertStop(Stop(id = "s1", tripId = "t1", location = LatLng(47.0, 7.0), orderIndex = 0))
+        tripRepository.upsertStop(Stop(id = "s2", tripId = "t1", location = LatLng(47.5, 7.5), orderIndex = 1))
+        tripRepository.upsertExpense(Expense(id = "e1", tripId = "t1", type = ExpenseType.FUEL, amount = 50.0))
+
+        viewModel().uiState.test {
+            assertTrue(awaitItem().fuelEstimates.isEmpty())
+        }
+    }
+
+    @Test
+    fun `estimates only use the trips own stops and expenses`() = runTest {
+        // t1 has a route; t2 has fuel logged. Cross-contamination would flip both.
+        tripRepository.upsertTrip(Trip(id = "t1", name = "A", startDate = LocalDate.of(2026, 7, 1)))
+        tripRepository.upsertTrip(Trip(id = "t2", name = "B", startDate = LocalDate.of(2026, 8, 1)))
+        tripRepository.upsertStop(Stop(id = "s1", tripId = "t1", location = LatLng(47.0, 7.0), orderIndex = 0))
+        tripRepository.upsertStop(Stop(id = "s2", tripId = "t1", location = LatLng(47.5, 7.5), orderIndex = 1))
+        tripRepository.upsertStop(Stop(id = "s3", tripId = "t2", location = LatLng(46.0, 6.0), orderIndex = 0))
+        tripRepository.upsertStop(Stop(id = "s4", tripId = "t2", location = LatLng(46.5, 6.5), orderIndex = 1))
+        tripRepository.upsertExpense(Expense(id = "e1", tripId = "t2", type = ExpenseType.FUEL, amount = 50.0))
+
+        viewModel().uiState.test {
+            assertEquals(setOf("t1"), awaitItem().fuelEstimates.keys)
+        }
+    }
+
+    @Test
+    fun `state updates when a trip is added`() = runTest {
+        val vm = viewModel()
+        vm.uiState.test {
+            assertTrue(awaitItem().trips.isEmpty())
+            tripRepository.upsertTrip(Trip(id = "t1", name = "New", startDate = LocalDate.of(2026, 7, 1)))
+            assertEquals(listOf("New"), awaitItem().trips.map { it.name })
+        }
+    }
+}

--- a/app/src/test/resources/robolectric.properties
+++ b/app/src/test/resources/robolectric.properties
@@ -1,0 +1,3 @@
+sdk=35
+graphicsMode=NATIVE
+qualifiers=w411dp-h891dp-420dpi

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,6 @@ junit = "4.13.2"
 turbine = "1.1.0"
 robolectric = "4.15.1"
 androidxTestExtJunit = "1.3.0"
-kover = "0.9.1"
 pitest = "1.19.1"
 
 [libraries]
@@ -65,4 +64,3 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,10 @@ playServicesLocation = "21.4.0"
 maplibreCompose = "0.15.0"
 junit = "4.13.2"
 turbine = "1.1.0"
+robolectric = "4.15.1"
+androidxTestExtJunit = "1.3.0"
+kover = "0.9.1"
+pitest = "1.19.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -49,6 +53,11 @@ maplibre-compose-runtime = { group = "org.maplibre.compose", name = "maplibre-co
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
+androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestExtJunit" }
+compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+pitest-command-line = { group = "org.pitest", name = "pitest-command-line", version.ref = "pitest" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -56,3 +65,4 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }


### PR DESCRIPTION
Closes #5.

## What's in here

**Test suite (150 tests, all on the JVM — no emulator needed in CI)**
- Domain, in-memory data layer, formatting, and all ViewModels (logic tests; coroutines via turbine/coroutines-test)
- Every screen tested with Robolectric + Compose test APIs: trip list, detail (incl. FAB menu, delete dialog, expense sheet), trip/stop editors, settings, sign-in, date/decimal fields
- End-to-end navigation tests through the real NavHost, including the location-picker round trip
- App wiring: auth gate (`AppRoot`), `AppContainer`, `MainActivity` launch

**Coverage — 100%, enforced** (`:app:coverageVerify`)
- JaCoCo line coverage on everything that can run on the JVM: 1357/1357 lines
- Excluded (documented in `app/build.gradle.kts`): MapLibre map internals, Play-services location, Firestore/Firebase auth — code that needs a real device/backend, verified via the emulator workflow instead

**Mutation testing — 93%, gate at 80%** (`:app:pitest`)
- pitest over the JVM-pure logic (domain, in-memory repos, formatting, plain ViewModels)
- 89/96 mutants killed; the survivors are coroutine-ABI equivalent mutants (suspend `Unit` returns), i.e. not real gaps

**CI on every PR** (`.github/workflows/ci.yml`)
- tests + coverage gate + mutation gate + debug APK build; reports uploaded as artifacts

## Testability refactors (behavior unchanged)
- `AuthRepository` is now an interface (`FirebaseAuthRepository` impl) exposing a Firebase-free `AuthUser`, so the auth gate and sign-in UI are testable with fakes
- `AppContainer` takes injected repos; Firebase wiring moved to `FirebaseBackend.kt`; `CamperApp.createContainer()` is overridable (tests use a deterministic in-memory `TestCamperApp`)
- `LocalMapEnabled` composition local swaps MapLibre for a placeholder under Robolectric
- Removed dead code the tests exposed: `StopEditScreen`'s unusable default viewModel factory, a pointless `.map { it }` in `SettingsViewModel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)