### PR TITLE
Expand AI guidance: test recipes, gate gotchas, and change-recipe skills

### DIFF
--- a/.claude/skills/add-model-field/SKILL.md
+++ b/.claude/skills/add-model-field/SKILL.md
@@ -1,0 +1,38 @@
+---
+description: Add or change a persisted field on Trip/Stop/Expense/UserSettings — model, manual Firestore mapping in both repositories, UI input, seed data, tests. Use whenever a feature needs new stored data.
+---
+
+# Add a model field
+
+There is no schema migration machinery: old Firestore docs simply lack the field, so
+every read must tolerate its absence.
+
+## Checklist
+
+1. **`data/model/Models.kt`** — add the field with a sensible default. That default is
+   also the value old documents deserialize to; choose it so existing data stays
+   correct (nullable if "unset" is meaningful).
+2. **Firestore mapping is manual — two places or the field silently doesn't persist:**
+   - Trip/Stop/Expense: `toMap()` **and** the `DocumentSnapshot.toX()` reader in
+     `FirestoreTripRepository`, null-safe (`getX(...) ?: default`). Types: `LocalDate`
+     → `toEpochDay()` Long; `LatLng` → `GeoPoint`; enums → `name` string with
+     `runCatching { valueOf }` fallback on read.
+   - UserSettings: `update()` map **and** the snapshot reader in
+     `FirestoreSettingsRepository` (defaults come from `UserSettings()`).
+3. **`InMemoryTripRepository`** usually needs no mapping change, but keep behavior in
+   parity with Firestore (ordering, defaults). Extend `seedDemoData()` if the field
+   should show up in local demo mode.
+4. **Totals impact**: if the field affects cost or nights, update
+   `domain/CostCalculator` — both repos' `recomputeTotals` already funnel through it.
+   Remember `Trip.totalCost` stays actuals-only; display-time estimates belong in
+   `FuelEstimator` + the screens' `≈` handling.
+5. **UI**: edit screens live in `ui/tripedit/` / `ui/tripdetail/ExpenseEditSheet` /
+   `ui/settings/`. Numeric input = `DecimalField` + `parseDecimal` (comma or dot);
+   dates = `DateField`; money display = `formatCurrency(amount, settings.currency)`.
+   In ViewModels, keep free-text/decimal fields as `String` in UiState, parse on save.
+6. **Tests**: extend the repo tests (`InMemoryTripRepositoryTest` /
+   `InMemorySettingsRepositoryTest`), the touched ViewModel/screen tests, and
+   `CostCalculatorTest`/`FuelEstimatorTest` if step 4 applied.
+   `./gradlew test :app:coverageVerify :app:pitest` must all pass (Firestore repos are
+   coverage-excluded — their mapping is exercised on-device only, so double-check
+   step 2 by hand or in the emulator).

--- a/.claude/skills/app-review/SKILL.md
+++ b/.claude/skills/app-review/SKILL.md
@@ -13,6 +13,7 @@ Review the current diff (`git diff` / `git diff HEAD`) against these invariants.
 - **Repository parity.** `InMemoryTripRepository` and `FirestoreTripRepository` implement the same interface and must stay behaviorally equivalent (ordering, id generation on blank id, cascade delete of stops/expenses with the trip). A change to one usually needs the mirror change.
 - **Camping cost lives on the Stop** (`campingCostTotal`). The CAMPING expense type is only for extra fees not tied to a stay; `CostCalculator.breakdown` merges both. Don't introduce double-counting.
 - Dates are `LocalDate` in models, epoch-day `Long` in Firestore. Mapping is manual in the Firestore repos — new fields need both `toMap()` and the snapshot reader, with a null-safe default.
+- **No collection-group queries.** Security rules are path-scoped and would reject them; cross-trip reads combine per-trip listeners (see `allStops()`). Flag any `collectionGroup(...)` call.
 
 ## UI conventions
 
@@ -21,6 +22,11 @@ Review the current diff (`git diff` / `git diff HEAD`) against these invariants.
 - New ViewModels follow the companion `Factory = containerViewModelFactory { … }` pattern; dependencies come from `AppContainer` only.
 - New screens/routes: `@Serializable` route in `ui/nav/Routes.kt` + `composable<Route>` in `AppNavHost`. Results back to a previous screen go through the previous back-stack entry's `SavedStateHandle` (see `PICKED_LOCATION_KEY`).
 - Map work stays inside `ui/map/TripMap.kt`; trip colors via `tripColor(trip.id.hashCode())` for cross-screen stability.
