### PR TITLE
Add git-derived semver (shown in Settings) and per-merge CI screenshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history: the version's patch number is the commit count
 
       - uses: actions/setup-java@v4
         with:
@@ -26,6 +28,19 @@ jobs:
 
       - name: Build debug APK
         run: ./gradlew :app:assembleDebug
+
+      - name: Compute version
+        if: github.event_name == 'push'
+        id: version
+        run: echo "v=$(grep '^appVersionBase=' gradle.properties | cut -d= -f2).$(git rev-list --count HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload screenshots (written by ScreenshotsTest)
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots-v${{ steps.version.outputs.v }}
+          path: app/build/screenshots
+          retention-days: 90
 
       - name: Upload reports
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,13 @@ adding new ones.
 ```
 
 CI (`.github/workflows/ci.yml`) runs tests + both gates + assembleDebug on every PR.
+On pushes to main it also uploads `app/build/screenshots/` (main screens light+dark,
+written by `ScreenshotsTest` during the normal test run) as a versioned artifact.
+
+**Versioning**: `versionName` = `appVersionBase` (gradle.properties, major.minor) +
+git commit count as patch; shown at the bottom of Settings. Bump `appVersionBase`
+for milestones; the patch advances by itself. CI checks out full history so the
+count is right.
 
 Emulator workflow (AVD `Pixel_9a` exists locally; needs Play services image for
 sign-in/fused location/reverse geocoding — `location/PlaceNameResolver.kt` uses the

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,6 +27,14 @@ val webClientId: String = run {
         ?: ""
 }
 
+// Semver: appVersionBase (gradle.properties) is major.minor, patch = git commit count.
+// Shown in Settings via BuildConfig.VERSION_NAME. Falls back to patch 0 without git
+// (e.g. a shallow clone counts fewer commits; CI checks out full history).
+val commitCount: Int = providers.exec {
+    commandLine("git", "rev-list", "--count", "HEAD")
+    isIgnoreExitValue = true
+}.standardOutput.asText.map { it.trim().toIntOrNull() ?: 0 }.get()
+
 android {
     namespace = "com.nuelto.camperexperience"
     compileSdk = 37
@@ -35,8 +43,8 @@ android {
         applicationId = "com.nuelto.camperexperience"
         minSdk = 28
         targetSdk = 36
-        versionCode = 1
-        versionName = "0.1.0"
+        versionCode = maxOf(commitCount, 1)
+        versionName = "${providers.gradleProperty("appVersionBase").getOrElse("0.1")}.$commitCount"
         vectorDrawables { useSupportLibrary = true }
     }
 

--- a/app/src/main/java/com/nuelto/camperexperience/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/settings/SettingsScreen.kt
@@ -34,6 +34,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.nuelto.camperexperience.BuildConfig
 import com.nuelto.camperexperience.containerViewModelFactory
 import com.nuelto.camperexperience.data.AuthRepository
 import com.nuelto.camperexperience.data.SettingsRepository
@@ -140,6 +141,13 @@ fun SettingsScreen(
                     Text("Sign out")
                 }
             }
+
+            HorizontalDivider()
+            Text(
+                "Version ${BuildConfig.VERSION_NAME}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/app/src/test/java/com/nuelto/camperexperience/ScreenshotsTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ScreenshotsTest.kt
@@ -1,0 +1,94 @@
+package com.nuelto.camperexperience
+
+import android.graphics.Bitmap
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.camperexperience.data.InMemorySettingsRepository
+import com.nuelto.camperexperience.data.InMemoryTripRepository
+import com.nuelto.camperexperience.testutil.TestCamperApp
+import com.nuelto.camperexperience.ui.map.LocalMapEnabled
+import com.nuelto.camperexperience.ui.settings.SettingsScreen
+import com.nuelto.camperexperience.ui.settings.SettingsViewModel
+import com.nuelto.camperexperience.ui.theme.CamperTheme
+import com.nuelto.camperexperience.ui.tripdetail.TripDetailScreen
+import com.nuelto.camperexperience.ui.tripdetail.TripDetailViewModel
+import com.nuelto.camperexperience.ui.triplist.TripListScreen
+import com.nuelto.camperexperience.ui.triplist.TripListViewModel
+import java.io.File
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Not a regression test: renders the main screens with the demo seed data and writes
+ * PNGs (light + dark) to app/build/screenshots/. CI uploads them as a versioned
+ * artifact on every push to main.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(application = TestCamperApp::class)
+class ScreenshotsTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val tripRepository = InMemoryTripRepository() // seeded demo trips
+    private val settingsRepository = InMemorySettingsRepository()
+
+    private fun shoot(name: String, content: @Composable () -> Unit) {
+        val dark = mutableStateOf(false)
+        compose.setContent {
+            val isDark by dark
+            CompositionLocalProvider(LocalMapEnabled provides false) {
+                CamperTheme(darkTheme = isDark) { content() }
+            }
+        }
+        save("$name-light")
+        dark.value = true
+        save("$name-dark")
+    }
+
+    private fun save(fileName: String) {
+        val bitmap = compose.onRoot().captureToImage().asAndroidBitmap()
+        val file = File("build/screenshots/$fileName.png")
+        file.parentFile?.mkdirs()
+        file.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+    }
+
+    @Test
+    fun tripList() = shoot("trip-list") {
+        TripListScreen(
+            onTripClick = {}, onAddTrip = {}, onOpenMap = {}, onOpenSettings = {},
+            viewModel = TripListViewModel(tripRepository, settingsRepository),
+        )
+    }
+
+    @Test
+    fun tripDetail() = shoot("trip-detail") {
+        TripDetailScreen(
+            onBack = {}, onEditTrip = {}, onAddStop = {}, onEditStop = { _, _ -> },
+            onOpenTripMap = {},
+            viewModel = TripDetailViewModel(
+                SavedStateHandle(mapOf("tripId" to "demo-provence")),
+                tripRepository,
+                settingsRepository,
+            ),
+        )
+    }
+
+    @Test
+    fun settings() = shoot("settings") {
+        SettingsScreen(
+            onBack = {},
+            viewModel = SettingsViewModel(settingsRepository, authRepository = null),
+        )
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/settings/SettingsScreenTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.camperexperience.BuildConfig
 import com.nuelto.camperexperience.data.InMemorySettingsRepository
 import com.nuelto.camperexperience.testutil.FakeAuthRepository
 import com.nuelto.camperexperience.testutil.TestCamperApp
@@ -85,6 +86,12 @@ class SettingsScreenTest {
         setContent(auth)
         compose.onNodeWithText("Sign out").performClick()
         assertEquals(1, auth.signOutCalls)
+    }
+
+    @Test
+    fun `shows the app version`() {
+        setContent()
+        compose.onNodeWithText("Version ${BuildConfig.VERSION_NAME}").assertIsDisplayed()
     }
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,6 @@ android.builtInKotlin=false
 android.newDsl=false
 android.nonTransitiveRClass=true
 kotlin.code.style=official
+# Semver major.minor; the patch is the git commit count (see app/build.gradle.kts).
+appVersionBase=0.1
 webClientId=380057794405-mojj4v4jaadd5a5f0gnejmbm0f943jdi.apps.googleusercontent.com


### PR DESCRIPTION
## What

- **Semver versioning**: `versionName` = `appVersionBase` (gradle.properties, currently `0.1`) + git commit count as patch, `versionCode` = commit count. Currently resolves to 0.1.24. Shown at the bottom of the Settings screen via `BuildConfig.VERSION_NAME`, with a screen test asserting it.
- **Screenshots on every push to main**: new `ScreenshotsTest` renders the trip list, trip detail (seeded Provence demo trip), and settings screens in light + dark theme through Robolectric native graphics — no emulator — and writes six PNGs to `app/build/screenshots/`. It runs as part of the normal test suite; CI just uploads the folder as a `screenshots-v0.1.N` artifact (90-day retention) on pushes to main.

## Why

Per-merge visual record of the main screens plus a visible, automatically advancing version — bump `appVersionBase` manually for milestones, the patch tracks commits by itself.

## Notes for review

- CI now checks out with `fetch-depth: 0` so the commit count (and thus the version) is correct in CI.
- The map area in the trip-detail screenshot is blank: tests swap MapLibre for the placeholder (`LocalMapEnabled = false`) since GL can't render on the JVM.
- Verified locally: full test suite + `coverageVerify` green; screenshots eyeballed (Settings shows "Version 0.1.24").

🤖 Generated with [Claude Code](https://claude.com/claude-code)