+
+## Build-gate blind spots
+
+- New JVM-pure logic (ViewModel without Robolectric tests, domain/data class) should be in the pitest `--targetClasses`/`--targetTests` lists in app/build.gradle.kts; Robolectric-dependent classes must **not** be (minions crash).
+- New device-only code (MapLibre, Play services location, Firebase classes) needs a `coverageExcludes` entry or `coverageVerify` fails; conversely, flag exclusions added for code that *could* be JVM-tested.
 
 ## Auth-mode blind spots
 

--- a/.claude/skills/new-screen/SKILL.md
+++ b/.claude/skills/new-screen/SKILL.md
@@ -1,0 +1,60 @@
+---
+description: Scaffold a new screen end-to-end — route, NavHost entry, ViewModel with container factory, Compose screen, and the tests both gates demand. Use when adding a screen, destination, or navigation flow.
+---
+
+# New screen recipe
+
+Follow existing screens (`ui/settings/` is the simplest full example). Steps:
+
+## 1. Route — `ui/nav/Routes.kt`
+
+`@Serializable` object (no args) or data class (args as constructor params, optional
+args defaulted to null). Nothing else — no route strings anywhere.
+
+## 2. ViewModel — `ui/<feature>/<Name>ViewModel.kt`
+
+- Constructor takes repositories (interfaces from `data/`), never the container.
+- State: private `MutableStateFlow<UiState>` + public `StateFlow`; derived values as
+  `get()` properties on the UiState data class (e.g. `canSave`).
+- Route args come from `SavedStateHandle.toRoute<MyRoute>()`.
+- Companion `Factory = containerViewModelFactory { container -> … }`; use
+  `createSavedStateHandle()` for route args.
+- Repository writes inside `viewModelScope.launch`; navigation side effects via
+  callback parameters (`onSaved: () -> Unit`), never held in state.
+
+## 3. Screen — `ui/<feature>/<Name>Screen.kt`
+
+- Signature: navigation callbacks first, then
+  `viewModel: X = viewModel(factory = X.Factory)` last (tests pass their own).
+- Collect state with `collectAsStateWithLifecycle()`.
+- Money: `formatCurrency(amount, settings.currency)`; dates: `formatDate`/
+  `formatDateRange` (`ui/Format.kt`); decimal/date inputs: `DecimalField`/`DateField`
+  + `parseDecimal` (`ui/components/Fields.kt`).
+
+## 4. Wire up — `ui/nav/AppNavHost.kt`
+
+`composable<MyRoute> { … }` with navigation lambdas calling `navController`. A result
+returned to the previous screen goes through
+`navController.previousBackStackEntry?.savedStateHandle` (see `PICKED_LOCATION_KEY`).
+
+## 5. Tests (both gates are hard failures)
+
+- ViewModel test: plain JUnit, `MainDispatcherRule`, Turbine; in-memory repos with
+  `seed = false`. Route args via
+  `SavedStateHandle(mapOf(...))` — copy an existing ViewModel test's setup.
+- Screen test: `createComposeRule` + `@RunWith(AndroidJUnit4::class)` +
+  `@Config(application = TestCamperApp::class)`; construct the ViewModel yourself and
+  record navigation callbacks into a list. If the screen embeds a map, wrap content in
+  `CompositionLocalProvider(LocalMapEnabled provides false)`.
+- Add a navigation-flow assertion to `AppNavHostTest` if the screen is reachable from
+  an existing one.
+- 100% line coverage: `./gradlew :app:coverageVerify`. Device-only code goes in
+  `coverageExcludes` (app/build.gradle.kts) instead — sparingly.
+- If the ViewModel is JVM-pure (no Robolectric in its tests), add it to the pitest
+  `--targetClasses` and `--targetTests` lists in app/build.gradle.kts and keep
+  `./gradlew :app:pitest` ≥ 80%.
+
+## 6. Verify
+
+`./gradlew test :app:coverageVerify` (+ `:app:pitest` if step 5 touched it). Then the
+**verify-app** skill for a real walk-through if navigation or maps changed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,9 @@ MVVM + repository, hand-rolled DI — no Hilt, no Room. Package root:
   `stops/{stopId}`, `expenses/{expenseId}`. Reads are snapshot-listener `callbackFlow`s;
   writes are fire-and-forget so they queue offline (never `await()` a write — it would
   block until server ack). Models use `LocalDate`, stored as epoch-day Longs; mapping is
-  manual (no Firestore reflection) in `FirestoreTripRepository`.
+  manual (no Firestore reflection) in `FirestoreTripRepository`. Security rules are
+  path-scoped, so collection-group queries are rejected — cross-trip reads
+  (`allStops()`/`allExpenses()`) combine per-trip listeners instead.
 - **Denormalized totals**: `Trip.totalCost`/`Trip.nights` are recomputed client-side by
   each repository after every stop/expense mutation (`recomputeTotals`), reading Firestore
   from `Source.CACHE` (which includes pending writes, so it works offline). Any new
@@ -100,11 +102,25 @@ MVVM + repository, hand-rolled DI — no Hilt, no Room. Package root:
 UI tests run on the JVM: Robolectric + Compose test APIs (`robolectric.properties`
 pins sdk/graphics/screen). `TestCamperApp` forces the in-memory container regardless
 of a local google-services.json; `LocalMapEnabled provides false` swaps MapLibre for
-a placeholder (`ui/map/TripMap.kt`). Fakes live in `testutil/`. The coverage gate is
-100% of non-excluded lines (`coverageExcludes` in app/build.gradle.kts lists the
-device-only code) — new code needs tests or, if genuinely untestable on the JVM, an
-exclusion entry. pitest mutates domain/data/format/plain-JVM ViewModels only
-(Robolectric tests don't survive pitest minions); keep its 80% threshold green.
+a placeholder (`ui/map/TripMap.kt`). Fakes live in `testutil/`.
+
+- **Screen tests**: `createComposeRule` + `@RunWith(AndroidJUnit4::class)` +
+  `@Config(application = TestCamperApp::class)`; construct the ViewModel directly with
+  `InMemoryTripRepository(seed = false)` etc. and pass it into the screen composable.
+- **ViewModel tests**: plain JUnit with `MainDispatcherRule` (testutil) and Turbine
+  for flow assertions. Async races (late geocode result, slow sign-in) use the gated
+  fakes: `FakeAuthRepository.gate`, `FakePlaceNameResolver.gates`.
+- **Coverage gate** is 100% of non-excluded lines — new code needs tests or, if
+  genuinely untestable on the JVM (device/backend-only), an entry in
+  `coverageExcludes` in app/build.gradle.kts.
+- **pitest targets are explicit lists**: a new JVM-pure ViewModel or domain/data class
+  worth mutating must be added to `--targetClasses`/`--targetTests` in
+  app/build.gradle.kts; never add Robolectric-dependent classes (minions crash).
+  Keep the 80% threshold green.
+
+Multi-file change recipes live in `.claude/skills/`: **new-screen** (route + screen +
+ViewModel + tests), **add-model-field** (model + Firestore mapping + UI + tests),
+**app-review** (pre-commit invariant checklist).
 
 ## Verification expectations
 


### PR DESCRIPTION
## What changed

- **CLAUDE.md**: documented the path-scoped-security-rules constraint (no collection-group queries; `allStops()`/`allExpenses()` combine per-trip listeners), concrete test recipes (screen tests via `createComposeRule` + `TestCamperApp`, ViewModel tests via `MainDispatcherRule` + Turbine, gated fakes for async races), and two build-gate gotchas (pitest's explicit target lists, `coverageExcludes` for device-only code).
- **New skill `new-screen`**: end-to-end scaffold recipe for a screen — route, ViewModel + container factory, screen conventions, NavHost wiring, and the tests both gates demand.
- **New skill `add-model-field`**: checklist for adding persisted data — null-safe defaults for old Firestore docs, both manual mapping sites, repo parity, seed data, totals implications.
- **`app-review` skill**: added the collection-group-query check and a "Build-gate blind spots" section.

## Why

So AI sessions have recipe-level context for the common multi-file changes (new screens, new persisted fields) and the non-obvious gate maintenance, without re-reading the codebase each time. All content was verified against the current source — the existing docs were accurate; this fills gaps only.

## Reviewer notes

Docs/skills only, no code changes. CI should be a no-op pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)