### PR TITLE
Follow the road between stops, with driving time and elevation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,8 @@ MVVM + repository, hand-rolled DI — no Hilt, no Room. Package root:
   (`allStops()`/`allExpenses()`) combine per-trip listeners instead.
 - **Trip lifecycle**: `Trip.status` PLANNED → ACTIVE → DONE; one Timeline screen
   (TripDetail) serves all three with status-gated affordances. Stops carry `kind`
-  (CAMPSITE/STELLPLATZ/FREE_CAMP/VISIT — visits are zero-cost route points) and `state`
+  (CAMPSITE/STELLPLATZ/FREE_CAMP/VISIT/HOME — visits and home are zero-cost route points;
+  everything nights- or price-related keys off `StopKind.isStay`, never off naming VISIT) and `state`
   (PLANNED/DONE/SKIPPED — skipped stops stay in the record but count toward nothing).
   Legacy Firestore docs derive status from endDate (`legacyTripStatus`) — never PLANNED.
   Start-tour/plan-again copies go through `domain/TripStarter` (composed over the
@@ -190,6 +191,12 @@ MVVM + repository, hand-rolled DI — no Hilt, no Room. Package root:
   road tax and other expenses. Vignette suggestions come from `domain/CountryGuess`
   (offline bounding boxes, confirm-only) + `domain/VignetteTable` — **refresh the table's
   prices yearly with the `appVersionBase` bump**.
+- **Home** is a `UserSettings` pin (`homeName`/`homeLocation`) picked in Settings through
+  the same injected `LocationSection` the stop editor uses. A new *plan* opens with it as
+  its first stop (`domain/HomeStop`) — a real Stop of kind HOME, not a special case, so
+  the timeline, map, distance and fuel all count it without knowing what home is. It is
+  editable and deletable like any other stop; HOME is hidden from the kind chips so a
+  second one cannot be made by hand.
 - **Navigation** (`ui/nav/`): type-safe kotlinx-serialization routes. The location picker
   returns its result through the **previous** back-stack entry's `SavedStateHandle` under
   `PICKED_LOCATION_KEY` (a `DoubleArray`); `AppNavHost` observes it and feeds

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,21 @@ There is no lint/format tooling configured.
   needs Kotlin ≥ 2.4 metadata while every AGP release bundles built-in Kotlin 2.2.10.
   Both opt-outs die in AGP 10 (expected late 2026): when an AGP with built-in Kotlin ≥ 2.4
   exists, remove the two properties and the `org.jetbrains.kotlin.android` plugin.
+- **Routes follow roads.** `domain/GoogleRoutes` builds the Routes API `computeRoutes`
+  call (pure body + field mask + parse), `location/RouteServices` makes it, and each drive
+  is stored on the arriving stop as `Stop.leg` (`StopLeg`: encoded polyline, distance,
+  duration, ascent/descent). A leg records the two coordinates it was routed between, so
+  `domain/RouteCache` invalidates it by comparison when a stop moves or the order changes
+  — plus the same 30-day clock as Places (SST §19.3), enforced by `domain/RouteRefresher`
+  from TripDetailViewModel. Stay off the Pro SKU: ≤10 intermediates per call
+  (`GoogleRoutes.windows` splits longer trips), `TRAFFIC_UNAWARE`, no waypoint
+  optimisation. Same `mapsApiKey` as the map — Routes API just has to be enabled and in the
+  key's API restrictions. Note Places and Routes are called as plain web services, so an
+  Android *application* restriction would break both unless `X-Android-Package`/
+  `X-Android-Cert` headers are added. Everything degrades to straight lines without a key.
+- **Elevation is not Google**: its Elevation API forbids storing results, so climb comes
+  from Open-Meteo (Copernicus DEM) via `domain/Elevation` — sampled by distance along the
+  polyline, then a hysteresis filter so DEM noise does not read as ascent.
 - **Maps and place search are Google**, wired up when `mapsApiKey` is in local.properties
   (`MapsBackend.kt`, mirroring FirebaseBackend). Without a key the app runs with no map —
   the two switches are independent: Firebase decides the store, the key decides the map.
@@ -141,8 +156,12 @@ MVVM + repository, hand-rolled DI — no Hilt, no Room. Package root:
 - **Cost semantics** (`domain/CostCalculator.kt`): camping cost lives **on the Stop**
   (`campingCostTotal`); the CAMPING expense type is only for extra site fees. Breakdown
   merges both into the CAMPING category. The fuel estimator (`domain/FuelEstimator.kt`)
-  prefills distance as haversine leg-sum × `roadDistanceFactor` from settings; estimator-
-  created expenses carry `isEstimate = true`. Trips with **no** recorded FUEL expense get
+  prefills distance from the road Google routed for each leg, falling back to haversine
+  × `roadDistanceFactor` only where a leg was never routed; estimator-created expenses
+  carry `isEstimate = true`. Climbing is priced on top, by the gravity term of the
+  road-load equation (`FuelEstimator.liftLiters`, ~0.086 l per tonne per 100 m of ascent),
+  with a descent giving back at most the fuel that stretch would have burned anyway —
+  **the constants are unvalidated against a real tankful**. Trips with **no** recorded FUEL expense get
   an automatic fuel estimate (`FuelEstimator.autoTripFuelCost`, same distance formula)
   that is computed at display time, never stored. **`Trip.totalCost` holds recorded
   numbers only** — display-time estimates never get denormalized; PLANNED/ACTIVE trips
@@ -157,9 +176,11 @@ MVVM + repository, hand-rolled DI — no Hilt, no Room. Package root:
   `PICKED_LOCATION_KEY` (a `DoubleArray`); `AppNavHost` observes it and feeds
   `StopEditViewModel.setLocation`. StopEdit's GPS/map-picker buttons are injected by the
   nav layer as the `locationSection` slot composable.
-- **Maps** (`ui/map/TripMap.kt`): one shared composable renders per-trip
-  CircleLayer markers + LineLayer routes from GeoJSON built in code; stop/trip ids ride
-  along as feature properties for click handling. Colors follow the lifecycle: planned
+- **Maps** (`ui/map/TripMap.kt`): one shared composable renders per-trip markers and
+  route polylines; stop/trip ids ride along for click handling. Route geometry is the
+  decoded `StopLeg` polyline where there is one and a straight hop where there is not
+  (`MapOverlay.routes`), and the camera frames marker **and** route vertices so a detour
+  cannot fall off-screen. Colors follow the lifecycle: planned
   routes dashed blue, done grey, active trips segmented grey (done) / green (current
   leg) / dashed blue (ahead); visit stops render hollow, skipped stops leave the route.
   `AllTripsMapScreen` doubles as the single-trip fullscreen map via its nullable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,9 @@ MVVM + repository, hand-rolled DI — no Hilt, no Room. Package root:
   length); nights/arrival changes instead shift downstream dates (`DateCascade.shift`).
   Color language everywhere (lists, timeline, maps):
   **blue = planned, green = active/current, grey = done** (`ui/theme/StatusColors.kt`).
+  In the timeline a stop's icon carries both axes at once: the **shape** is the kind
+  (tent / RV hookup / forest / camera) and the **tint** is that status color. Its height
+  above sea level rides to the right of the name as a small mountain badge.
 - **Denormalized totals**: `Trip.totalCost`/`Trip.nights` are recomputed client-side by
   each repository after every stop/expense mutation (`recomputeTotals`), reading Firestore
   from `Source.CACHE` (which includes pending writes, so it works offline). Any new

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,14 @@ Multi-file change recipes live in `.claude/skills/`: **new-screen** (route + scr
 ViewModel + tests), **add-model-field** (model + Firestore mapping + UI + tests),
 **app-review** (pre-commit invariant checklist).
 
+**Edge-to-edge**: `enableEdgeToEdge()` + targetSdk 36, so the app draws under the system
+bars. Screens get it free by applying the `Scaffold` padding (they all do), but a
+**`bottomBar` slot does not** — Scaffold places it flush with the window, so it needs its
+own `windowInsetsPadding` (inside the Surface, so the background still fills the gesture
+area). Same for `ModalBottomSheet` content: `navigationBarsPadding()` on the scrollable
+column, or the Save button lands under the navigation bar. Robolectric renders no system
+bars, so neither the tests nor `ScreenshotsTest` can catch this — check on a device.
+
 ## Verification expectations
 
 Logic/UI changes: `./gradlew test :app:coverageVerify` (+ `:app:pitest` for domain/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,11 @@ There is no lint/format tooling configured.
   key's API restrictions. Note Places and Routes are called as plain web services, so an
   Android *application* restriction would break both unless `X-Android-Package`/
   `X-Android-Cert` headers are added. Everything degrades to straight lines without a key.
+- **"How far from here"**: on an ACTIVE trip the NowCard replaces the planned leg with a
+  live route from the current GPS fix to the stop you are heading for (`domain/DriveFromHere`
+  + `LiveDrive` rules, `MapProvider.drive`). Never stored — it is true for one fix.
+  `LiveDrive` throttles it: no refetch under 2 km of movement, and nothing shown once you
+  are within 150 m. The permission is asked for on tap, never on opening a trip.
 - **Elevation is not Google**: its Elevation API forbids storing results, so height comes
   from Open-Meteo (Copernicus DEM) via `domain/Elevation`. Two different numbers:
   `Stop.elevation` is **how high the stop is**, one point, stable, and the only one shown

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,9 +64,16 @@ There is no lint/format tooling configured.
   key's API restrictions. Note Places and Routes are called as plain web services, so an
   Android *application* restriction would break both unless `X-Android-Package`/
   `X-Android-Cert` headers are added. Everything degrades to straight lines without a key.
-- **Elevation is not Google**: its Elevation API forbids storing results, so climb comes
-  from Open-Meteo (Copernicus DEM) via `domain/Elevation` — sampled by distance along the
-  polyline, then a hysteresis filter so DEM noise does not read as ascent.
+- **Elevation is not Google**: its Elevation API forbids storing results, so height comes
+  from Open-Meteo (Copernicus DEM) via `domain/Elevation`. Two different numbers:
+  `Stop.elevation` is **how high the stop is**, one point, stable, and the only one shown
+  (beside the name, the way a village sign gives it); per-leg ascent/descent is a costing
+  input for the fuel estimate and is deliberately **never displayed** — next to a place
+  name it reads as that place's altitude. Cumulative ascent does not converge (sample a
+  215 km route 16× finer and a 10 m threshold grows it 47%) and the DEM reports the
+  mountain over a tunnel, so `profile` first clamps each step to `MAX_ROAD_GRADE` and then
+  applies `MIN_RISE_M` hysteresis — 6% across the same range. Treat it as an order of
+  magnitude, never a measurement.
 - **Maps and place search are Google**, wired up when `mapsApiKey` is in local.properties
   (`MapsBackend.kt`, mirroring FirebaseBackend). Without a key the app runs with no map —
   the two switches are independent: Firebase decides the store, the key decides the map.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,11 @@ There is no lint/format tooling configured.
   live route from the current GPS fix to the stop you are heading for (`domain/DriveFromHere`
   + `LiveDrive` rules, `MapProvider.drive`). Never stored — it is true for one fix.
   `LiveDrive` throttles it: no refetch under 2 km of movement, and nothing shown once you
-  are within 150 m. The permission is asked for on tap, never on opening a trip.
+  are within 150 m. The line also carries the arrival time (`formatArrival`, rounded to the
+  minute like `formatDuration` so the two agree), read at composition — no ticker, because
+  an endless `LaunchedEffect` would leave the Compose test clock busy forever. Checking in
+  clears it in the combine: you are there, so distance stops being a question. The
+  permission is asked for on tap, never on opening a trip.
 - **Elevation is not Google**: its Elevation API forbids storing results, so height comes
   from Open-Meteo (Copernicus DEM) via `domain/Elevation`. Two different numbers:
   `Stop.elevation` is **how high the stop is**, one point, stable, and the only one shown

--- a/GOOGLE_MAPS_SETUP.md
+++ b/GOOGLE_MAPS_SETUP.md
@@ -48,11 +48,15 @@ between stops, and distance to straight line × the road factor in Settings.
 
 ## Elevation is not Google
 
-The climb figure that feeds the fuel estimate comes from Open-Meteo (Copernicus DEM
-GLO-90), not Google's Elevation API. Google's policies forbid caching or storing elevation
-results at all, and a per-leg climb that has to be re-fetched to draw a list is no use.
-Open-Meteo needs no key; the Copernicus licence asks for attribution, which is the second
-half of the line at the bottom of Settings.
+Heights come from Open-Meteo (Copernicus DEM GLO-90), not Google's Elevation API, whose
+policies forbid caching or storing results at all — and a height that has to be re-fetched
+to draw a list is no use. Open-Meteo needs no key; the Copernicus licence asks for
+attribution, which is the second half of the line at the bottom of Settings.
+
+A DEM gives ground level, which is the road only where the road is on the ground. Through
+a tunnel it returns the mountain above, so the per-leg climb clamps every step to a grade
+a road could actually hold before summing it. The stop's own height needs none of that —
+one point, no accumulation — which is why it is the number worth showing.
 
 A new key can take a few minutes to activate. A grey map is almost always a key problem:
 

--- a/GOOGLE_MAPS_SETUP.md
+++ b/GOOGLE_MAPS_SETUP.md
@@ -8,19 +8,51 @@ The app needs a Google Maps Platform key. Without one it still builds, installs 
 1. https://console.cloud.google.com → new project (or reuse the Firebase one).
 2. **Billing must be enabled**, even inside the free tier. The Android Maps SDK has no
    per-load charge, but Google requires a card on file.
-3. APIs & Services → Library → enable **Maps SDK for Android** and **Places API (New)**
-   (the one called "Places API (New)", not the legacy "Places API").
+3. APIs & Services → Library → enable **Maps SDK for Android**, **Places API (New)**
+   (the one called "Places API (New)", not the legacy "Places API") and **Routes API**.
 4. APIs & Services → Credentials → Create credentials → API key. Then restrict it:
    - *Application restrictions* → Android apps → add package `com.nuelto.camperexperience`
      with your debug SHA-1 (and the release one when you have it):
      ```bash
      ./gradlew :app:signingReport
      ```
-   - *API restrictions* → Restrict key → Maps SDK for Android + Places API (New).
+   - *API restrictions* → Restrict key → Maps SDK for Android + Places API (New) +
+     Routes API.
 5. Put it in `local.properties` (gitignored, same file as `webClientId`):
    ```properties
    mapsApiKey=AIza...
    ```
+
+## Application restrictions and the web-service calls
+
+One key covers all three APIs — verified against a live `computeRoutes` call. Enabling
+Routes API and listing it under *API restrictions* is the whole requirement.
+
+The catch is the **application** restriction in step 4. Maps SDK for Android is an SDK and
+proves its identity by itself, but Places API (New) and Routes API are called here as
+plain web services over `HttpURLConnection`. Google's rule for those is that an
+Android-restricted key requires `X-Android-Package` and `X-Android-Cert` (SHA-1 as
+undelimited hex) headers on every request — which this app does not send, for either API.
+
+So the key currently works because it carries no Android application restriction. Add one
+and **both** place search and routing stop working, not just routing. If you want that
+restriction, the fix is those two headers in `location/GooglePlacesSearch` and
+`location/RouteServices`, not a second key.
+
+Either way, cap the spend: APIs & Services → Quotas → Routes API, and set a daily ceiling
+you would not mind paying. Compute Routes Essentials gives 10,000 free requests a month
+and this app spends roughly one per trip edit.
+
+**Without the Routes API enabled** the app still runs: routes fall back to straight lines
+between stops, and distance to straight line × the road factor in Settings.
+
+## Elevation is not Google
+
+The climb figure that feeds the fuel estimate comes from Open-Meteo (Copernicus DEM
+GLO-90), not Google's Elevation API. Google's policies forbid caching or storing elevation
+results at all, and a per-leg climb that has to be re-fetched to draw a list is no use.
+Open-Meteo needs no key; the Copernicus licence asks for attribution, which is the second
+half of the line at the bottom of Settings.
 
 A new key can take a few minutes to activate. A grey map is almost always a key problem:
 
@@ -58,6 +90,13 @@ rather than ignored:
 app is next opened online. Trips shorter than a month are unaffected during and just
 after the trip; older trips need one online visit to redraw. That is the trade this
 design accepts — the alternative was not storing Google coordinates at all.
+
+The Routes API sits under the same clock: §19.3 grants it the same 30-day window that
+§14.3 grants Places, and a stored leg is a sequence of coordinates. `domain/RouteCache`
+decides when one is past its days or no longer describes the drive it was fetched for,
+and `domain/RouteRefresher` re-fetches where it can and deletes where it can't. A leg
+that goes is not a loss: the map falls back to a straight line and the estimate to the
+road factor.
 
 §14.2 also forbids showing Places results "in conjunction with a non-Google map" — moot
 now that Google is the only map, but it is why search and map cannot be mixed providers.

--- a/app/src/main/java/com/nuelto/camperexperience/CamperApp.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/CamperApp.kt
@@ -12,6 +12,8 @@ import com.nuelto.camperexperience.data.InMemorySettingsRepository
 import com.nuelto.camperexperience.data.InMemoryTripRepository
 import com.nuelto.camperexperience.data.SettingsRepository
 import com.nuelto.camperexperience.data.TripRepository
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.location.LocationProvider
 import com.nuelto.camperexperience.ui.map.PlaceholderMapProvider
 import com.nuelto.camperexperience.ui.map.MapProvider
 
@@ -27,12 +29,19 @@ class AppContainer(
     // Independent of the Firebase switch: a Firestore install with no Maps key still
     // runs, and a local-only install with a key still gets Google Maps.
     val mapProvider: MapProvider = PlaceholderMapProvider,
+    // One-shot GPS fix. The caller must hold ACCESS_FINE_LOCATION; the screens ask, and
+    // this returns null when they have not.
+    val currentLocation: suspend () -> LatLng? = { null },
 ) {
     val firebaseEnabled: Boolean get() = authRepository != null
 
     companion object {
-        fun inMemory(mapProvider: MapProvider = PlaceholderMapProvider) =
-            AppContainer(null, InMemoryTripRepository(), InMemorySettingsRepository(), mapProvider)
+        fun inMemory(
+            mapProvider: MapProvider = PlaceholderMapProvider,
+            currentLocation: suspend () -> LatLng? = { null },
+        ) = AppContainer(
+            null, InMemoryTripRepository(), InMemorySettingsRepository(), mapProvider, currentLocation,
+        )
     }
 }
 
@@ -49,7 +58,8 @@ open class CamperApp : Application() {
         // Two independent switches: Firebase decides the store, the key decides the map.
         // No key: the app runs, the map is simply blank.
         val map = googleMapProvider(this) ?: PlaceholderMapProvider
-        return firebaseContainer(this, map) ?: AppContainer.inMemory(map)
+        val locate: suspend () -> LatLng? = { LocationProvider(this).currentLocation() }
+        return firebaseContainer(this, map, locate) ?: AppContainer.inMemory(map, locate)
     }
 }
 

--- a/app/src/main/java/com/nuelto/camperexperience/FirebaseBackend.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/FirebaseBackend.kt
@@ -7,13 +7,18 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.FirebaseFirestoreSettings
 import com.google.firebase.firestore.firestoreSettings
 import com.google.firebase.firestore.persistentCacheSettings
+import com.nuelto.camperexperience.data.model.LatLng
 import com.nuelto.camperexperience.ui.map.MapProvider
 import com.nuelto.camperexperience.data.FirebaseAuthRepository
 import com.nuelto.camperexperience.data.FirestoreSettingsRepository
 import com.nuelto.camperexperience.data.FirestoreTripRepository
 
 /** Firestore-backed container, or null when no google-services config is baked into the build. */
-fun firebaseContainer(app: Application, mapProvider: MapProvider): AppContainer? {
+fun firebaseContainer(
+    app: Application,
+    mapProvider: MapProvider,
+    currentLocation: suspend () -> LatLng? = { null },
+): AppContainer? {
     val firebaseApp = FirebaseApp.initializeApp(app) ?: return null
     val db = FirebaseFirestore.getInstance()
     db.firestoreSettings = firestoreSettings {
@@ -29,5 +34,6 @@ fun firebaseContainer(app: Application, mapProvider: MapProvider): AppContainer?
         authRepository = FirebaseAuthRepository(auth, BuildConfig.WEB_CLIENT_ID),
         tripRepository = FirestoreTripRepository(db, auth),
         settingsRepository = FirestoreSettingsRepository(db, auth),
+        currentLocation = currentLocation,
     )
 }

--- a/app/src/main/java/com/nuelto/camperexperience/data/FirestoreSettingsRepository.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/data/FirestoreSettingsRepository.kt
@@ -2,6 +2,8 @@ package com.nuelto.camperexperience.data
 
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.GeoPoint
+import com.nuelto.camperexperience.data.model.LatLng
 import com.nuelto.camperexperience.data.model.UserSettings
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -31,6 +33,9 @@ class FirestoreSettingsRepository(
                             ?: defaults.roadDistanceFactor,
                         vehicleMassKg = snapshot?.getDouble("vehicleMassKg")
                             ?: defaults.vehicleMassKg,
+                        homeName = snapshot?.getString("homeName") ?: defaults.homeName,
+                        homeLocation = snapshot?.getGeoPoint("homeLocation")
+                            ?.let { LatLng(it.latitude, it.longitude) },
                         campsitePerNight = snapshot?.getDouble("campsitePerNight")
                             ?: defaults.campsitePerNight,
                         stellplatzPerNight = snapshot?.getDouble("stellplatzPerNight")
@@ -50,6 +55,8 @@ class FirestoreSettingsRepository(
                 "fuelPricePerLiter" to settings.fuelPricePerLiter,
                 "roadDistanceFactor" to settings.roadDistanceFactor,
                 "vehicleMassKg" to settings.vehicleMassKg,
+                "homeName" to settings.homeName,
+                "homeLocation" to settings.homeLocation?.let { GeoPoint(it.latitude, it.longitude) },
                 "campsitePerNight" to settings.campsitePerNight,
                 "stellplatzPerNight" to settings.stellplatzPerNight,
             ),

--- a/app/src/main/java/com/nuelto/camperexperience/data/FirestoreSettingsRepository.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/data/FirestoreSettingsRepository.kt
@@ -29,6 +29,8 @@ class FirestoreSettingsRepository(
                             ?: defaults.fuelPricePerLiter,
                         roadDistanceFactor = snapshot?.getDouble("roadDistanceFactor")
                             ?: defaults.roadDistanceFactor,
+                        vehicleMassKg = snapshot?.getDouble("vehicleMassKg")
+                            ?: defaults.vehicleMassKg,
                         campsitePerNight = snapshot?.getDouble("campsitePerNight")
                             ?: defaults.campsitePerNight,
                         stellplatzPerNight = snapshot?.getDouble("stellplatzPerNight")
@@ -47,6 +49,7 @@ class FirestoreSettingsRepository(
                 "fuelConsumptionL100km" to settings.fuelConsumptionL100km,
                 "fuelPricePerLiter" to settings.fuelPricePerLiter,
                 "roadDistanceFactor" to settings.roadDistanceFactor,
+                "vehicleMassKg" to settings.vehicleMassKg,
                 "campsitePerNight" to settings.campsitePerNight,
                 "stellplatzPerNight" to settings.stellplatzPerNight,
             ),

--- a/app/src/main/java/com/nuelto/camperexperience/data/FirestoreTripRepository.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/data/FirestoreTripRepository.kt
@@ -11,6 +11,7 @@ import com.nuelto.camperexperience.data.model.Expense
 import com.nuelto.camperexperience.data.model.ExpenseType
 import com.nuelto.camperexperience.data.model.LatLng
 import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.StopElevation
 import com.nuelto.camperexperience.data.model.StopLeg
 import com.nuelto.camperexperience.data.model.StopKind
 import com.nuelto.camperexperience.data.model.StopState
@@ -92,6 +93,9 @@ class FirestoreTripRepository(
         "placeId" to placeId,
         "locationCachedAt" to locationCachedAt?.toEpochDay(),
         "leg" to leg?.toMap(),
+        "elevation" to elevation?.let {
+            mapOf("at" to GeoPoint(it.at.latitude, it.at.longitude), "meters" to it.meters)
+        },
     )
 
     private fun StopLeg.toMap() = mapOf(
@@ -140,6 +144,10 @@ class FirestoreTripRepository(
         placeId = getString("placeId"),
         locationCachedAt = getLong("locationCachedAt")?.let { LocalDate.ofEpochDay(it) },
         leg = (get("leg") as? Map<*, *>)?.toStopLeg(),
+        elevation = (get("elevation") as? Map<*, *>)?.let { stored ->
+            val at = stored["at"] as? GeoPoint ?: return@let null
+            StopElevation(LatLng(at.latitude, at.longitude), (stored["meters"] as? Number)?.toInt() ?: 0)
+        },
     )
 
     private fun Expense.toMap() = mapOf(

--- a/app/src/main/java/com/nuelto/camperexperience/data/FirestoreTripRepository.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/data/FirestoreTripRepository.kt
@@ -11,6 +11,7 @@ import com.nuelto.camperexperience.data.model.Expense
 import com.nuelto.camperexperience.data.model.ExpenseType
 import com.nuelto.camperexperience.data.model.LatLng
 import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.StopLeg
 import com.nuelto.camperexperience.data.model.StopKind
 import com.nuelto.camperexperience.data.model.StopState
 import com.nuelto.camperexperience.data.model.Trip
@@ -90,7 +91,36 @@ class FirestoreTripRepository(
         "costKnown" to costKnown,
         "placeId" to placeId,
         "locationCachedAt" to locationCachedAt?.toEpochDay(),
+        "leg" to leg?.toMap(),
     )
+
+    private fun StopLeg.toMap() = mapOf(
+        "from" to GeoPoint(from.latitude, from.longitude),
+        "to" to GeoPoint(to.latitude, to.longitude),
+        "polyline" to polyline,
+        "distanceMeters" to distanceMeters,
+        "durationSeconds" to durationSeconds,
+        "ascentMeters" to ascentMeters,
+        "descentMeters" to descentMeters,
+        "fetchedAt" to fetchedAt.toEpochDay(),
+    )
+
+    /** No endpoints, no leg: without them nothing can tell whether it still applies. */
+    private fun Map<*, *>.toStopLeg(): StopLeg? {
+        val from = this["from"] as? GeoPoint ?: return null
+        val to = this["to"] as? GeoPoint ?: return null
+        return StopLeg(
+            from = LatLng(from.latitude, from.longitude),
+            to = LatLng(to.latitude, to.longitude),
+            polyline = this["polyline"] as? String ?: "",
+            distanceMeters = (this["distanceMeters"] as? Number)?.toInt() ?: 0,
+            durationSeconds = (this["durationSeconds"] as? Number)?.toInt() ?: 0,
+            ascentMeters = (this["ascentMeters"] as? Number)?.toInt(),
+            descentMeters = (this["descentMeters"] as? Number)?.toInt(),
+            fetchedAt = (this["fetchedAt"] as? Number)
+                ?.let { LocalDate.ofEpochDay(it.toLong()) } ?: LocalDate.now(),
+        )
+    }
 
     private fun DocumentSnapshot.toStop(tripId: String): Stop = Stop(
         id = id,
@@ -109,6 +139,7 @@ class FirestoreTripRepository(
         costKnown = getBoolean("costKnown") ?: true,
         placeId = getString("placeId"),
         locationCachedAt = getLong("locationCachedAt")?.let { LocalDate.ofEpochDay(it) },
+        leg = (get("leg") as? Map<*, *>)?.toStopLeg(),
     )
 
     private fun Expense.toMap() = mapOf(

--- a/app/src/main/java/com/nuelto/camperexperience/data/InMemoryTripRepository.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/data/InMemoryTripRepository.kt
@@ -4,6 +4,7 @@ import com.nuelto.camperexperience.data.model.Expense
 import com.nuelto.camperexperience.data.model.ExpenseType
 import com.nuelto.camperexperience.data.model.LatLng
 import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.StopElevation
 import com.nuelto.camperexperience.data.model.StopKind
 import com.nuelto.camperexperience.data.model.StopState
 import com.nuelto.camperexperience.data.model.Trip
@@ -145,66 +146,79 @@ class InMemoryTripRepository(seed: Boolean = true) : TripRepository {
                 id = "demo-p1", tripId = provence.id, name = "Camping de la Durance",
                 location = LatLng(44.0966, 6.2358), arrivalDate = LocalDate.of(2025, 9, 12),
                 nights = 3, campingCostTotal = 84.0, orderIndex = 0,
+                elevation = StopElevation(LatLng(44.0966, 6.2358), 449),
             ),
             Stop(
                 id = "demo-p2", tripId = provence.id, name = "Gorges du Verdon",
                 location = LatLng(43.7497, 6.3286), arrivalDate = LocalDate.of(2025, 9, 15),
                 nights = 4, campingCostTotal = 128.0, orderIndex = 1,
+                elevation = StopElevation(LatLng(43.7497, 6.3286), 782),
             ),
             Stop(
                 id = "demo-p3", tripId = provence.id, name = "Aire de Cassis",
                 location = LatLng(43.2140, 5.5396), arrivalDate = LocalDate.of(2025, 9, 19),
                 nights = 2, campingCostTotal = 30.0, orderIndex = 2,
+                elevation = StopElevation(LatLng(43.214, 5.5396), 17),
             ),
             Stop(
                 id = "demo-b1", tripId = blackForest.id, name = "Camping Kirnbergsee",
                 location = LatLng(47.9203, 8.3752), arrivalDate = LocalDate.of(2026, 5, 14),
                 nights = 2, campingCostTotal = 56.0, orderIndex = 0,
+                elevation = StopElevation(LatLng(47.9203, 8.3752), 780),
             ),
             Stop(
                 id = "demo-b2", tripId = blackForest.id, name = "Titisee",
                 location = LatLng(47.8990, 8.1580), arrivalDate = LocalDate.of(2026, 5, 16),
                 nights = 2, campingCostTotal = 64.0, orderIndex = 1,
+                elevation = StopElevation(LatLng(47.899, 8.158), 858),
             ),
             Stop(
                 id = "demo-j1", tripId = jura.id, name = "Camping Lido Luzern",
                 location = LatLng(47.0410, 8.3370), arrivalDate = LocalDate.of(2027, 6, 10),
                 nights = 2, orderIndex = 0, costKnown = false,
+                elevation = StopElevation(LatLng(47.041, 8.337), 434),
             ),
             Stop(
                 id = "demo-j2", tripId = jura.id, name = "Aareschlucht",
                 location = LatLng(46.7226, 8.2231), arrivalDate = LocalDate.of(2027, 6, 12),
                 nights = 0, orderIndex = 1, kind = StopKind.VISIT,
+                elevation = StopElevation(LatLng(46.7226, 8.2231), 600),
             ),
             Stop(
                 id = "demo-j3", tripId = jura.id, name = "Stellplatz Airolo",
                 location = LatLng(46.5285, 8.6120), arrivalDate = LocalDate.of(2027, 6, 12),
                 nights = 1, orderIndex = 2, kind = StopKind.STELLPLATZ, costKnown = false,
+                elevation = StopElevation(LatLng(46.5285, 8.612), 1175),
             ),
             Stop(
                 id = "demo-j4", tripId = jura.id, name = "Camping Delta Locarno",
                 location = LatLng(46.1591, 8.7853), arrivalDate = LocalDate.of(2027, 6, 13),
                 nights = 3, campingCostTotal = 186.0, orderIndex = 3,
+                elevation = StopElevation(LatLng(46.1591, 8.7853), 199),
             ),
             Stop(
                 id = "demo-v1", tripId = vierwald.id, name = "Camping Seefeld Sarnen",
                 location = LatLng(46.8709, 8.2492), arrivalDate = LocalDate.now().minusDays(1),
                 nights = 2, campingCostTotal = 84.0, orderIndex = 0, state = StopState.DONE,
+                elevation = StopElevation(LatLng(46.8709, 8.2492), 473),
             ),
             Stop(
                 id = "demo-v2", tripId = vierwald.id, name = "Rütli",
                 location = LatLng(46.9690, 8.5990), arrivalDate = LocalDate.now().plusDays(1),
                 nights = 0, orderIndex = 1, kind = StopKind.VISIT,
+                elevation = StopElevation(LatLng(46.969, 8.599), 451),
             ),
             Stop(
                 id = "demo-v3", tripId = vierwald.id, name = "Stellplatz Brunnen",
                 location = LatLng(46.9930, 8.6060), arrivalDate = LocalDate.now().plusDays(1),
                 nights = 1, orderIndex = 2, kind = StopKind.STELLPLATZ, costKnown = false,
+                elevation = StopElevation(LatLng(46.993, 8.606), 439),
             ),
             Stop(
                 id = "demo-v4", tripId = vierwald.id, name = "Camping Buochs",
                 location = LatLng(46.9740, 8.4230), arrivalDate = LocalDate.now().plusDays(2),
                 nights = 2, orderIndex = 3, costKnown = false,
+                elevation = StopElevation(LatLng(46.974, 8.423), 435),
             ),
         )
         expensesFlow.value = listOf(

--- a/app/src/main/java/com/nuelto/camperexperience/data/model/Models.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/data/model/Models.kt
@@ -39,6 +39,13 @@ enum class StopKind { CAMPSITE, STELLPLATZ, FREE_CAMP, VISIT }
 enum class StopState { PLANNED, DONE, SKIPPED }
 
 /**
+ * How high the stop sits above sea level. [at] is the coordinate it was measured for, so
+ * moving the pin invalidates it by comparison. Copernicus is open data, so unlike a Places
+ * coordinate this never expires.
+ */
+data class StopElevation(val at: LatLng = LatLng(0.0, 0.0), val meters: Int = 0)
+
+/**
  * The drive from the previous stop, as Google routed it. [from]/[to] are the stop
  * coordinates the route was computed between, so a reorder or a moved pin invalidates
  * the leg by simple comparison rather than by hoping something remembered to clear it.
@@ -85,6 +92,7 @@ data class Stop(
     // The drive that arrives here, from the stop before it. Null on the first stop of a
     // trip, and until the route has been fetched.
     val leg: StopLeg? = null,
+    val elevation: StopElevation? = null,
 )
 
 enum class ExpenseType {

--- a/app/src/main/java/com/nuelto/camperexperience/data/model/Models.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/data/model/Models.kt
@@ -38,6 +38,29 @@ enum class StopKind { CAMPSITE, STELLPLATZ, FREE_CAMP, VISIT }
  *  are excluded from route distance, nights, and cost math. */
 enum class StopState { PLANNED, DONE, SKIPPED }
 
+/**
+ * The drive from the previous stop, as Google routed it. [from]/[to] are the stop
+ * coordinates the route was computed between, so a reorder or a moved pin invalidates
+ * the leg by simple comparison rather than by hoping something remembered to clear it.
+ *
+ * Google's terms let a routed coordinate be kept for 30 days (SST §19.3, the same window
+ * as the Places rule), so [fetchedAt] is not optional — see domain/RouteCache.
+ */
+data class StopLeg(
+    val from: LatLng = LatLng(0.0, 0.0),
+    val to: LatLng = LatLng(0.0, 0.0),
+    // Encoded polyline, decoded for drawing by domain/Polyline.
+    val polyline: String = "",
+    val distanceMeters: Int = 0,
+    val durationSeconds: Int = 0,
+    // Cumulative climb along the leg, from an open DEM — null until it is fetched, and
+    // null forever if the elevation source is unreachable. Google is not the source:
+    // its Elevation API forbids storing results at all.
+    val ascentMeters: Int? = null,
+    val descentMeters: Int? = null,
+    val fetchedAt: LocalDate = LocalDate.now(),
+)
+
 data class Stop(
     val id: String = "",
     val tripId: String = "",
@@ -59,6 +82,9 @@ data class Stop(
     // When [location] was fetched from Google Places. Null means the coordinate came
     // from somewhere without a retention limit and never expires. See domain/PlaceCache.
     val locationCachedAt: LocalDate? = null,
+    // The drive that arrives here, from the stop before it. Null on the first stop of a
+    // trip, and until the route has been fetched.
+    val leg: StopLeg? = null,
 )
 
 enum class ExpenseType {
@@ -83,8 +109,12 @@ data class UserSettings(
     val currency: String = "CHF",
     val fuelConsumptionL100km: Double = 10.0,
     val fuelPricePerLiter: Double = 1.80,
-    // Multiplier on straight-line (haversine) distance to approximate road distance.
+    // Fallback multiplier on straight-line (haversine) distance, used only for legs with
+    // no routed distance — offline, no API key, or a fetch that failed.
     val roadDistanceFactor: Double = 1.25,
+    // Laden weight, for the climb term of the fuel estimate. 3.5 t is the usual limit a
+    // camper is built to sit under.
+    val vehicleMassKg: Double = 3500.0,
     // Default per-night camping estimates, used while a stop's price isn't known yet.
     val campsitePerNight: Double = 45.0,
     val stellplatzPerNight: Double = 15.0,

--- a/app/src/main/java/com/nuelto/camperexperience/data/model/Models.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/data/model/Models.kt
@@ -31,8 +31,18 @@ data class Trip(
     val plannedNights: Int? = null,
 )
 
-/** Site type for pricing defaults; VISIT = drive-through waypoint (no nights, no cost). */
-enum class StopKind { CAMPSITE, STELLPLATZ, FREE_CAMP, VISIT }
+/**
+ * Site type for pricing defaults. VISIT is a drive-through waypoint and HOME is where the
+ * trip starts from — neither is a night, and neither costs anything.
+ */
+enum class StopKind { CAMPSITE, STELLPLATZ, FREE_CAMP, VISIT, HOME }
+
+/**
+ * True for the kinds you sleep and pay at. Everything nights- or price-related keys off
+ * this rather than naming VISIT, so HOME could be added without hunting down the checks.
+ */
+val StopKind.isStay: Boolean
+    get() = this == StopKind.CAMPSITE || this == StopKind.STELLPLATZ || this == StopKind.FREE_CAMP
 
 /** The stop's own position in the timeline. SKIPPED stops stay in the record but
  *  are excluded from route distance, nights, and cost math. */
@@ -123,6 +133,10 @@ data class UserSettings(
     // Laden weight, for the climb term of the fuel estimate. 3.5 t is the usual limit a
     // camper is built to sit under.
     val vehicleMassKg: Double = 3500.0,
+    // Where trips start from. A new plan opens with this as its first stop; null until it
+    // has been set, and then plans simply start at whatever you add first.
+    val homeName: String = "",
+    val homeLocation: LatLng? = null,
     // Default per-night camping estimates, used while a stop's price isn't known yet.
     val campsitePerNight: Double = 45.0,
     val stellplatzPerNight: Double = 15.0,

--- a/app/src/main/java/com/nuelto/camperexperience/domain/DriveFromHere.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/domain/DriveFromHere.kt
@@ -1,0 +1,44 @@
+package com.nuelto.camperexperience.domain
+
+import com.nuelto.camperexperience.data.model.LatLng
+
+/**
+ * How far the stop you are heading for is from where you are standing, as Google routes it
+ * for one GPS fix.
+ *
+ * Never stored, and deliberately not a [com.nuelto.camperexperience.data.model.StopLeg]:
+ * that is the planned drive between two stops and stays true until the plan changes, while
+ * this is true only until you move. It carries [from] so a later fix can tell whether it
+ * still describes the situation.
+ */
+data class DriveFromHere(
+    val from: LatLng,
+    val to: LatLng,
+    val distanceMeters: Int,
+    val durationSeconds: Int,
+)
+
+/** When to ask Google again for the drive from here, and when not to bother at all. */
+object LiveDrive {
+
+    /**
+     * Refetch once the fix has moved this far. Below it the answer barely changes, and
+     * every fetch is a billed route — a phone sitting on the dashboard must not spend the
+     * monthly allowance on its own GPS jitter.
+     */
+    const val REFRESH_AFTER_METERS = 2_000.0
+
+    /** Inside this you are there, and "0 km · 0 min" is noise rather than information. */
+    const val ARRIVED_WITHIN_METERS = 150.0
+
+    fun arrived(from: LatLng, to: LatLng): Boolean =
+        GeoUtils.haversineKm(from, to) * 1000 < ARRIVED_WITHIN_METERS
+
+    /** True when nothing usable is held for this fix and this destination. */
+    fun needsFetch(current: DriveFromHere?, from: LatLng, to: LatLng): Boolean = when {
+        current == null -> true
+        // A different destination is a different question, however little you moved.
+        current.to != to -> true
+        else -> GeoUtils.haversineKm(current.from, from) * 1000 >= REFRESH_AFTER_METERS
+    }
+}

--- a/app/src/main/java/com/nuelto/camperexperience/domain/Elevation.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/domain/Elevation.kt
@@ -1,0 +1,101 @@
+package com.nuelto.camperexperience.domain
+
+import com.nuelto.camperexperience.data.model.LatLng
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/** Cumulative climb and drop along a leg, in metres. */
+data class Climb(val ascentMeters: Double, val descentMeters: Double)
+
+/**
+ * Height along a route, from Open-Meteo's elevation service (Copernicus DEM GLO-90).
+ *
+ * Not Google: the Elevation API's policies forbid caching or storing its results at all,
+ * and a per-leg climb figure that has to be re-fetched every time the trip list is drawn
+ * is no use. Copernicus is open data, so the derived numbers can simply be kept — see
+ * [ATTRIBUTION], which the licence requires.
+ */
+object Elevation {
+
+    const val ATTRIBUTION = "Elevation © Copernicus DEM via Open-Meteo"
+
+    private const val BASE_URL = "https://api.open-meteo.com/v1/elevation"
+
+    /** The service takes at most 100 coordinates per call. */
+    const val MAX_SAMPLES = 100
+
+    /**
+     * Below this, a rise is DEM noise rather than a hill. Without it, summing every
+     * upward step inflates cumulative ascent badly — the error compounds over hundreds
+     * of samples and always in the same direction.
+     */
+    const val MIN_RISE_M = 10.0
+
+    fun url(points: List<LatLng>): String =
+        "$BASE_URL?latitude=${points.joinToString(",") { it.latitude.toString() }}" +
+            "&longitude=${points.joinToString(",") { it.longitude.toString() }}"
+
+    /** Lenient: an error body or a surprise shape yields no heights, never a throw. */
+    fun parse(body: String): List<Double> {
+        val root = runCatching { Json.parseToJsonElement(body) }.getOrNull() as? JsonObject
+        val elevation = root?.get("elevation") as? JsonArray ?: return emptyList()
+        return elevation.map { element ->
+            (element as? JsonPrimitive)?.takeIf { !it.isString }?.content?.toDoubleOrNull()
+                ?: return emptyList()
+        }
+    }
+
+    /**
+     * [count] points spread evenly by *distance* along the path — not by index. A decoded
+     * polyline crowds its vertices into the switchbacks, so sampling by index would spend
+     * most of the budget on the hairpins and skip the long straight climb between them.
+     */
+    fun sample(points: List<LatLng>, count: Int = MAX_SAMPLES): List<LatLng> {
+        if (count <= 0) return emptyList()
+        if (points.size <= count) return points
+        if (count == 1) return points.take(1)
+        // Distance from the start at each vertex, so a target distance can be looked up.
+        val marks = DoubleArray(points.size)
+        for (index in 1 until points.size) {
+            marks[index] = marks[index - 1] + GeoUtils.haversineKm(points[index - 1], points[index])
+        }
+        val total = marks.last()
+        // A closed loop or a pile of identical points has no length to spread over.
+        if (total <= 0.0) return points.take(count)
+        var vertex = 0
+        return (0 until count).map { step ->
+            val target = total * step / (count - 1)
+            // `<=`, not `<`: the last target is exactly the total length, and a strict
+            // test would stop one vertex short and never sample the end of the leg.
+            while (vertex < points.size - 1 && marks[vertex + 1] <= target) vertex++
+            points[vertex]
+        }
+    }
+
+    /**
+     * Cumulative ascent and descent, with a hysteresis filter: a move only counts once it
+     * passes [minRise], and then becomes the new reference. That is what separates a real
+     * climb from the sampling noise sitting on top of it.
+     */
+    fun profile(heights: List<Double>, minRise: Double = MIN_RISE_M): Climb {
+        var anchor = heights.firstOrNull() ?: return Climb(0.0, 0.0)
+        var ascent = 0.0
+        var descent = 0.0
+        heights.forEach { height ->
+            val delta = height - anchor
+            when {
+                delta >= minRise -> {
+                    ascent += delta
+                    anchor = height
+                }
+                delta <= -minRise -> {
+                    descent -= delta
+                    anchor = height
+                }
+            }
+        }
+        return Climb(ascent, descent)
+    }
+}

--- a/app/src/main/java/com/nuelto/camperexperience/domain/Elevation.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/domain/Elevation.kt
@@ -1,6 +1,7 @@
 package com.nuelto.camperexperience.domain
 
 import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.data.model.Stop
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -27,11 +28,23 @@ object Elevation {
     const val MAX_SAMPLES = 100
 
     /**
-     * Below this, a rise is DEM noise rather than a hill. Without it, summing every
-     * upward step inflates cumulative ascent badly — the error compounds over hundreds
-     * of samples and always in the same direction.
+     * Below this, a rise is road undulation rather than a climb. It has to be this large:
+     * cumulative ascent does not converge — sample the same 215 km route 16× more finely
+     * and a 10 m threshold grows the total by 47%. At 50 m, with [MAX_ROAD_GRADE], the
+     * same range of densities moves it by 6%.
+     *
+     * Undulation is also already inside the user's measured l/100km, so charging for it
+     * would count it twice. Only sustained climbs are new information.
      */
-    const val MIN_RISE_M = 10.0
+    const val MIN_RISE_M = 50.0
+
+    /**
+     * Steepest average grade a road sustains between two samples. Anything above it is
+     * the DEM describing terrain rather than tarmac — a tunnel reports the mountain over
+     * it, which on one Swiss route showed a road passing through 2876 m, several hundred
+     * metres above the highest pass in the country.
+     */
+    const val MAX_ROAD_GRADE = 0.08
 
     fun url(points: List<LatLng>): String =
         "$BASE_URL?latitude=${points.joinToString(",") { it.latitude.toString() }}" +
@@ -75,27 +88,46 @@ object Elevation {
     }
 
     /**
-     * Cumulative ascent and descent, with a hysteresis filter: a move only counts once it
-     * passes [minRise], and then becomes the new reference. That is what separates a real
-     * climb from the sampling noise sitting on top of it.
+     * Cumulative ascent and descent along [points] at [heights], in two passes:
+     *
+     * 1. Clamp each step to what [MAX_ROAD_GRADE] allows over the distance covered, which
+     *    flattens the phantom peaks the DEM puts over tunnels and deep cuttings.
+     * 2. Hysteresis: a move counts only once it passes [minRise], and then becomes the new
+     *    reference — so undulation does not accumulate.
+     *
+     * Both are needed. Neither alone gives a figure that survives a change of sampling
+     * density, and this one is only stable to about 6%: treat it as an order of magnitude
+     * for costing a climb, never as a measurement.
      */
-    fun profile(heights: List<Double>, minRise: Double = MIN_RISE_M): Climb {
+    fun profile(
+        points: List<LatLng>,
+        heights: List<Double>,
+        minRise: Double = MIN_RISE_M,
+    ): Climb {
         var anchor = heights.firstOrNull() ?: return Climb(0.0, 0.0)
+        var road = anchor
         var ascent = 0.0
         var descent = 0.0
-        heights.forEach { height ->
-            val delta = height - anchor
+        heights.forEachIndexed { index, height ->
+            if (index > 0) {
+                val limit = MAX_ROAD_GRADE * GeoUtils.haversineKm(points[index - 1], points[index]) * 1000
+                road = height.coerceIn(road - limit, road + limit)
+            }
+            val delta = road - anchor
             when {
                 delta >= minRise -> {
                     ascent += delta
-                    anchor = height
+                    anchor = road
                 }
                 delta <= -minRise -> {
                     descent -= delta
-                    anchor = height
+                    anchor = road
                 }
             }
         }
         return Climb(ascent, descent)
     }
+
+    /** A stop's own height, when it was measured where the stop currently sits. */
+    fun ofStop(stop: Stop): Int? = stop.elevation?.takeIf { it.at == stop.location }?.meters
 }

--- a/app/src/main/java/com/nuelto/camperexperience/domain/FuelEstimator.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/domain/FuelEstimator.kt
@@ -3,8 +3,9 @@ package com.nuelto.camperexperience.domain
 import com.nuelto.camperexperience.data.model.Expense
 import com.nuelto.camperexperience.data.model.ExpenseType
 import com.nuelto.camperexperience.data.model.Stop
-import com.nuelto.camperexperience.data.model.StopState
+import com.nuelto.camperexperience.data.model.StopLeg
 import com.nuelto.camperexperience.data.model.UserSettings
+import kotlin.math.min
 
 object FuelEstimator {
 
@@ -13,26 +14,88 @@ object FuelEstimator {
 
     /**
      * Automatic fuel estimate for a trip, derived from the driving distance between its
-     * stops. Never stored — computed at display time. Null when the trip already has a
-     * recorded FUEL expense (real costs replace the estimate) or when fewer than two
-     * stops have a location.
+     * stops and what it costs to climb between them. Never stored — computed at display
+     * time. Null when the trip already has a recorded FUEL expense (real costs replace
+     * the estimate) or when fewer than two stops have a location.
      */
     fun autoTripFuelCost(stops: List<Stop>, expenses: List<Expense>, settings: UserSettings): Double? {
         if (expenses.any { it.type == ExpenseType.FUEL }) return null
         val distanceKm = defaultTripDistanceKm(stops, settings)
         if (distanceKm <= 0.0) return null
-        return estimateCost(distanceKm, settings.fuelConsumptionL100km, settings.fuelPricePerLiter)
+        val liters = distanceKm * settings.fuelConsumptionL100km / 100.0 + climbLiters(stops, settings)
+        return liters * settings.fuelPricePerLiter
     }
 
     /**
-     * Default distance to prefill the estimator with: straight-line legs between the
-     * trip's stops (in order, skipped ones excluded), scaled by the road-distance
-     * factor. Always user-editable.
+     * Driving distance for the trip: the road distance Google routed for every leg that
+     * has one, and straight-line × `roadDistanceFactor` for the rest. The factor is the
+     * fallback now, not the rule — it covers legs that were never routed because there
+     * was no key, no signal, or no route.
+     *
+     * Also the estimator sheet's prefill, so it stays user-editable.
      */
-    fun defaultTripDistanceKm(stops: List<Stop>, settings: UserSettings): Double {
-        val points = stops.sortedBy { it.orderIndex }
-            .filterNot { it.state == StopState.SKIPPED }
-            .mapNotNull { it.location }
-        return GeoUtils.routeLengthKm(points) * settings.roadDistanceFactor
+    fun defaultTripDistanceKm(stops: List<Stop>, settings: UserSettings): Double =
+        RouteCache.drives(stops).sumOf { (from, to) -> driveDistanceKm(from, to, settings) }
+
+    // Safe: RouteCache.drives keeps only stops that have a location.
+    private fun driveDistanceKm(from: Stop, to: Stop, settings: UserSettings): Double =
+        RouteCache.usable(from, to)?.let { it.distanceMeters / 1000.0 }
+            ?: (GeoUtils.haversineKm(from.location!!, to.location!!) * settings.roadDistanceFactor)
+
+    // The gravity term of the road-load equation: lower heating value of diesel, and a
+    // drivetrain efficiency in the band a loaded van sits in on a long climb (0.30–0.35).
+    private const val GRAVITY = 9.81
+    private const val DIESEL_MJ_PER_LITER = 35.8
+    private const val DRIVETRAIN_EFFICIENCY = 0.32
+
+    /** Most of a descent's theoretical saving — never all of it, and never more than
+     *  the fuel it replaces. */
+    private const val DESCENT_RECOVERY = 0.85
+
+    /**
+     * Litres of diesel to lift [massKg] through [ascentMeters] — about 0.086 l per tonne
+     * per 100 m of climb.
+     *
+     * Deliberately the gravity term alone: rolling resistance and drag are already inside
+     * the user's l/100km figure, which was measured on real roads. Adding them here would
+     * count them twice.
+     */
+    fun liftLiters(massKg: Double, ascentMeters: Double): Double =
+        massKg * GRAVITY * ascentMeters / (DRIVETRAIN_EFFICIENCY * DIESEL_MJ_PER_LITER * 1e6)
+
+    /**
+     * What the trip's climbing adds over a flat route of the same length. Legs with no
+     * elevation figure — never fetched, or the DEM service was unreachable — contribute
+     * nothing, so the estimate degrades to distance-only rather than to nonsense.
+     *
+     * Treat the constants as unvalidated until they have been checked against a real
+     * tankful: they are the right physics, but the efficiency term is a single number
+     * standing in for a whole engine map.
+     */
+    fun climbLiters(stops: List<Stop>, settings: UserSettings): Double =
+        RouteCache.drives(stops).sumOf { (from, to) ->
+            legClimbLiters(
+                RouteCache.usable(from, to),
+                driveDistanceKm(from, to, settings),
+                settings,
+            )
+        }
+
+    private fun legClimbLiters(leg: StopLeg?, distanceKm: Double, settings: UserSettings): Double {
+        if (leg == null) return 0.0
+        val ascent = leg.ascentMeters?.toDouble() ?: 0.0
+        val descent = leg.descentMeters?.toDouble() ?: 0.0
+        if (ascent + descent <= 0.0) return 0.0
+        // Split the leg's length between climbing and descending in proportion to the
+        // heights, so the saving is bounded by the distance the descent actually covers.
+        val descentKm = distanceKm * descent / (ascent + descent)
+        // A non-hybrid cannot bank potential energy: going down, the only recovery is the
+        // injectors shutting off on the overrun, which can at best cancel the fuel that
+        // stretch would have burned anyway.
+        val recovered = DESCENT_RECOVERY * min(
+            liftLiters(settings.vehicleMassKg, descent),
+            settings.fuelConsumptionL100km * descentKm / 100.0,
+        )
+        return liftLiters(settings.vehicleMassKg, ascent) - recovered
     }
 }

--- a/app/src/main/java/com/nuelto/camperexperience/domain/GooglePlaces.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/domain/GooglePlaces.kt
@@ -73,6 +73,8 @@ object GooglePlaces {
         // matches it pulled in weak ones from the other side of the continent.
         StopKind.FREE_CAMP -> listOf("parking", "rest_stop")
         StopKind.VISIT -> listOf("tourist_attraction")
+        // Home is an address, not a category Google filters on.
+        StopKind.HOME -> emptyList()
     }
 
     /** Lenient by design: an error body or a surprise shape yields no hits, never a throw. */

--- a/app/src/main/java/com/nuelto/camperexperience/domain/GoogleRoutes.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/domain/GoogleRoutes.kt
@@ -1,0 +1,118 @@
+package com.nuelto.camperexperience.domain
+
+import com.nuelto.camperexperience.data.model.LatLng
+import kotlin.math.roundToInt
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/** One drive between two consecutive stops, as Google routed it. */
+data class RoutedLeg(
+    val polyline: String,
+    val distanceMeters: Int,
+    val durationSeconds: Int,
+)
+
+/**
+ * Google Routes API (computeRoutes): the road-following geometry, distance and driving
+ * time between stops. Pure request building and lenient parsing; the HTTP call is
+ * location/GoogleRoutesService.
+ *
+ * Note this is a web service, not the Android SDK — an API key restricted to Android
+ * apps cannot call it. See GOOGLE_MAPS_SETUP.md.
+ */
+object GoogleRoutes {
+
+    const val COMPUTE_ROUTES_URL = "https://routes.googleapis.com/directions/v2:computeRoutes"
+
+    /**
+     * Mandatory — the API has no default field set and rejects a request without a mask.
+     * Per-leg only: the route totals are the sum of the legs, and every extra field is
+     * billed. `*` would work and is what the docs warn against.
+     */
+    const val FIELD_MASK = "routes.legs.distanceMeters,routes.legs.duration," +
+        "routes.legs.polyline.encodedPolyline"
+
+    /**
+     * Origin, destination and at most 10 intermediates. Eleven intermediates is one of
+     * the four things that move the call from the Compute Routes Essentials SKU to Pro
+     * at twice the price, so a longer trip is split into overlapping windows instead of
+     * paying for one big request. (The API's own hard cap is 25.)
+     */
+    const val MAX_POINTS_PER_REQUEST = 12
+
+    /**
+     * The trip's points split into requests, each sharing its first point with the
+     * previous window's last so the legs join up. Fewer than two points is not a drive.
+     */
+    fun windows(points: List<LatLng>): List<List<LatLng>> {
+        if (points.size < 2) return emptyList()
+        val windows = mutableListOf<List<LatLng>>()
+        var start = 0
+        while (start < points.size - 1) {
+            val end = minOf(start + MAX_POINTS_PER_REQUEST, points.size)
+            windows += points.subList(start, end)
+            start = end - 1
+        }
+        return windows
+    }
+
+    /**
+     * Intermediates are plain (non-`via`) waypoints, which is what makes Google return
+     * one leg per pair of stops — a `via` waypoint would collapse the whole window into
+     * a single leg and lose the per-stop numbers.
+     *
+     * TRAFFIC_UNAWARE deliberately: live traffic is meaningless for a trip planned weeks
+     * out, and asking for it is another jump to the Pro SKU.
+     */
+    fun computeRoutesBody(points: List<LatLng>): String {
+        val middle = points.subList(1, points.size - 1)
+        val intermediates =
+            if (middle.isEmpty()) {
+                ""
+            } else {
+                middle.joinToString(",", ",\"intermediates\":[", "]") { waypoint(it) }
+            }
+        return "{\"origin\":${waypoint(points.first())}," +
+            "\"destination\":${waypoint(points.last())}$intermediates," +
+            "\"travelMode\":\"DRIVE\",\"routingPreference\":\"TRAFFIC_UNAWARE\"," +
+            "\"polylineQuality\":\"HIGH_QUALITY\"}"
+    }
+
+    private fun waypoint(point: LatLng): String =
+        "{\"location\":{\"latLng\":{\"latitude\":${point.latitude}," +
+            "\"longitude\":${point.longitude}}}}"
+
+    /**
+     * The legs of the first route, in order. Order is the whole contract — leg *i* is
+     * the drive to point *i+1* — so a malformed entry discards the response rather than
+     * silently shifting every leg onto the wrong stop.
+     */
+    fun parseLegs(body: String): List<RoutedLeg> {
+        val root = runCatching { Json.parseToJsonElement(body) }.getOrNull() as? JsonObject
+        val routes = root?.get("routes") as? JsonArray ?: return emptyList()
+        val legs = (routes.firstOrNull() as? JsonObject)?.get("legs") as? JsonArray
+            ?: return emptyList()
+        return legs.map { element ->
+            val leg = element as? JsonObject ?: return emptyList()
+            RoutedLeg(
+                polyline = (leg["polyline"] as? JsonObject)?.string("encodedPolyline").orEmpty(),
+                // Proto3 JSON omits zero-valued fields, so a zero-length leg arrives
+                // with neither number present.
+                distanceMeters = leg.int("distanceMeters") ?: 0,
+                durationSeconds = leg.string("duration")?.let(::parseDuration) ?: 0,
+            )
+        }
+    }
+
+    /** Durations are protobuf strings — seconds with optional fraction, then "s". */
+    fun parseDuration(text: String): Int? =
+        text.removeSuffix("s").toDoubleOrNull()?.roundToInt()
+
+    private fun JsonObject.string(key: String): String? =
+        (this[key] as? JsonPrimitive)?.takeIf { it.isString }?.content?.takeIf { it.isNotBlank() }
+
+    private fun JsonObject.int(key: String): Int? =
+        (this[key] as? JsonPrimitive)?.takeIf { !it.isString }?.content?.toIntOrNull()
+}

--- a/app/src/main/java/com/nuelto/camperexperience/domain/HomeStop.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/domain/HomeStop.kt
@@ -1,0 +1,35 @@
+package com.nuelto.camperexperience.domain
+
+import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.StopKind
+import com.nuelto.camperexperience.data.model.UserSettings
+import java.time.LocalDate
+
+/**
+ * Where a plan starts from. A new plan opens with the home address as its first stop, so
+ * the first leg is the drive out of the door rather than a guess — the distance, the fuel
+ * and the map all count it without knowing anything about "home".
+ *
+ * It is a real [Stop] rather than a setting the rest of the app has to special-case: the
+ * only thing that makes it different is its [StopKind], and being a kind means the
+ * timeline, the map and the estimator already handle it. That also makes it editable and
+ * removable like any other stop — a trip that starts somewhere else just says so.
+ */
+object HomeStop {
+
+    const val DEFAULT_NAME = "Home"
+
+    /** Null when no home is set, which leaves a new plan starting wherever you add first. */
+    fun forNewPlan(tripId: String, settings: UserSettings, startDate: LocalDate): Stop? {
+        val location = settings.homeLocation ?: return null
+        return Stop(
+            tripId = tripId,
+            name = settings.homeName.ifBlank { DEFAULT_NAME },
+            location = location,
+            arrivalDate = startDate,
+            nights = 0,
+            orderIndex = 0,
+            kind = StopKind.HOME,
+        )
+    }
+}

--- a/app/src/main/java/com/nuelto/camperexperience/domain/MapOverlay.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/domain/MapOverlay.kt
@@ -2,7 +2,7 @@ package com.nuelto.camperexperience.domain
 
 import com.nuelto.camperexperience.data.model.LatLng
 import com.nuelto.camperexperience.data.model.Stop
-import com.nuelto.camperexperience.data.model.StopKind
+import com.nuelto.camperexperience.data.model.isStay
 import com.nuelto.camperexperience.data.model.StopState
 import com.nuelto.camperexperience.data.model.Trip
 import com.nuelto.camperexperience.data.model.TripStatus
@@ -10,7 +10,7 @@ import com.nuelto.camperexperience.data.model.TripStatus
 /** The app's colour language, provider-agnostic: blue = planned, green = current, grey = done. */
 enum class MapAccent { PLANNED, CURRENT, DONE }
 
-/** Visits render hollow — they are route points, not stays. */
+/** Visits and home render hollow — they are route points, not stays. */
 data class MapMarker(
     val tripId: String,
     val stopId: String,
@@ -60,7 +60,7 @@ object MapOverlay {
                     stopId = stop.id,
                     at = it,
                     accent = entry.accent(stop),
-                    hollow = stop.kind == StopKind.VISIT,
+                    hollow = !stop.kind.isStay,
                 )
             }
         }

--- a/app/src/main/java/com/nuelto/camperexperience/domain/MapOverlay.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/domain/MapOverlay.kt
@@ -80,7 +80,7 @@ object MapOverlay {
             .filter { it.location != null }
         if (located.size < 2) return@flatMap emptyList()
         val leg = { stops: List<Stop>, accent: MapAccent, dashed: Boolean ->
-            MapRoute(entry.trip.id, stops.mapNotNull { it.location }, accent, dashed)
+            MapRoute(entry.trip.id, path(stops), accent, dashed)
         }
 
         when (entry.trip.status) {
@@ -98,6 +98,27 @@ object MapOverlay {
                 }
             }
         }
+    }
+
+    /**
+     * The line through [stops]: the road Google routed wherever there is a leg for it,
+     * and a straight hop between the two pins wherever there is not — no key, no signal,
+     * or a stop moved since the route was fetched.
+     */
+    private fun path(stops: List<Stop>): List<LatLng> {
+        val points = mutableListOf<LatLng>()
+        stops.zipWithNext().forEach { (from, to) ->
+            val segment = segment(from, to)
+            // Consecutive segments share the stop between them; a routed one starts at
+            // the road, not the pin, so the join is only dropped when it really repeats.
+            points += if (points.lastOrNull() == segment.firstOrNull()) segment.drop(1) else segment
+        }
+        return points
+    }
+
+    private fun segment(from: Stop, to: Stop): List<LatLng> {
+        val road = RouteCache.usable(from, to)?.let { Polyline.decode(it.polyline) }
+        return if (road != null && road.size >= 2) road else listOfNotNull(from.location, to.location)
     }
 
     /** Identical coordinates collapse, so a degenerate bounding box never reaches the map. */

--- a/app/src/main/java/com/nuelto/camperexperience/domain/Polyline.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/domain/Polyline.kt
@@ -1,0 +1,51 @@
+package com.nuelto.camperexperience.domain
+
+import com.nuelto.camperexperience.data.model.LatLng
+
+/**
+ * Google's encoded polyline algorithm, decode half. Hand-rolled rather than pulled in
+ * with `android-maps-utils`, which is not a dependency and whose `PolyUtil` would drag
+ * the decode out of `domain/` — where it is covered and mutation-tested — into the
+ * Android-only half of the app.
+ *
+ * Lenient like the rest of the parsing here: a truncated or junk string yields the
+ * points that could be read, never a throw.
+ */
+object Polyline {
+
+    private const val PRECISION = 1e5
+
+    fun decode(encoded: String): List<LatLng> {
+        val cursor = Cursor(encoded)
+        val points = mutableListOf<LatLng>()
+        var lat = 0
+        var lng = 0
+        while (!cursor.done) {
+            lat += cursor.next() ?: return points
+            lng += cursor.next() ?: return points
+            points += LatLng(lat / PRECISION, lng / PRECISION)
+        }
+        return points
+    }
+
+    /** One zig-zag-encoded delta at a time, so latitude and longitude share the reader. */
+    private class Cursor(private val text: String) {
+        private var index = 0
+
+        val done: Boolean get() = index >= text.length
+
+        /** Null when the chunk runs off the end of the string — i.e. truncated input. */
+        fun next(): Int? {
+            var shift = 0
+            var result = 0
+            var chunk: Int
+            do {
+                if (done) return null
+                chunk = text[index++].code - 63
+                result = result or ((chunk and 0x1f) shl shift)
+                shift += 5
+            } while (chunk >= 0x20)
+            return if (result and 1 != 0) (result shr 1).inv() else result shr 1
+        }
+    }
+}

--- a/app/src/main/java/com/nuelto/camperexperience/domain/RouteCache.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/domain/RouteCache.kt
@@ -1,0 +1,71 @@
+package com.nuelto.camperexperience.domain
+
+import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.StopLeg
+import com.nuelto.camperexperience.data.model.StopState
+import java.time.LocalDate
+
+/**
+ * When a stored route still describes the drive it was fetched for, and when it has to
+ * go. Two independent reasons to drop one:
+ *
+ * - **It no longer matches.** A leg records the two coordinates it was computed between,
+ *   so a reorder, a moved pin or a skipped stop invalidates it by comparison — nothing
+ *   has to remember to clear it.
+ * - **It expired.** The Routes API terms allow keeping a routed coordinate for 30 days
+ *   (SST §19.3), the same window as the Places rule in [PlaceCache]. A polyline is a
+ *   sequence of coordinates, so it lives under the same clock.
+ *
+ * Expiry is [RouteRefresher]'s business, exactly as [PlaceCacheSweeper] owns §14.3: the
+ * map and the estimator ask only whether a leg still matches, and the refresher is what
+ * deletes one that has run out of days.
+ */
+object RouteCache {
+
+    const val RETENTION_DAYS = 30L
+
+    /** The stops a route runs through, in order. Skipped stops leave the route. */
+    fun routed(stops: List<Stop>): List<Stop> = stops
+        .sortedBy { it.orderIndex }
+        .filterNot { it.state == StopState.SKIPPED }
+        .filter { it.location != null }
+
+    /** Consecutive drives of the trip, each as the stop it leaves and the one it reaches. */
+    fun drives(stops: List<Stop>): List<Pair<Stop, Stop>> = routed(stops).zipWithNext()
+
+    /** The stored leg for the drive [previous] → [stop], if it still describes it. */
+    fun usable(previous: Stop, stop: Stop): StopLeg? =
+        stop.leg?.takeIf { it.from == previous.location && it.to == stop.location }
+
+    /**
+     * The drive arriving at each stop, keyed by stop id — only where the stored leg still
+     * describes it, so the timeline never shows a distance left over from before an edit.
+     */
+    fun byStop(stops: List<Stop>): Map<String, StopLeg> = drives(stops)
+        .mapNotNull { (from, to) -> usable(from, to)?.let { to.id to it } }
+        .toMap()
+
+    fun isExpired(leg: StopLeg, today: LocalDate): Boolean =
+        !today.isBefore(leg.fetchedAt.plusDays(RETENTION_DAYS))
+
+    /**
+     * Stops holding a leg that must be dropped — expired, or describing a drive that is
+     * no longer the one arriving there (including a stop that no longer has a drive at
+     * all, because it was skipped, unpinned or dragged to the front).
+     */
+    fun stale(stops: List<Stop>, today: LocalDate): List<Stop> {
+        val previous = drives(stops).associate { (from, to) -> to.id to from }
+        return stops.filter { stop ->
+            val leg = stop.leg ?: return@filter false
+            val from = previous[stop.id]
+            from == null || usable(from, stop) == null || isExpired(leg, today)
+        }
+    }
+
+    /** True when any drive of the trip has no leg to draw or cost with. */
+    fun needsFetch(stops: List<Stop>, today: LocalDate): Boolean =
+        drives(stops).any { (from, to) ->
+            val leg = usable(from, to)
+            leg == null || isExpired(leg, today)
+        }
+}

--- a/app/src/main/java/com/nuelto/camperexperience/domain/RouteRefresher.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/domain/RouteRefresher.kt
@@ -1,0 +1,122 @@
+package com.nuelto.camperexperience.domain
+
+import com.nuelto.camperexperience.data.TripRepository
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.StopLeg
+import java.time.LocalDate
+import kotlin.math.roundToInt
+import kotlinx.coroutines.flow.first
+
+/**
+ * Keeps a trip's road-following legs in step with its stops: drops the ones that no
+ * longer describe a drive or have run out of days, and fetches what is missing. Composed
+ * over the TripRepository interface, so it works the same against Firestore and the
+ * in-memory store — the same shape as [PlaceCacheSweeper], for the same reason.
+ *
+ * Fail-soft throughout, like the Places path: no key, no signal or a malformed response
+ * simply leaves the legs alone, and the map and the estimate fall back to straight lines
+ * scaled by the road-distance factor.
+ *
+ * When anything at all is missing the whole chain is re-fetched rather than the gaps
+ * alone. One request covers a normal trip, and a partial fetch would have to reason about
+ * which stored leg belongs to which pair after a reorder — which is exactly the bug class
+ * [RouteCache] exists to make impossible.
+ */
+class RouteRefresher(
+    private val tripRepository: TripRepository,
+    private val route: suspend (points: List<LatLng>) -> List<RoutedLeg>?,
+    // Null-returning by default: elevation is a second, optional service, and a leg
+    // without a climb figure still draws and still costs.
+    private val heights: suspend (points: List<LatLng>) -> List<Double>? = { null },
+) {
+
+    suspend fun refresh(tripId: String, today: LocalDate = LocalDate.now()): Result {
+        val stops = tripRepository.stops(tripId).first()
+        val cleared = clearStale(tripId, stops, today)
+        if (!RouteCache.needsFetch(stops, today)) return Result(fetched = 0, cleared = cleared)
+
+        val routed = RouteCache.routed(stops)
+        // Safe: routed() keeps only stops that have a location.
+        val legs = fetchAll(routed.map { it.location!! })
+            ?: return Result(fetched = 0, cleared = cleared)
+
+        var fetched = 0
+        routed.zipWithNext().forEachIndexed { index, (from, to) ->
+            val climb = climb(legs[index].polyline)
+            val leg = StopLeg(
+                // The coordinates the route was actually computed between. A stop edited
+                // while the request was in flight must invalidate this leg on the next
+                // pass, not quietly adopt it.
+                from = from.location!!,
+                to = to.location!!,
+                polyline = legs[index].polyline,
+                distanceMeters = legs[index].distanceMeters,
+                durationSeconds = legs[index].durationSeconds,
+                ascentMeters = climb?.ascentMeters?.roundToInt(),
+                descentMeters = climb?.descentMeters?.roundToInt(),
+                fetchedAt = today,
+            )
+            if (write(tripId, to.id) { it.copy(leg = leg.keepingClimbOf(it.leg)) }) fetched++
+        }
+        return Result(fetched = fetched, cleared = cleared)
+    }
+
+    /**
+     * A failed elevation call must not erase a climb already measured for the same drive.
+     * [RouteCache.needsFetch] only asks whether a leg exists, so a leg written with a null
+     * climb is never revisited — the figure would be gone until the stop moved again.
+     */
+    private fun StopLeg.keepingClimbOf(stored: StopLeg?): StopLeg {
+        if (ascentMeters != null) return this
+        val measured = stored?.takeIf { it.from == from && it.to == to } ?: return this
+        return copy(ascentMeters = measured.ascentMeters, descentMeters = measured.descentMeters)
+    }
+
+    /** §19.3 deletion plus invalidation: a leg that no longer applies is simply removed. */
+    private suspend fun clearStale(tripId: String, stops: List<Stop>, today: LocalDate): Int {
+        var cleared = 0
+        RouteCache.stale(stops, today).forEach { stale ->
+            val dropped = write(tripId, stale.id) { stop ->
+                stop.copy(leg = null).takeIf { stop.leg != null }
+            }
+            if (dropped) cleared++
+        }
+        return cleared
+    }
+
+    /**
+     * Re-reads the stop before writing it. Every fetch here is a network round trip, so
+     * the stop may have been edited meanwhile — and `upsertStop` replaces the whole
+     * document, so writing the stale copy would revert that edit.
+     */
+    private suspend fun write(tripId: String, stopId: String, edit: (Stop) -> Stop?): Boolean {
+        val current = tripRepository.stops(tripId).first().find { it.id == stopId } ?: return false
+        val updated = edit(current) ?: return false
+        tripRepository.upsertStop(updated)
+        return true
+    }
+
+    /** Null on the first window that fails, so a half-routed trip is never written. */
+    private suspend fun fetchAll(points: List<LatLng>): List<RoutedLeg>? {
+        val legs = mutableListOf<RoutedLeg>()
+        GoogleRoutes.windows(points).forEach { window ->
+            val fetched = route(window) ?: return null
+            // One leg per pair, or the response cannot be lined up with the stops.
+            if (fetched.size != window.size - 1) return null
+            legs += fetched
+        }
+        return legs
+    }
+
+    private suspend fun climb(polyline: String): Climb? {
+        val samples = Elevation.sample(Polyline.decode(polyline))
+        if (samples.size < 2) return null
+        val measured = heights(samples) ?: return null
+        return if (measured.size != samples.size) null else Elevation.profile(measured)
+    }
+
+    data class Result(val fetched: Int, val cleared: Int) {
+        val touched: Boolean get() = fetched > 0 || cleared > 0
+    }
+}

--- a/app/src/main/java/com/nuelto/camperexperience/domain/RouteRefresher.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/domain/RouteRefresher.kt
@@ -3,6 +3,7 @@ package com.nuelto.camperexperience.domain
 import com.nuelto.camperexperience.data.TripRepository
 import com.nuelto.camperexperience.data.model.LatLng
 import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.StopElevation
 import com.nuelto.camperexperience.data.model.StopLeg
 import java.time.LocalDate
 import kotlin.math.roundToInt
@@ -34,12 +35,15 @@ class RouteRefresher(
     suspend fun refresh(tripId: String, today: LocalDate = LocalDate.now()): Result {
         val stops = tripRepository.stops(tripId).first()
         val cleared = clearStale(tripId, stops, today)
-        if (!RouteCache.needsFetch(stops, today)) return Result(fetched = 0, cleared = cleared)
+        val elevated = fillElevations(tripId, stops)
+        if (!RouteCache.needsFetch(stops, today)) {
+            return Result(fetched = 0, cleared = cleared, elevated = elevated)
+        }
 
         val routed = RouteCache.routed(stops)
         // Safe: routed() keeps only stops that have a location.
         val legs = fetchAll(routed.map { it.location!! })
-            ?: return Result(fetched = 0, cleared = cleared)
+            ?: return Result(fetched = 0, cleared = cleared, elevated = elevated)
 
         var fetched = 0
         routed.zipWithNext().forEachIndexed { index, (from, to) ->
@@ -59,7 +63,26 @@ class RouteRefresher(
             )
             if (write(tripId, to.id) { it.copy(leg = leg.keepingClimbOf(it.leg)) }) fetched++
         }
-        return Result(fetched = fetched, cleared = cleared)
+        return Result(fetched = fetched, cleared = cleared, elevated = elevated)
+    }
+
+    /**
+     * How high each stop sits, in one call for the whole trip. Independent of routing: a
+     * lone stop has no drive but still has a height, and the DEM is free and open, so
+     * there is no reason to make it wait for a billed route.
+     */
+    private suspend fun fillElevations(tripId: String, stops: List<Stop>): Int {
+        val due = stops.filter { it.location != null && Elevation.ofStop(it) == null }
+        if (due.isEmpty()) return 0
+        val points = due.mapNotNull { it.location }.take(Elevation.MAX_SAMPLES)
+        val measured = heights(points) ?: return 0
+        if (measured.size != points.size) return 0
+        var elevated = 0
+        due.take(points.size).forEachIndexed { index, stop ->
+            val elevation = StopElevation(points[index], measured[index].roundToInt())
+            if (write(tripId, stop.id) { it.copy(elevation = elevation) }) elevated++
+        }
+        return elevated
     }
 
     /**
@@ -113,10 +136,10 @@ class RouteRefresher(
         val samples = Elevation.sample(Polyline.decode(polyline))
         if (samples.size < 2) return null
         val measured = heights(samples) ?: return null
-        return if (measured.size != samples.size) null else Elevation.profile(measured)
+        return if (measured.size != samples.size) null else Elevation.profile(samples, measured)
     }
 
-    data class Result(val fetched: Int, val cleared: Int) {
-        val touched: Boolean get() = fetched > 0 || cleared > 0
+    data class Result(val fetched: Int, val cleared: Int, val elevated: Int = 0) {
+        val touched: Boolean get() = fetched > 0 || cleared > 0 || elevated > 0
     }
 }

--- a/app/src/main/java/com/nuelto/camperexperience/domain/TripEstimator.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/domain/TripEstimator.kt
@@ -30,7 +30,7 @@ object TripEstimator {
     fun nightlyRate(kind: StopKind, settings: UserSettings): Double = when (kind) {
         StopKind.CAMPSITE -> settings.campsitePerNight
         StopKind.STELLPLATZ -> settings.stellplatzPerNight
-        StopKind.FREE_CAMP, StopKind.VISIT -> 0.0
+        StopKind.FREE_CAMP, StopKind.VISIT, StopKind.HOME -> 0.0
     }
 
     fun estimate(stops: List<Stop>, expenses: List<Expense>, settings: UserSettings): EstimateBreakdown {

--- a/app/src/main/java/com/nuelto/camperexperience/location/GooglePlacesSearch.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/location/GooglePlacesSearch.kt
@@ -33,7 +33,8 @@ class GooglePlacesSearch(private val apiKey: String = BuildConfig.MAPS_API_KEY) 
         prefer: StopKind?,
     ): List<PlaceSuggestion>? = withContext(Dispatchers.IO) {
         val all = autocomplete(query, near, emptyList()) ?: return@withContext null
-        val types = prefer?.let(GooglePlaces::preferredTypes) ?: return@withContext all
+        val types = prefer?.let(GooglePlaces::preferredTypes)?.takeIf { it.isNotEmpty() }
+            ?: return@withContext all
         // A second, type-filtered pass: what the user is looking for goes to the top,
         // and it surfaces places the open query misses entirely.
         val wanted = autocomplete(query, near, types).orEmpty()

--- a/app/src/main/java/com/nuelto/camperexperience/location/RouteServices.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/location/RouteServices.kt
@@ -1,0 +1,85 @@
+package com.nuelto.camperexperience.location
+
+import com.nuelto.camperexperience.BuildConfig
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.domain.Elevation
+import com.nuelto.camperexperience.domain.GoogleRoutes
+import com.nuelto.camperexperience.domain.RoutedLeg
+import java.net.HttpURLConnection
+import java.net.URL
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Google Routes API over plain HTTP — there is no Android client library for it (the
+ * official ones are server-side, for five other languages), and the request building and
+ * parsing are better off in `domain/GoogleRoutes` where they are mutation-tested anyway.
+ *
+ * Only reachable in Google-map mode, on the same key as the map and Places — the Routes
+ * API just has to be enabled and allowed by the key's API restrictions.
+ */
+class GoogleRoutesService(private val apiKey: String = BuildConfig.MAPS_API_KEY) {
+
+    /** One leg per pair of consecutive points, or null if the call did not come back. */
+    suspend fun legs(points: List<LatLng>): List<RoutedLeg>? = withContext(Dispatchers.IO) {
+        val body = post(
+            url = GoogleRoutes.COMPUTE_ROUTES_URL,
+            body = GoogleRoutes.computeRoutesBody(points),
+            headers = mapOf(
+                "X-Goog-Api-Key" to apiKey,
+                "X-Goog-FieldMask" to GoogleRoutes.FIELD_MASK,
+            ),
+        )
+        body?.let(GoogleRoutes::parseLegs)
+    }
+}
+
+/**
+ * Open-Meteo's elevation service (Copernicus DEM GLO-90). Not Google's Elevation API,
+ * whose policies forbid storing the result — see `domain/Elevation`.
+ */
+class ElevationService {
+
+    /** One height per point, in order, or null if the call did not come back. */
+    suspend fun heights(points: List<LatLng>): List<Double>? = withContext(Dispatchers.IO) {
+        get(Elevation.url(points))?.let(Elevation::parse)?.takeIf { it.isNotEmpty() }
+    }
+}
+
+// Fail-soft like the Places path: every failure mode — offline, timeout, 4xx, junk body
+// — collapses to null, and the caller falls back to straight lines.
+
+private fun post(url: String, body: String, headers: Map<String, String>): String? = runCatching {
+    val connection = open(url, headers).apply {
+        requestMethod = "POST"
+        doOutput = true
+        setRequestProperty("Content-Type", "application/json")
+    }
+    try {
+        connection.outputStream.use { it.write(body.toByteArray()) }
+        connection.readBodyIfOk()
+    } finally {
+        connection.disconnect()
+    }
+}.getOrNull()
+
+private fun get(url: String): String? = runCatching {
+    val connection = open(url, emptyMap())
+    try {
+        connection.readBodyIfOk()
+    } finally {
+        connection.disconnect()
+    }
+}.getOrNull()
+
+private fun open(url: String, headers: Map<String, String>) =
+    (URL(url).openConnection() as HttpURLConnection).apply {
+        connectTimeout = 5_000
+        readTimeout = 10_000
+        headers.forEach { (name, value) -> setRequestProperty(name, value) }
+        setRequestProperty("User-Agent", "CamperExperience/${BuildConfig.VERSION_NAME}")
+    }
+
+private fun HttpURLConnection.readBodyIfOk(): String? =
+    if (responseCode != HttpURLConnection.HTTP_OK) null
+    else inputStream.bufferedReader().use { it.readText() }

--- a/app/src/main/java/com/nuelto/camperexperience/ui/Format.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/Format.kt
@@ -45,13 +45,9 @@ fun formatDuration(seconds: Int): String {
 }
 
 /**
- * The drive that arrives at a stop: "124 km · 1 h 45 min", plus the climb when there is
- * enough of it to be worth a driver's attention.
+ * The drive that arrives at a stop: "124 km · 1 h 45 min". Deliberately not the leg's
+ * climb — cumulative ascent next to a place name reads as the height of the place, which
+ * is a different number and the one people actually want.
  */
-fun formatDrive(leg: StopLeg): String {
-    val climb = leg.ascentMeters?.takeIf { it >= CLIMB_WORTH_MENTIONING_M }?.let { " · ↑ $it m" }
-    return "${formatDistance(leg.distanceMeters)} · ${formatDuration(leg.durationSeconds)}" +
-        climb.orEmpty()
-}
-
-private const val CLIMB_WORTH_MENTIONING_M = 200
+fun formatDrive(leg: StopLeg): String =
+    "${formatDistance(leg.distanceMeters)} · ${formatDuration(leg.durationSeconds)}"

--- a/app/src/main/java/com/nuelto/camperexperience/ui/Format.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/Format.kt
@@ -5,8 +5,10 @@ import com.nuelto.camperexperience.data.model.Trip
 import com.nuelto.camperexperience.data.model.TripStatus
 import java.text.NumberFormat
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
+import java.time.temporal.ChronoUnit
 import java.util.Currency
 import kotlin.math.roundToInt
 
@@ -52,6 +54,29 @@ fun formatDuration(seconds: Int): String {
 fun formatDrive(leg: StopLeg): String =
     "${formatDistance(leg.distanceMeters)} · ${formatDuration(leg.durationSeconds)}"
 
-/** The live drive to the stop you are heading for: "47 km · 55 min from here". */
-fun formatDriveFromHere(distanceMeters: Int, durationSeconds: Int): String =
-    "${formatDistance(distanceMeters)} · ${formatDuration(durationSeconds)} from here"
+private val timeFormatter: DateTimeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
+
+/**
+ * When you get there if you set off now. Names the day too once the drive crosses
+ * midnight — "arrive 04:12" on its own would read as four hours ago.
+ */
+fun formatArrival(durationSeconds: Int, now: LocalDateTime): String {
+    // Rounded to the minute exactly as formatDuration rounds, or the same line would say
+    // "2 min" and then an arrival one minute earlier than that.
+    val arrival = now.plusMinutes((durationSeconds / 60.0).roundToInt().toLong())
+    val days = ChronoUnit.DAYS.between(now.toLocalDate(), arrival.toLocalDate())
+    val day = when (days) {
+        0L -> ""
+        1L -> " tomorrow"
+        else -> " on ${formatDate(arrival.toLocalDate())}"
+    }
+    return "arrive ${arrival.format(timeFormatter)}$day"
+}
+
+/**
+ * The live drive to the stop you are heading for, and when it gets you there:
+ * "47 km · 55 min from here · arrive 16:42".
+ */
+fun formatDriveFromHere(distanceMeters: Int, durationSeconds: Int, now: LocalDateTime): String =
+    "${formatDistance(distanceMeters)} · ${formatDuration(durationSeconds)} from here · " +
+        formatArrival(durationSeconds, now)

--- a/app/src/main/java/com/nuelto/camperexperience/ui/Format.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/Format.kt
@@ -51,3 +51,7 @@ fun formatDuration(seconds: Int): String {
  */
 fun formatDrive(leg: StopLeg): String =
     "${formatDistance(leg.distanceMeters)} · ${formatDuration(leg.durationSeconds)}"
+
+/** The live drive to the stop you are heading for: "47 km · 55 min from here". */
+fun formatDriveFromHere(distanceMeters: Int, durationSeconds: Int): String =
+    "${formatDistance(distanceMeters)} · ${formatDuration(durationSeconds)} from here"

--- a/app/src/main/java/com/nuelto/camperexperience/ui/Format.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/Format.kt
@@ -1,5 +1,6 @@
 package com.nuelto.camperexperience.ui
 
+import com.nuelto.camperexperience.data.model.StopLeg
 import com.nuelto.camperexperience.data.model.Trip
 import com.nuelto.camperexperience.data.model.TripStatus
 import java.text.NumberFormat
@@ -7,6 +8,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.util.Currency
+import kotlin.math.roundToInt
 
 fun formatCurrency(amount: Double, currencyCode: String): String {
     val format = NumberFormat.getCurrencyInstance()
@@ -28,3 +30,28 @@ fun formatTripDates(trip: Trip): String =
     } else {
         formatDateRange(trip.startDate, trip.endDate)
     }
+
+/** Driving distance at the precision a road sign uses — nobody plans in metres. */
+fun formatDistance(meters: Int): String =
+    if (meters < 1_000) "$meters m" else "${(meters / 1000.0).roundToInt()} km"
+
+fun formatDuration(seconds: Int): String {
+    val minutes = (seconds / 60.0).roundToInt()
+    return when {
+        minutes < 60 -> "$minutes min"
+        minutes % 60 == 0 -> "${minutes / 60} h"
+        else -> "${minutes / 60} h ${minutes % 60} min"
+    }
+}
+
+/**
+ * The drive that arrives at a stop: "124 km · 1 h 45 min", plus the climb when there is
+ * enough of it to be worth a driver's attention.
+ */
+fun formatDrive(leg: StopLeg): String {
+    val climb = leg.ascentMeters?.takeIf { it >= CLIMB_WORTH_MENTIONING_M }?.let { " · ↑ $it m" }
+    return "${formatDistance(leg.distanceMeters)} · ${formatDuration(leg.durationSeconds)}" +
+        climb.orEmpty()
+}
+
+private const val CLIMB_WORTH_MENTIONING_M = 200

--- a/app/src/main/java/com/nuelto/camperexperience/ui/map/GoogleMapProvider.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/map/GoogleMapProvider.kt
@@ -30,7 +30,11 @@ import com.nuelto.camperexperience.data.TripRepository
 import com.nuelto.camperexperience.domain.PlaceCacheSweeper
 import com.nuelto.camperexperience.domain.PlaceSearch
 import com.nuelto.camperexperience.domain.PlaceSuggestion
+import com.nuelto.camperexperience.domain.Elevation
+import com.nuelto.camperexperience.domain.RouteRefresher
+import com.nuelto.camperexperience.location.ElevationService
 import com.nuelto.camperexperience.location.GooglePlacesSearch
+import com.nuelto.camperexperience.location.GoogleRoutesService
 import com.nuelto.camperexperience.ui.theme.accentColor
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -45,11 +49,18 @@ private fun LatLng.gms() = GmsLatLng(latitude, longitude)
  */
 object GoogleMapProvider : MapProvider {
 
-    override val attribution = "Map data and places © Google"
+    // Copernicus is separate from Google and its licence asks to be named.
+    override val attribution = "Map data, places and routes © Google · ${Elevation.ATTRIBUTION}"
 
     override fun placeSearch(): PlaceSearch = GooglePlacesSearch()
 
     override suspend fun photo(handle: String): ByteArray? = GooglePlacesSearch().photo(handle)
+
+    override fun routeRefresher(tripRepository: TripRepository): RouteRefresher {
+        val routes = GoogleRoutesService()
+        val elevation = ElevationService()
+        return RouteRefresher(tripRepository, routes::legs, elevation::heights)
+    }
 
     override fun placeCacheSweeper(tripRepository: TripRepository): PlaceCacheSweeper {
         val places = GooglePlacesSearch()

--- a/app/src/main/java/com/nuelto/camperexperience/ui/map/GoogleMapProvider.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/map/GoogleMapProvider.kt
@@ -32,6 +32,7 @@ import com.nuelto.camperexperience.domain.PlaceSearch
 import com.nuelto.camperexperience.domain.PlaceSuggestion
 import com.nuelto.camperexperience.domain.Elevation
 import com.nuelto.camperexperience.domain.RouteRefresher
+import com.nuelto.camperexperience.domain.RoutedLeg
 import com.nuelto.camperexperience.location.ElevationService
 import com.nuelto.camperexperience.location.GooglePlacesSearch
 import com.nuelto.camperexperience.location.GoogleRoutesService
@@ -55,6 +56,9 @@ object GoogleMapProvider : MapProvider {
     override fun placeSearch(): PlaceSearch = GooglePlacesSearch()
 
     override suspend fun photo(handle: String): ByteArray? = GooglePlacesSearch().photo(handle)
+
+    override suspend fun drive(from: LatLng, to: LatLng): RoutedLeg? =
+        GoogleRoutesService().legs(listOf(from, to))?.singleOrNull()
 
     override fun routeRefresher(tripRepository: TripRepository): RouteRefresher {
         val routes = GoogleRoutesService()

--- a/app/src/main/java/com/nuelto/camperexperience/ui/map/MapProvider.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/map/MapProvider.kt
@@ -13,6 +13,7 @@ import com.nuelto.camperexperience.domain.MapRoute
 import com.nuelto.camperexperience.data.TripRepository
 import com.nuelto.camperexperience.domain.PlaceCacheSweeper
 import com.nuelto.camperexperience.domain.PlaceSearch
+import com.nuelto.camperexperience.domain.RoutedLeg
 import com.nuelto.camperexperience.domain.RouteRefresher
 import com.nuelto.camperexperience.domain.PlaceSuggestion
 
@@ -50,6 +51,12 @@ interface MapProvider {
      * means this provider cannot route, and the map falls back to straight lines.
      */
     fun routeRefresher(tripRepository: TripRepository): RouteRefresher? = null
+
+    /**
+     * One drive between two points, for the live "how far is it from here". Separate from
+     * [routeRefresher] because the answer is never stored: it is true for one GPS fix.
+     */
+    suspend fun drive(from: LatLng, to: LatLng): RoutedLeg? = null
 
     /**
      * Loads a photo handed out by [PlaceDetails.photo], as encoded bytes — decoding is

--- a/app/src/main/java/com/nuelto/camperexperience/ui/map/MapProvider.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/map/MapProvider.kt
@@ -13,6 +13,7 @@ import com.nuelto.camperexperience.domain.MapRoute
 import com.nuelto.camperexperience.data.TripRepository
 import com.nuelto.camperexperience.domain.PlaceCacheSweeper
 import com.nuelto.camperexperience.domain.PlaceSearch
+import com.nuelto.camperexperience.domain.RouteRefresher
 import com.nuelto.camperexperience.domain.PlaceSuggestion
 
 /**
@@ -43,6 +44,12 @@ interface MapProvider {
      * results are ours to keep, so nothing ever has to be swept.
      */
     fun placeCacheSweeper(tripRepository: TripRepository): PlaceCacheSweeper? = null
+
+    /**
+     * Road-following geometry, distance and driving time between a trip's stops. Null
+     * means this provider cannot route, and the map falls back to straight lines.
+     */
+    fun routeRefresher(tripRepository: TripRepository): RouteRefresher? = null
 
     /**
      * Loads a photo handed out by [PlaceDetails.photo], as encoded bytes — decoding is

--- a/app/src/main/java/com/nuelto/camperexperience/ui/map/TripMap.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/map/TripMap.kt
@@ -2,6 +2,7 @@ package com.nuelto.camperexperience.ui.map
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import com.nuelto.camperexperience.domain.MapOverlay
 import com.nuelto.camperexperience.domain.TripMapData
@@ -20,16 +21,23 @@ fun TripMap(
 ) {
     val provider = LocalMapProvider.current
     val camera = provider.rememberCamera(start = null, zoom = DEFAULT_ZOOM)
-    val markers = MapOverlay.markers(data)
+    // Remembered: routes() decodes a polyline per leg, which is not work for every
+    // recomposition of a screen that also scrolls.
+    val markers = remember(data) { MapOverlay.markers(data) }
+    val routes = remember(data) { MapOverlay.routes(data) }
 
     if (fitToStops) {
-        LaunchedEffect(markers) { camera.apply(MapOverlay.frame(markers.map { it.at })) }
+        // Route vertices too, or a detour that bulges outside the box the stops make
+        // gets framed off-screen.
+        LaunchedEffect(markers, routes) {
+            camera.apply(MapOverlay.frame(markers.map { it.at } + routes.flatMap { it.points }))
+        }
     }
 
     provider.Canvas(
         camera = camera,
         markers = markers,
-        routes = MapOverlay.routes(data),
+        routes = routes,
         modifier = modifier,
         onMarkerClick = onStopClick?.let { click -> { tripId, stopId -> click(tripId, stopId); true } },
     )

--- a/app/src/main/java/com/nuelto/camperexperience/ui/nav/AppNavHost.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/nav/AppNavHost.kt
@@ -15,6 +15,7 @@ import com.nuelto.camperexperience.ui.map.AllTripsMapScreen
 import com.nuelto.camperexperience.ui.map.LocationPickerScreen
 import com.nuelto.camperexperience.ui.map.LocationSection
 import com.nuelto.camperexperience.ui.settings.SettingsScreen
+import com.nuelto.camperexperience.ui.settings.SettingsViewModel
 import com.nuelto.camperexperience.ui.tripdetail.TripDetailScreen
 import com.nuelto.camperexperience.ui.tripedit.StopEditScreen
 import com.nuelto.camperexperience.ui.tripedit.StopEditViewModel
@@ -126,8 +127,40 @@ fun AppNavHost() {
                 onCancel = { navController.popBackStack() },
             )
         }
-        composable<SettingsRoute> {
-            SettingsScreen(onBack = { navController.popBackStack() })
+        composable<SettingsRoute> { backStackEntry ->
+            val viewModel: SettingsViewModel = viewModel(factory = SettingsViewModel.Factory)
+            // Home comes back from the picker the same way a stop's location does.
+            val picked by backStackEntry.savedStateHandle
+                .getStateFlow<DoubleArray?>(PICKED_LOCATION_KEY, null)
+                .collectAsStateWithLifecycle()
+            LaunchedEffect(picked) {
+                picked?.let { (lat, lon) ->
+                    val place = backStackEntry.savedStateHandle.get<Array<String>>(PICKED_PLACE_KEY)
+                    viewModel.setHome(LatLng(lat, lon), place?.getOrNull(0).orEmpty())
+                    backStackEntry.savedStateHandle[PICKED_LOCATION_KEY] = null
+                    backStackEntry.savedStateHandle[PICKED_PLACE_KEY] = null
+                }
+            }
+            val settings by viewModel.settings.collectAsStateWithLifecycle()
+            SettingsScreen(
+                onBack = { navController.popBackStack() },
+                viewModel = viewModel,
+                locationSection = {
+                    LocationSection(
+                        onLocationChange = { viewModel.setHome(it) },
+                        onPickOnMap = {
+                            val start = settings?.homeLocation
+                            navController.navigate(
+                                LocationPickerRoute(
+                                    start?.latitude,
+                                    start?.longitude,
+                                    StopKind.HOME.name,
+                                ),
+                            )
+                        },
+                    )
+                },
+            )
         }
     }
 }

--- a/app/src/main/java/com/nuelto/camperexperience/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/settings/SettingsScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TextButton
+import com.nuelto.camperexperience.data.model.LatLng
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -33,7 +35,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewModelScope
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.nuelto.camperexperience.BuildConfig
 import com.nuelto.camperexperience.containerViewModelFactory
 import com.nuelto.camperexperience.data.AuthRepository
@@ -60,6 +61,26 @@ class SettingsViewModel(
         viewModelScope.launch { settingsRepository.update(settings) }
     }
 
+    /** Sets home from the picker or a GPS fix; an unnamed pick keeps the name it had. */
+    fun setHome(location: LatLng, name: String = "") {
+        val current = settings.value ?: return
+        viewModelScope.launch {
+            settingsRepository.update(
+                current.copy(
+                    homeLocation = location,
+                    homeName = name.ifBlank { current.homeName },
+                ),
+            )
+        }
+    }
+
+    fun clearHome() {
+        val current = settings.value ?: return
+        viewModelScope.launch {
+            settingsRepository.update(current.copy(homeLocation = null, homeName = ""))
+        }
+    }
+
     fun signOut() {
         authRepository?.signOut()
     }
@@ -77,7 +98,12 @@ private val commonCurrencies = listOf("CHF", "EUR", "USD", "GBP", "NOK", "SEK", 
 @Composable
 fun SettingsScreen(
     onBack: () -> Unit,
-    viewModel: SettingsViewModel = viewModel(factory = SettingsViewModel.Factory),
+    // No factory default: the nav layer owns the instance to feed it picker results,
+    // the same reason StopEditScreen has none.
+    viewModel: SettingsViewModel,
+    // Injected by the nav layer, exactly as the stop editor's is: GPS, search and
+    // pick-on-map all live behind the map provider.
+    locationSection: @Composable () -> Unit = {},
 ) {
     val settings by viewModel.settings.collectAsStateWithLifecycle()
 
@@ -106,6 +132,25 @@ fun SettingsScreen(
                 selected = current.currency,
                 onSelect = { viewModel.update(current.copy(currency = it)) },
             )
+
+            Text("Home", style = MaterialTheme.typography.titleMedium)
+            OutlinedTextField(
+                value = current.homeName,
+                onValueChange = { viewModel.update(current.copy(homeName = it)) },
+                label = { Text("Name") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Text(
+                current.homeLocation?.let { "Set — new plans start here." }
+                    ?: "Not set. Pick it below and new plans will start from it.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            locationSection()
+            if (current.homeLocation != null) {
+                TextButton(onClick = viewModel::clearHome) { Text("Clear home") }
+            }
 
             Text("Fuel estimator defaults", style = MaterialTheme.typography.titleMedium)
             NumberSetting(

--- a/app/src/main/java/com/nuelto/camperexperience/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/settings/SettingsScreen.kt
@@ -127,8 +127,21 @@ fun SettingsScreen(
                 onCommit = { viewModel.update(current.copy(roadDistanceFactor = it)) },
             )
             Text(
-                "The estimator prefills trip distance as straight-line distance between " +
-                    "stops multiplied by this factor.",
+                "Distance comes from the road Google routes between stops. This factor " +
+                    "only fills in for legs with no route yet — no map key, or no signal " +
+                    "when they were added.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            NumberSetting(
+                label = "Vehicle weight",
+                suffix = "kg",
+                value = current.vehicleMassKg,
+                onCommit = { viewModel.update(current.copy(vehicleMassKg = it)) },
+            )
+            Text(
+                "Used to price the climbing on a route: lifting the van over a pass costs " +
+                    "fuel the flat-road consumption above does not account for.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/ExpenseEditSheet.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/ExpenseEditSheet.kt
@@ -35,6 +35,7 @@ import com.nuelto.camperexperience.ui.components.parseDecimal
 import com.nuelto.camperexperience.ui.formatCurrency
 import java.time.LocalDate
 import java.util.Locale
+import kotlin.math.abs
 
 /**
  * Bottom sheet for creating/editing an expense. When type is FUEL an expandable
@@ -141,28 +142,60 @@ private fun FuelEstimatorSection(
     settings: UserSettings,
     onUseAmount: (Double) -> Unit,
 ) {
+    val routedKm = remember(stops, settings) { FuelEstimator.defaultTripDistanceKm(stops, settings) }
     var distance by remember {
-        val prefill = FuelEstimator.defaultTripDistanceKm(stops, settings)
-        mutableStateOf(if (prefill > 0) String.format(Locale.ROOT, "%.0f", prefill) else "")
+        mutableStateOf(if (routedKm > 0) String.format(Locale.ROOT, "%.0f", routedKm) else "")
     }
+    // What the climbing adds on top of the flat-road figure. Shown, not folded into the
+    // distance — the distance field has to stay something the user can recognise.
+    val tripClimbLiters = remember(stops, settings) { FuelEstimator.climbLiters(stops, settings) }
     var consumption by remember { mutableStateOf(settings.fuelConsumptionL100km.toString()) }
     var price by remember { mutableStateOf(settings.fuelPricePerLiter.toString()) }
 
+    val entered = parseDecimal(distance)
+    // The climb belongs to the routed drive, so price only the share of it the user kept.
+    // Otherwise shortening the distance leaves the whole trip's climbing on a fraction of
+    // it — and on a net-descent trip the credit would swamp what is left.
+    val climbLiters =
+        if (routedKm > 0 && entered != null) tripClimbLiters * entered / routedKm else 0.0
+
     val estimated = run {
-        val d = parseDecimal(distance)
         val c = parseDecimal(consumption)
         val p = parseDecimal(price)
-        if (d != null && c != null && p != null) FuelEstimator.estimateCost(d, c, p) else null
+        if (entered != null && c != null && p != null) {
+            // Floored: the descent credit was capped against the consumption in Settings,
+            // so a much lower figure typed here could otherwise turn the estimate negative
+            // and save a negative fuel expense.
+            (FuelEstimator.estimateCost(entered, c, p) + climbLiters * p).coerceAtLeast(0.0)
+        } else {
+            null
+        }
     }
 
     Card(Modifier.fillMaxWidth()) {
         Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Text("Fuel estimate", style = MaterialTheme.typography.titleSmall)
             Text(
-                "Distance is prefilled from the stops (straight line × road factor) — adjust to your real route.",
+                "Distance is prefilled from the stops — the road Google routed where there " +
+                    "is one, straight line × road factor where there isn't. Adjust to your " +
+                    "real route.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+            // Both directions are worth saying: a descent that pays some fuel back is just
+            // as surprising as a climb that costs extra.
+            val climbNote = when {
+                climbLiters > 0 -> "Plus %.1f l for the climbing on the way."
+                climbLiters < 0 -> "Less %.1f l, given back on the way down."
+                else -> null
+            }
+            if (climbNote != null) {
+                Text(
+                    String.format(Locale.ROOT, climbNote, abs(climbLiters)),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
             DecimalField(label = "Distance", value = distance, onValueChange = { distance = it }, suffix = "km")
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 DecimalField(

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/ExpenseEditSheet.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/ExpenseEditSheet.kt
@@ -3,6 +3,7 @@ package com.nuelto.camperexperience.ui.tripdetail
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -64,6 +65,9 @@ fun ExpenseEditSheet(
         Column(
             modifier = Modifier
                 .verticalScroll(rememberScrollState())
+                // The sheet reaches the window edge; its Save button must not sit under
+                // the navigation bar. A no-op where the sheet already consumed the inset.
+                .navigationBarsPadding()
                 .padding(horizontal = 16.dp)
                 .padding(bottom = 24.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreen.kt
@@ -88,6 +88,7 @@ import com.nuelto.camperexperience.data.model.StopState
 import com.nuelto.camperexperience.data.model.TripStatus
 import com.nuelto.camperexperience.data.model.UserSettings
 import com.nuelto.camperexperience.domain.TripMapData
+import com.nuelto.camperexperience.domain.Elevation
 import com.nuelto.camperexperience.domain.GapRow
 import com.nuelto.camperexperience.domain.StopRow
 import com.nuelto.camperexperience.domain.TripEstimator
@@ -531,7 +532,11 @@ private fun NowCard(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(stop.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text(
+                    stop.name + altitudeSuffix(stop),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
                 if (stop.kind != StopKind.VISIT) {
                     Text(
                         stopPriceText(stop, TripStatus.ACTIVE, settings),
@@ -723,7 +728,7 @@ private fun StopDot(stop: Stop, tripStatus: TripStatus) {
 
 private fun stopMetaText(stop: Stop, tripStatus: TripStatus, settings: UserSettings): String {
     val date = formatDate(stop.arrivalDate)
-    return when {
+    val meta = when {
         stop.state == StopState.SKIPPED -> "skipped"
         stop.kind == StopKind.VISIT -> "$date · visit"
         else -> {
@@ -731,7 +736,12 @@ private fun stopMetaText(stop: Stop, tripStatus: TripStatus, settings: UserSetti
             "$date · $nights · ${stopPriceText(stop, tripStatus, settings)}"
         }
     }
+    return meta + altitudeSuffix(stop)
 }
+
+/** How high the place is, the way a Swiss village sign gives it. */
+private fun altitudeSuffix(stop: Stop): String =
+    Elevation.ofStop(stop)?.let { " · $it m" }.orEmpty()
 
 /** An unpriced stay on a live trip shows what the default rate would charge. */
 private fun stopPriceText(stop: Stop, tripStatus: TripStatus, settings: UserSettings): String =

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreen.kt
@@ -126,6 +126,7 @@ import com.nuelto.camperexperience.ui.theme.ActiveGreen
 import com.nuelto.camperexperience.ui.theme.PlannedBlue
 import com.nuelto.camperexperience.ui.theme.stopColor
 import java.time.LocalDate
+import java.time.LocalDateTime
 import kotlinx.coroutines.launch
 
 val ExpenseType.displayName: String
@@ -587,11 +588,19 @@ private fun NowCard(
             // live distance replaces the planned leg rather than sitting beside it.
             when {
                 fromHere != null && fromHere.to == stop.location -> Text(
-                    formatDriveFromHere(fromHere.distanceMeters, fromHere.durationSeconds),
+                    // "now" is read at composition: opening the trip gives a current
+                    // answer, and every state change refreshes it. It does not tick on
+                    // its own — an endless timer in a LaunchedEffect would leave the
+                    // Compose test clock permanently busy.
+                    formatDriveFromHere(
+                        fromHere.distanceMeters,
+                        fromHere.durationSeconds,
+                        LocalDateTime.now(),
+                    ),
                     style = MaterialTheme.typography.labelSmall,
                     color = ActiveGreen,
                 )
-                onLocate != null && stop.location != null -> Text(
+                onLocate != null && stop.location != null && stop.state != StopState.DONE -> Text(
                     "Show distance from here",
                     style = MaterialTheme.typography.labelSmall,
                     color = ActiveGreen,

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material.icons.filled.Terrain
 import androidx.compose.material.icons.filled.RvHookup
 import androidx.compose.material.icons.filled.PhotoCamera
 import androidx.compose.material.icons.filled.Forest
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Festival
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.KeyboardArrowDown
@@ -101,6 +102,7 @@ import com.nuelto.camperexperience.data.model.Expense
 import com.nuelto.camperexperience.data.model.ExpenseType
 import com.nuelto.camperexperience.data.model.Stop
 import com.nuelto.camperexperience.data.model.StopKind
+import com.nuelto.camperexperience.data.model.isStay
 import com.nuelto.camperexperience.data.model.StopLeg
 import com.nuelto.camperexperience.data.model.StopState
 import com.nuelto.camperexperience.data.model.TripStatus
@@ -420,7 +422,7 @@ fun TripDetailScreen(
                             onChangeNights = { delta -> viewModel.changeNights(row.stop.id, delta) },
                             onArrived = {
                                 viewModel.arrived(row.stop.id)
-                                if (row.stop.kind != StopKind.VISIT) arrivalPromptStop = row.stop
+                                if (row.stop.kind.isStay) arrivalPromptStop = row.stop
                             },
                             onSkip = { skipWithUndo(row.stop) },
                         )
@@ -579,7 +581,7 @@ private fun NowCard(
     ) {
         Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
             Text(
-                if (stop.kind == StopKind.VISIT) "NEXT" else "TONIGHT",
+                if (stop.kind.isStay) "TONIGHT" else "NEXT",
                 style = MaterialTheme.typography.labelSmall,
                 color = ActiveGreen,
                 fontWeight = FontWeight.Bold,
@@ -629,14 +631,14 @@ private fun NowCard(
                     )
                     ElevationBadge(stop)
                 }
-                if (stop.kind != StopKind.VISIT) {
+                if (stop.kind.isStay) {
                     Text(
                         stopPriceText(stop, TripStatus.ACTIVE, settings),
                         style = MaterialTheme.typography.titleSmall,
                     )
                 }
             }
-            if (stop.kind != StopKind.VISIT) {
+            if (stop.kind.isStay) {
                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
                     Text(
                         "${formatDate(stop.arrivalDate)} ·",
@@ -833,6 +835,7 @@ private fun kindIcon(kind: StopKind): ImageVector = when (kind) {
     StopKind.STELLPLATZ -> Icons.Default.RvHookup
     StopKind.FREE_CAMP -> Icons.Default.Forest
     StopKind.VISIT -> Icons.Default.PhotoCamera
+    StopKind.HOME -> Icons.Default.Home
 }
 
 /** How high the place is — a mountain, because "1469 m" alone reads as a distance. */
@@ -861,6 +864,7 @@ private fun stopMetaText(stop: Stop, tripStatus: TripStatus, settings: UserSetti
     val date = formatDate(stop.arrivalDate)
     return when {
         stop.state == StopState.SKIPPED -> "skipped"
+        stop.kind == StopKind.HOME -> "$date · start"
         stop.kind == StopKind.VISIT -> "$date · visit"
         else -> {
             val nights = if (stop.nights == 1) "1 night" else "${stop.nights} nights"

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreen.kt
@@ -3,7 +3,6 @@ package com.nuelto.camperexperience.ui.tripdetail
 import android.content.Intent
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -20,13 +19,17 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DragHandle
+import androidx.compose.material.icons.filled.Terrain
+import androidx.compose.material.icons.filled.RvHookup
+import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material.icons.filled.Forest
+import androidx.compose.material.icons.filled.Festival
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
@@ -69,6 +72,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontStyle
@@ -101,6 +105,7 @@ import com.nuelto.camperexperience.ui.components.reorderable
 import com.nuelto.camperexperience.ui.formatCurrency
 import com.nuelto.camperexperience.ui.formatDate
 import com.nuelto.camperexperience.ui.formatDrive
+import com.nuelto.camperexperience.ui.tripedit.displayName
 import com.nuelto.camperexperience.ui.formatTripDates
 import com.nuelto.camperexperience.ui.map.TripMap
 import com.nuelto.camperexperience.ui.theme.ActiveGreen
@@ -529,14 +534,25 @@ private fun NowCard(
             DriveLine(leg)
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(
-                    stop.name + altitudeSuffix(stop),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                )
+                StopDot(stop, TripStatus.ACTIVE)
+                // Weighted, so the price stays pinned to the right edge; the name inside
+                // is not, so the height badge sits against the name rather than drifting.
+                Row(
+                    verticalAlignment = Alignment.Bottom,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(
+                        stop.name,
+                        modifier = Modifier.weight(1f, fill = false),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    ElevationBadge(stop)
+                }
                 if (stop.kind != StopKind.VISIT) {
                     Text(
                         stopPriceText(stop, TripStatus.ACTIVE, settings),
@@ -661,11 +677,20 @@ private fun TimelineStopRow(
             StopDot(stop, tripStatus)
             Column(Modifier.weight(1f)) {
                 DriveLine(leg)
-                Text(
-                    stop.name,
-                    style = MaterialTheme.typography.titleSmall,
-                    textDecoration = if (stop.state == StopState.SKIPPED) TextDecoration.LineThrough else null,
-                )
+                Row(
+                    verticalAlignment = Alignment.Bottom,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    Text(
+                        stop.name,
+                        // fill = false so the height sits against the name, not out at
+                        // the far edge; unweighted, the badge keeps its width first.
+                        modifier = Modifier.weight(1f, fill = false),
+                        style = MaterialTheme.typography.titleSmall,
+                        textDecoration = if (stop.state == StopState.SKIPPED) TextDecoration.LineThrough else null,
+                    )
+                    ElevationBadge(stop)
+                }
                 Text(
                     stopMetaText(stop, tripStatus, settings),
                     style = MaterialTheme.typography.bodyMedium,
@@ -708,7 +733,10 @@ private fun DriveLine(leg: StopLeg?) {
     )
 }
 
-/** Blue = upcoming, green = current, grey = done/skipped; visits are hollow. */
+/**
+ * What the spot is, in the lifecycle colour: blue = upcoming, green = current,
+ * grey = done/skipped. Shape says the kind, colour says where it is in the trip.
+ */
 @Composable
 private fun StopDot(stop: Stop, tripStatus: TripStatus) {
     val color = if (tripStatus == TripStatus.DONE) {
@@ -716,19 +744,46 @@ private fun StopDot(stop: Stop, tripStatus: TripStatus) {
     } else {
         stopColor(stop.state, isCurrent = false)
     }
-    val dot = Modifier.size(12.dp).clip(CircleShape)
-    Box(
-        if (stop.kind == StopKind.VISIT) {
-            dot.border(2.dp, color, CircleShape)
-        } else {
-            dot.background(color)
-        },
+    Icon(
+        kindIcon(stop.kind),
+        contentDescription = stop.kind.displayName,
+        modifier = Modifier.size(18.dp),
+        tint = color,
     )
+}
+
+private fun kindIcon(kind: StopKind): ImageVector = when (kind) {
+    StopKind.CAMPSITE -> Icons.Default.Festival
+    StopKind.STELLPLATZ -> Icons.Default.RvHookup
+    StopKind.FREE_CAMP -> Icons.Default.Forest
+    StopKind.VISIT -> Icons.Default.PhotoCamera
+}
+
+/** How high the place is — a mountain, because "1469 m" alone reads as a distance. */
+@Composable
+private fun ElevationBadge(stop: Stop) {
+    val meters = Elevation.ofStop(stop) ?: return
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Icon(
+            Icons.Default.Terrain,
+            contentDescription = "Height above sea level",
+            modifier = Modifier.size(13.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            "$meters m",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
 }
 
 private fun stopMetaText(stop: Stop, tripStatus: TripStatus, settings: UserSettings): String {
     val date = formatDate(stop.arrivalDate)
-    val meta = when {
+    return when {
         stop.state == StopState.SKIPPED -> "skipped"
         stop.kind == StopKind.VISIT -> "$date · visit"
         else -> {
@@ -736,12 +791,7 @@ private fun stopMetaText(stop: Stop, tripStatus: TripStatus, settings: UserSetti
             "$date · $nights · ${stopPriceText(stop, tripStatus, settings)}"
         }
     }
-    return meta + altitudeSuffix(stop)
 }
-
-/** How high the place is, the way a Swiss village sign gives it. */
-private fun altitudeSuffix(stop: Stop): String =
-    Elevation.ofStop(stop)?.let { " · $it m" }.orEmpty()
 
 /** An unpriced stay on a live trip shows what the default rate would charge. */
 private fun stopPriceText(stop: Stop, tripStatus: TripStatus, settings: UserSettings): String =

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreen.kt
@@ -10,6 +10,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -489,7 +495,16 @@ private fun TimelineBottomBar(
 ) {
     Surface(shadowElevation = 8.dp) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                // Inside the Surface, so its background still fills the gesture area while
+                // the total and the button sit above the navigation bar. The app is
+                // edge-to-edge (enableEdgeToEdge + targetSdk 36), and Scaffold does not
+                // inset a bottom bar for you — it places it flush with the window.
+                .windowInsetsPadding(
+                    WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom),
+                )
+                .padding(horizontal = 16.dp, vertical = 10.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -811,7 +826,8 @@ private fun StartTourSheet(
     var keepPlan by remember { mutableStateOf(true) }
     ModalBottomSheet(onDismissRequest = onDismiss) {
         Column(
-            Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, bottom = 32.dp),
+            Modifier.fillMaxWidth().navigationBarsPadding()
+                .padding(start = 16.dp, end = 16.dp, bottom = 32.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Text("Start this tour", style = MaterialTheme.typography.titleLarge)
@@ -851,7 +867,8 @@ private fun ArrivalPriceSheet(
     var priceText by remember { mutableStateOf("") }
     ModalBottomSheet(onDismissRequest = onDismiss) {
         Column(
-            Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, bottom = 32.dp),
+            Modifier.fillMaxWidth().navigationBarsPadding()
+                .padding(start = 16.dp, end = 16.dp, bottom = 32.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Text("Arrived at ${stop.name}", style = MaterialTheme.typography.titleLarge)

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreen.kt
@@ -83,6 +83,7 @@ import com.nuelto.camperexperience.data.model.Expense
 import com.nuelto.camperexperience.data.model.ExpenseType
 import com.nuelto.camperexperience.data.model.Stop
 import com.nuelto.camperexperience.data.model.StopKind
+import com.nuelto.camperexperience.data.model.StopLeg
 import com.nuelto.camperexperience.data.model.StopState
 import com.nuelto.camperexperience.data.model.TripStatus
 import com.nuelto.camperexperience.data.model.UserSettings
@@ -98,6 +99,7 @@ import com.nuelto.camperexperience.ui.components.rememberReorderState
 import com.nuelto.camperexperience.ui.components.reorderable
 import com.nuelto.camperexperience.ui.formatCurrency
 import com.nuelto.camperexperience.ui.formatDate
+import com.nuelto.camperexperience.ui.formatDrive
 import com.nuelto.camperexperience.ui.formatTripDates
 import com.nuelto.camperexperience.ui.map.TripMap
 import com.nuelto.camperexperience.ui.theme.ActiveGreen
@@ -365,6 +367,7 @@ fun TripDetailScreen(
                     is StopRow -> if (row.stop.id == state.currentStopId) {
                         NowCard(
                             stop = row.stop,
+                            leg = state.drives[row.stop.id],
                             settings = state.settings,
                             onClick = { onEditStop(trip.id, row.stop.id) },
                             onChangeNights = { delta -> viewModel.changeNights(row.stop.id, delta) },
@@ -377,6 +380,7 @@ fun TripDetailScreen(
                     } else {
                         TimelineStopRow(
                             stop = row.stop,
+                            leg = state.drives[row.stop.id],
                             tripStatus = trip.status,
                             settings = state.settings,
                             movable = movable,
@@ -502,6 +506,7 @@ private fun TimelineBottomBar(
 @Composable
 private fun NowCard(
     stop: Stop,
+    leg: StopLeg?,
     settings: UserSettings,
     onClick: () -> Unit,
     onChangeNights: (Int) -> Unit,
@@ -520,6 +525,7 @@ private fun NowCard(
                 color = ActiveGreen,
                 fontWeight = FontWeight.Bold,
             )
+            DriveLine(leg)
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -632,6 +638,7 @@ private fun GapCard(
 @Composable
 private fun TimelineStopRow(
     stop: Stop,
+    leg: StopLeg?,
     tripStatus: TripStatus,
     settings: UserSettings,
     movable: Boolean,
@@ -648,6 +655,7 @@ private fun TimelineStopRow(
         ) {
             StopDot(stop, tripStatus)
             Column(Modifier.weight(1f)) {
+                DriveLine(leg)
                 Text(
                     stop.name,
                     style = MaterialTheme.typography.titleSmall,
@@ -679,6 +687,20 @@ private fun TimelineStopRow(
             }
         }
     }
+}
+
+/**
+ * How far and how long the drive to this stop is, as Google routed it. Absent until the
+ * route has been fetched, and while a stop edit has outdated it.
+ */
+@Composable
+private fun DriveLine(leg: StopLeg?) {
+    if (leg == null) return
+    Text(
+        "\u2192 ${formatDrive(leg)}",
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
 }
 
 /** Blue = upcoming, green = current, grey = done/skipped; visits are hollow. */

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreen.kt
@@ -1,6 +1,13 @@
 package com.nuelto.camperexperience.ui.tripdetail
 
 import android.content.Intent
+import com.nuelto.camperexperience.ui.formatDriveFromHere
+import com.nuelto.camperexperience.domain.DriveFromHere
+import androidx.core.content.ContextCompat
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.compose.rememberLauncherForActivityResult
+import android.content.pm.PackageManager
+import android.Manifest
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.border
@@ -69,6 +76,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -178,6 +186,26 @@ fun TripDetailScreen(
             )
             if (result == SnackbarResult.ActionPerformed) viewModel.restore(stop.id)
         }
+    }
+
+    // "How far from here" needs a fix. Asked for on tap rather than on open: a permission
+    // dialog the moment a trip is opened is not a trade the user agreed to.
+    val locationContext = LocalContext.current
+    var locationGranted by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(
+                locationContext,
+                Manifest.permission.ACCESS_FINE_LOCATION,
+            ) == PackageManager.PERMISSION_GRANTED,
+        )
+    }
+    val locationPermission = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted -> locationGranted = granted }
+    // Keyed on the grant too, so answering the dialog is what triggers the first fix —
+    // the launcher callback only has to record it.
+    LaunchedEffect(state.currentStopId, locationGranted) {
+        if (locationGranted) viewModel.refreshDriveFromHere()
     }
 
     Scaffold(
@@ -380,6 +408,12 @@ fun TripDetailScreen(
                         NowCard(
                             stop = row.stop,
                             leg = state.drives[row.stop.id],
+                            fromHere = state.driveFromHere,
+                            onLocate = if (locationGranted) {
+                                null
+                            } else {
+                                { locationPermission.launch(Manifest.permission.ACCESS_FINE_LOCATION) }
+                            },
                             settings = state.settings,
                             onClick = { onEditStop(trip.id, row.stop.id) },
                             onChangeNights = { delta -> viewModel.changeNights(row.stop.id, delta) },
@@ -528,6 +562,9 @@ private fun TimelineBottomBar(
 private fun NowCard(
     stop: Stop,
     leg: StopLeg?,
+    fromHere: DriveFromHere?,
+    // Null once the location permission is held; otherwise, what to call to ask for it.
+    onLocate: (() -> Unit)?,
     settings: UserSettings,
     onClick: () -> Unit,
     onChangeNights: (Int) -> Unit,
@@ -546,7 +583,22 @@ private fun NowCard(
                 color = ActiveGreen,
                 fontWeight = FontWeight.Bold,
             )
-            DriveLine(leg)
+            // Where you are beats where you came from: on the stop you are driving to, the
+            // live distance replaces the planned leg rather than sitting beside it.
+            when {
+                fromHere != null && fromHere.to == stop.location -> Text(
+                    formatDriveFromHere(fromHere.distanceMeters, fromHere.durationSeconds),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = ActiveGreen,
+                )
+                onLocate != null && stop.location != null -> Text(
+                    "Show distance from here",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = ActiveGreen,
+                    modifier = Modifier.clickable(onClick = onLocate),
+                )
+                else -> DriveLine(leg)
+            }
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModel.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModel.kt
@@ -11,6 +11,7 @@ import com.nuelto.camperexperience.data.TripRepository
 import com.nuelto.camperexperience.data.model.Expense
 import com.nuelto.camperexperience.data.model.ExpenseType
 import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.StopLeg
 import com.nuelto.camperexperience.data.model.StopState
 import com.nuelto.camperexperience.data.model.Trip
 import com.nuelto.camperexperience.data.model.TripStatus
@@ -24,6 +25,8 @@ import com.nuelto.camperexperience.domain.FuelEstimator
 import com.nuelto.camperexperience.domain.GapRow
 import com.nuelto.camperexperience.domain.StopRow
 import com.nuelto.camperexperience.domain.PlaceCacheSweeper
+import com.nuelto.camperexperience.domain.RouteCache
+import com.nuelto.camperexperience.domain.RouteRefresher
 import com.nuelto.camperexperience.domain.Timeline
 import com.nuelto.camperexperience.domain.TimelineRow
 import com.nuelto.camperexperience.domain.TripEstimator
@@ -35,6 +38,8 @@ import java.time.temporal.ChronoUnit
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -54,6 +59,9 @@ data class TripDetailUiState(
     val estimate: EstimateBreakdown? = null,
     // First upcoming stop of an ACTIVE trip: tonight's destination.
     val currentStopId: String? = null,
+    // The drive arriving at each stop, keyed by stop id. Only legs that still describe
+    // their drive are in here, so an edit blanks the line rather than lying about it.
+    val drives: Map<String, StopLeg> = emptyMap(),
     val vignetteSuggestions: List<VignetteTable.Choice> = emptyList(),
     val settings: UserSettings = UserSettings(),
     val loading: Boolean = true,
@@ -66,12 +74,27 @@ class TripDetailViewModel(
     // Renews Google Places coordinates that hit their 30-day retention, and deletes the
     // ones it cannot renew. Null when the map provider has no place lookup of its own.
     private val placeCacheSweeper: PlaceCacheSweeper? = null,
+    // Fetches the road between the stops, and drops legs that no longer describe one.
+    // Null when the map provider has no routing of its own — the map draws straight
+    // lines and the estimate falls back to the road-distance factor.
+    private val routeRefresher: RouteRefresher? = null,
 ) : ViewModel() {
 
     private val tripId: String = savedStateHandle.toRoute<TripDetailRoute>().tripId
 
     init {
         placeCacheSweeper?.let { sweeper -> viewModelScope.launch { sweeper.sweep(tripId) } }
+        routeRefresher?.let { refresher ->
+            viewModelScope.launch {
+                // Re-route when the drives themselves change — a stop added, moved,
+                // skipped or re-pinned. Writing the legs back does not change that list,
+                // so this settles instead of chasing its own writes.
+                tripRepository.stops(tripId)
+                    .map { stops -> RouteCache.drives(stops).map { (from, to) -> from.location to to.location } }
+                    .distinctUntilChanged()
+                    .collect { refresher.refresh(tripId) }
+            }
+        }
     }
 
     val uiState: StateFlow<TripDetailUiState> =
@@ -95,6 +118,7 @@ class TripDetailViewModel(
                 } else {
                     null
                 },
+                drives = RouteCache.byStop(stops),
                 vignetteSuggestions = if (planning) vignetteSuggestions(stops, expenses) else emptyList(),
                 settings = settings,
                 loading = false,
@@ -290,6 +314,7 @@ class TripDetailViewModel(
                 container.tripRepository,
                 container.settingsRepository,
                 container.mapProvider.placeCacheSweeper(container.tripRepository),
+                container.mapProvider.routeRefresher(container.tripRepository),
             )
         }
     }

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModel.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModel.kt
@@ -121,6 +121,12 @@ class TripDetailViewModel(
             liveDrive,
         ) { trip, stops, expenses, settings, fromHere ->
             val planning = trip != null && trip.status != TripStatus.DONE
+            val currentId = if (trip?.status == TripStatus.ACTIVE) {
+                CurrentStop.of(stops, LocalDate.now())
+            } else {
+                null
+            }
+            val current = stops.find { it.id == currentId }
             TripDetailUiState(
                 trip = trip,
                 stops = stops,
@@ -129,13 +135,11 @@ class TripDetailViewModel(
                 breakdown = CostCalculator.breakdown(stops, expenses),
                 fuelEstimate = FuelEstimator.autoTripFuelCost(stops, expenses, settings),
                 estimate = if (planning) TripEstimator.estimate(stops, expenses, settings) else null,
-                currentStopId = if (trip?.status == TripStatus.ACTIVE) {
-                    CurrentStop.of(stops, LocalDate.now())
-                } else {
-                    null
-                },
+                currentStopId = currentId,
                 drives = RouteCache.byStop(stops),
-                driveFromHere = fromHere,
+                // Once you have checked in you are there, so how far away it is stops
+                // being a question — whatever the last fix said.
+                driveFromHere = fromHere?.takeIf { current?.state != StopState.DONE },
                 vignetteSuggestions = if (planning) vignetteSuggestions(stops, expenses) else emptyList(),
                 settings = settings,
                 loading = false,
@@ -152,7 +156,10 @@ class TripDetailViewModel(
      */
     fun refreshDriveFromHere() {
         val state = uiState.value
-        val target = state.stops.find { it.id == state.currentStopId }?.location ?: return
+        val stop = state.stops.find { it.id == state.currentStopId } ?: return
+        // No route is worth buying for somewhere you have already arrived.
+        if (stop.state == StopState.DONE) return
+        val target = stop.location ?: return
         if (locating) return
         locating = true
         viewModelScope.launch {

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModel.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModel.kt
@@ -86,11 +86,12 @@ class TripDetailViewModel(
         placeCacheSweeper?.let { sweeper -> viewModelScope.launch { sweeper.sweep(tripId) } }
         routeRefresher?.let { refresher ->
             viewModelScope.launch {
-                // Re-route when the drives themselves change — a stop added, moved,
-                // skipped or re-pinned. Writing the legs back does not change that list,
-                // so this settles instead of chasing its own writes.
+                // Re-run when the pins themselves change — a stop added, moved, skipped
+                // or re-pinned. Every located stop, not just the drives: a lone stop has
+                // no drive but still has a height. Writing legs and heights back does not
+                // change this list, so it settles instead of chasing its own writes.
                 tripRepository.stops(tripId)
-                    .map { stops -> RouteCache.drives(stops).map { (from, to) -> from.location to to.location } }
+                    .map { stops -> RouteCache.routed(stops).map { it.location } }
                     .distinctUntilChanged()
                     .collect { refresher.refresh(tripId) }
             }

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModel.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModel.kt
@@ -8,6 +8,10 @@ import androidx.navigation.toRoute
 import com.nuelto.camperexperience.containerViewModelFactory
 import com.nuelto.camperexperience.data.SettingsRepository
 import com.nuelto.camperexperience.data.TripRepository
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.domain.DriveFromHere
+import com.nuelto.camperexperience.domain.LiveDrive
+import com.nuelto.camperexperience.domain.RoutedLeg
 import com.nuelto.camperexperience.data.model.Expense
 import com.nuelto.camperexperience.data.model.ExpenseType
 import com.nuelto.camperexperience.data.model.Stop
@@ -35,6 +39,7 @@ import com.nuelto.camperexperience.domain.VignetteTable
 import com.nuelto.camperexperience.ui.nav.TripDetailRoute
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -62,6 +67,9 @@ data class TripDetailUiState(
     // The drive arriving at each stop, keyed by stop id. Only legs that still describe
     // their drive are in here, so an edit blanks the line rather than lying about it.
     val drives: Map<String, StopLeg> = emptyMap(),
+    // Live distance to the stop you are heading for, from the last GPS fix. Null until
+    // one is taken, and again once you are there.
+    val driveFromHere: DriveFromHere? = null,
     val vignetteSuggestions: List<VignetteTable.Choice> = emptyList(),
     val settings: UserSettings = UserSettings(),
     val loading: Boolean = true,
@@ -78,6 +86,10 @@ class TripDetailViewModel(
     // Null when the map provider has no routing of its own — the map draws straight
     // lines and the estimate falls back to the road-distance factor.
     private val routeRefresher: RouteRefresher? = null,
+    // One-shot GPS fix; null unless the screen has the location permission.
+    private val currentLocation: suspend () -> LatLng? = { null },
+    // A single route, for "how far is it from here". Never stored — see DriveFromHere.
+    private val drive: suspend (from: LatLng, to: LatLng) -> RoutedLeg? = { _, _ -> null },
 ) : ViewModel() {
 
     private val tripId: String = savedStateHandle.toRoute<TripDetailRoute>().tripId
@@ -98,13 +110,16 @@ class TripDetailViewModel(
         }
     }
 
+    private val liveDrive = MutableStateFlow<DriveFromHere?>(null)
+
     val uiState: StateFlow<TripDetailUiState> =
         combine(
             tripRepository.trip(tripId),
             tripRepository.stops(tripId),
             tripRepository.expenses(tripId),
             settingsRepository.settings(),
-        ) { trip, stops, expenses, settings ->
+            liveDrive,
+        ) { trip, stops, expenses, settings, fromHere ->
             val planning = trip != null && trip.status != TripStatus.DONE
             TripDetailUiState(
                 trip = trip,
@@ -120,11 +135,44 @@ class TripDetailViewModel(
                     null
                 },
                 drives = RouteCache.byStop(stops),
+                driveFromHere = fromHere,
                 vignetteSuggestions = if (planning) vignetteSuggestions(stops, expenses) else emptyList(),
                 settings = settings,
                 loading = false,
             )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), TripDetailUiState())
+
+    // One fix at a time: the screen asks on open and again when the permission lands.
+    private var locating = false
+
+    /**
+     * Takes a GPS fix and asks Google how far the stop you are heading for is from it.
+     * Silent about every failure — no permission, no fix, no signal — because the card
+     * simply falls back to the planned drive.
+     */
+    fun refreshDriveFromHere() {
+        val state = uiState.value
+        val target = state.stops.find { it.id == state.currentStopId }?.location ?: return
+        if (locating) return
+        locating = true
+        viewModelScope.launch {
+            try {
+                val here = currentLocation() ?: return@launch
+                if (LiveDrive.arrived(here, target)) {
+                    liveDrive.value = null
+                    return@launch
+                }
+                // Drop an answer to a different question before asking the new one, or a
+                // failed fetch would leave the old stop's distance on screen.
+                if (liveDrive.value?.to != target) liveDrive.value = null
+                if (!LiveDrive.needsFetch(liveDrive.value, here, target)) return@launch
+                val leg = drive(here, target) ?: return@launch
+                liveDrive.value = DriveFromHere(here, target, leg.distanceMeters, leg.durationSeconds)
+            } finally {
+                locating = false
+            }
+        }
+    }
 
     /** Cheapest vignette per detected country that has no ROAD_TAX line yet. */
     private fun vignetteSuggestions(stops: List<Stop>, expenses: List<Expense>): List<VignetteTable.Choice> =
@@ -316,6 +364,8 @@ class TripDetailViewModel(
                 container.settingsRepository,
                 container.mapProvider.placeCacheSweeper(container.tripRepository),
                 container.mapProvider.routeRefresher(container.tripRepository),
+                container.currentLocation,
+                container.mapProvider::drive,
             )
         }
     }

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripedit/StopEditScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripedit/StopEditScreen.kt
@@ -43,6 +43,7 @@ val StopKind.displayName: String
         StopKind.STELLPLATZ -> "Stellplatz"
         StopKind.FREE_CAMP -> "Free camp"
         StopKind.VISIT -> "Visit"
+        StopKind.HOME -> "Home"
     }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -86,7 +87,7 @@ fun StopEditScreen(
                 modifier = Modifier.horizontalScroll(rememberScrollState()),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                StopKind.entries.forEach { kind ->
+                StopKind.entries.filter { it != StopKind.HOME || state.kind == StopKind.HOME }.forEach { kind ->
                     FilterChip(
                         selected = state.kind == kind,
                         onClick = { viewModel.setKind(kind) },
@@ -97,7 +98,7 @@ fun StopEditScreen(
             OutlinedTextField(
                 value = state.name,
                 onValueChange = viewModel::setName,
-                label = { Text(if (state.isVisit) "Place" else "Campsite / place") },
+                label = { Text(if (state.isStay) "Campsite / place" else "Place") },
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
             )
@@ -106,7 +107,7 @@ fun StopEditScreen(
                 date = state.arrivalDate,
                 onDateChange = viewModel::setArrivalDate,
             )
-            if (!state.isVisit) {
+            if (state.isStay) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripedit/StopEditViewModel.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripedit/StopEditViewModel.kt
@@ -12,6 +12,7 @@ import com.nuelto.camperexperience.data.TripRepository
 import com.nuelto.camperexperience.data.model.LatLng
 import com.nuelto.camperexperience.data.model.Stop
 import com.nuelto.camperexperience.data.model.StopKind
+import com.nuelto.camperexperience.data.model.isStay
 import com.nuelto.camperexperience.data.model.StopState
 import com.nuelto.camperexperience.data.model.TripStatus
 import com.nuelto.camperexperience.data.model.UserSettings
@@ -49,7 +50,8 @@ data class StopEditUiState(
     val locationCachedAt: LocalDate? = null,
 ) {
     val canSave: Boolean get() = name.isNotBlank()
-    val isVisit: Boolean get() = kind == StopKind.VISIT
+    /** Nights and a price only make sense where you actually stay. */
+    val isStay: Boolean get() = kind.isStay
     val pickerStart: LatLng? get() = location ?: nearbyLocation
 
     /** Google Maps link for this stop — the place itself when it came from Google. */
@@ -139,8 +141,8 @@ class StopEditViewModel(
 
     fun setKind(value: StopKind) = _uiState.update {
         when {
-            value == StopKind.VISIT -> it.copy(kind = value, nights = 0, campingCost = "")
-            it.isVisit -> it.copy(kind = value, nights = 1)
+            !value.isStay -> it.copy(kind = value, nights = 0, campingCost = "")
+            !it.isStay -> it.copy(kind = value, nights = 1)
             else -> it.copy(kind = value)
         }
     }
@@ -219,18 +221,18 @@ class StopEditViewModel(
                 val old = existing
                 val base = old ?: Stop(tripId = route.tripId, orderIndex = newOrderIndex())
                 val parsed = parseDecimal(state.campingCost)
-                val nights = if (state.isVisit) 0 else state.nights
+                val nights = if (state.isStay) state.nights else 0
                 // No parseable price means "estimate at the kind's default rate" —
                 // except kinds free by nature, and unchanged legacy known-zero stops.
                 val costKnown = parsed != null ||
-                    state.kind == StopKind.FREE_CAMP || state.isVisit ||
+                    state.kind == StopKind.FREE_CAMP || !state.isStay ||
                     (old != null && old.costKnown && old.campingCostTotal == 0.0 && old.kind == state.kind)
                 tripRepository.upsertStop(
                     base.copy(
                         name = state.name.trim(),
                         arrivalDate = state.arrivalDate,
                         nights = nights,
-                        campingCostTotal = if (state.isVisit) 0.0 else parsed ?: 0.0,
+                        campingCostTotal = if (state.isStay) parsed ?: 0.0 else 0.0,
                         location = state.location,
                         notes = state.notes.trim(),
                         kind = state.kind,

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripedit/TripEditViewModel.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripedit/TripEditViewModel.kt
@@ -7,6 +7,8 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.nuelto.camperexperience.containerViewModelFactory
 import com.nuelto.camperexperience.data.TripRepository
+import com.nuelto.camperexperience.domain.HomeStop
+import com.nuelto.camperexperience.data.SettingsRepository
 import com.nuelto.camperexperience.data.model.Trip
 import com.nuelto.camperexperience.data.model.TripStatus
 import com.nuelto.camperexperience.ui.nav.TripEditRoute
@@ -33,6 +35,7 @@ data class TripEditUiState(
 class TripEditViewModel(
     savedStateHandle: SavedStateHandle,
     private val tripRepository: TripRepository,
+    private val settingsRepository: SettingsRepository? = null,
 ) : ViewModel() {
 
     private val route: TripEditRoute = savedStateHandle.toRoute<TripEditRoute>()
@@ -97,6 +100,12 @@ class TripEditViewModel(
                         status = status,
                     ),
                 )
+                // A fresh plan starts at home, when there is one to start from.
+                if (state.isNew && status == TripStatus.PLANNED) {
+                    val settings = settingsRepository?.settings()?.first()
+                    settings?.let { HomeStop.forNewPlan(savedId, it, state.startDate) }
+                        ?.let { tripRepository.upsertStop(it) }
+                }
                 // Moving a plan's start moves its whole itinerary along.
                 if (base.status == TripStatus.PLANNED) {
                     val days = ChronoUnit.DAYS.between(base.startDate, state.startDate)
@@ -115,7 +124,11 @@ class TripEditViewModel(
 
     companion object {
         val Factory = containerViewModelFactory { container ->
-            TripEditViewModel(createSavedStateHandle(), container.tripRepository)
+            TripEditViewModel(
+                createSavedStateHandle(),
+                container.tripRepository,
+                container.settingsRepository,
+            )
         }
     }
 }

--- a/app/src/test/java/com/nuelto/camperexperience/data/model/ModelsTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/data/model/ModelsTest.kt
@@ -2,6 +2,8 @@ package com.nuelto.camperexperience.data.model
 
 import java.time.LocalDate
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
 import org.junit.Test
 
 class ModelsTest {
@@ -17,4 +19,13 @@ class ModelsTest {
         assertEquals(TripStatus.ACTIVE, legacyTripStatus(LocalDate.now()))
         assertEquals(TripStatus.ACTIVE, legacyTripStatus(LocalDate.now().plusDays(7)))
     }
+    @Test
+    fun `only the kinds you sleep at count as a stay`() {
+        assertTrue(StopKind.CAMPSITE.isStay)
+        assertTrue(StopKind.STELLPLATZ.isStay)
+        assertTrue(StopKind.FREE_CAMP.isStay)
+        assertFalse(StopKind.VISIT.isStay)
+        assertFalse(StopKind.HOME.isStay)
+    }
+
 }

--- a/app/src/test/java/com/nuelto/camperexperience/domain/ElevationTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/domain/ElevationTest.kt
@@ -1,0 +1,129 @@
+package com.nuelto.camperexperience.domain
+
+import com.nuelto.camperexperience.data.model.LatLng
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ElevationTest {
+
+    /** Five ~7.6 m steps, then three ~38 km legs: vertices crowded at one end. */
+    private val crowded = listOf(
+        LatLng(47.0, 8.0),
+        LatLng(47.0, 8.0001),
+        LatLng(47.0, 8.0002),
+        LatLng(47.0, 8.0003),
+        LatLng(47.0, 8.0004),
+        LatLng(47.0, 8.5),
+        LatLng(47.0, 9.0),
+        LatLng(47.0, 9.5),
+    )
+
+    @Test
+    fun `url lists the latitudes, then the longitudes, in point order`() {
+        assertEquals(
+            "https://api.open-meteo.com/v1/elevation?latitude=46.5,47.25&longitude=8.0,9.5",
+            Elevation.url(listOf(LatLng(46.5, 8.0), LatLng(47.25, 9.5))),
+        )
+    }
+
+    @Test
+    fun `parse reads the elevation array, whole numbers included`() {
+        assertEquals(
+            listOf(1234.5, 1200.0, 980.0),
+            Elevation.parse("""{"latitude":[46.5],"elevation":[1234.5,1200,980.0]}"""),
+        )
+    }
+
+    @Test
+    fun `junk, an empty object and a non-array elevation all yield no heights`() {
+        assertEquals(emptyList<Double>(), Elevation.parse("<html>502 Bad Gateway</html>"))
+        assertEquals(emptyList<Double>(), Elevation.parse("{}"))
+        assertEquals(emptyList<Double>(), Elevation.parse("""{"elevation":1234.5}"""))
+    }
+
+    @Test
+    fun `one unreadable height drops the whole array, never just that entry`() {
+        assertEquals(emptyList<Double>(), Elevation.parse("""{"elevation":[100.0,"n/a",300.0]}"""))
+        assertEquals(emptyList<Double>(), Elevation.parse("""{"elevation":[100.0,null]}"""))
+    }
+
+    @Test
+    fun `a non-positive budget samples nothing`() {
+        assertEquals(emptyList<LatLng>(), Elevation.sample(crowded, 0))
+        assertEquals(emptyList<LatLng>(), Elevation.sample(crowded, -1))
+    }
+
+    @Test
+    fun `a path within the budget is used as it stands`() {
+        val three = crowded.take(3)
+        assertEquals(three, Elevation.sample(three, 3))
+        assertEquals(three, Elevation.sample(three, 4))
+        assertEquals(three, Elevation.sample(three))
+    }
+
+    @Test
+    fun `a budget of one keeps the start`() {
+        assertEquals(listOf(crowded[0]), Elevation.sample(crowded, 1))
+    }
+
+    @Test
+    fun `a path with no length falls back to the first points`() {
+        val pile = List(4) { LatLng(47.0, 8.0) }
+        assertEquals(pile.take(2), Elevation.sample(pile, 2))
+    }
+
+    @Test
+    fun `sampling spreads by distance, not by index`() {
+        val result = Elevation.sample(crowded, 5)
+        assertEquals(5, result.size)
+        // Total 113.75 km, so targets 0 / 28.4 / 56.9 / 85.3 / 113.75: the crowded cluster
+        // collapses into one sample instead of eating four of the five slots, and the last
+        // target lands exactly on the final vertex.
+        assertEquals(
+            listOf(crowded[0], crowded[4], crowded[5], crowded[6], crowded[7]),
+            result,
+        )
+        assertEquals(crowded.first(), result.first())
+        assertEquals(crowded.last(), result.last())
+    }
+
+    @Test
+    fun `no heights is no climb`() {
+        assertEquals(Climb(0.0, 0.0), Elevation.profile(emptyList()))
+    }
+
+    @Test
+    fun `a steady climb sums its steps`() {
+        assertEquals(Climb(120.0, 0.0), Elevation.profile(listOf(500.0, 560.0, 620.0), 10.0))
+    }
+
+    @Test
+    fun `up then down is reported separately`() {
+        assertEquals(Climb(400.0, 250.0), Elevation.profile(listOf(600.0, 1000.0, 750.0), 10.0))
+    }
+
+    @Test
+    fun `a wobble under minRise counts for nothing`() {
+        assertEquals(
+            Climb(0.0, 0.0),
+            Elevation.profile(listOf(600.0, 609.9, 600.0, 609.9, 590.1), 10.0),
+        )
+    }
+
+    @Test
+    fun `a move of exactly minRise counts`() {
+        assertEquals(Climb(10.0, 0.0), Elevation.profile(listOf(600.0, 610.0), 10.0))
+        assertEquals(Climb(0.0, 10.0), Elevation.profile(listOf(600.0, 590.0), 10.0))
+    }
+
+    @Test
+    fun `steps are measured from the anchor, not from the last height`() {
+        assertEquals(Climb(11.0, 0.0), Elevation.profile(listOf(600.0, 605.0, 611.0), 10.0))
+    }
+
+    @Test
+    fun `the default filter is MIN_RISE_M`() {
+        assertEquals(Climb(0.0, 0.0), Elevation.profile(listOf(600.0, 609.99, 600.0)))
+        assertEquals(Climb(50.0, 0.0), Elevation.profile(listOf(600.0, 650.0)))
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/domain/ElevationTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/domain/ElevationTest.kt
@@ -1,6 +1,8 @@
 package com.nuelto.camperexperience.domain
 
 import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.StopElevation
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -87,43 +89,105 @@ class ElevationTest {
         assertEquals(crowded.last(), result.last())
     }
 
+    /** [count] points along a meridian, [spacingKm] apart. */
+    private fun line(count: Int, spacingKm: Double) =
+        List(count) { LatLng(47.0 + it * spacingKm / 111.195, 8.0) }
+
+    /** Far enough apart that the grade clamp cannot reach the hysteresis cases. */
+    private fun far(count: Int) = line(count, 10.0)
+
     @Test
     fun `no heights is no climb`() {
-        assertEquals(Climb(0.0, 0.0), Elevation.profile(emptyList()))
+        assertEquals(Climb(0.0, 0.0), Elevation.profile(emptyList(), emptyList()))
     }
 
     @Test
     fun `a steady climb sums its steps`() {
-        assertEquals(Climb(120.0, 0.0), Elevation.profile(listOf(500.0, 560.0, 620.0), 10.0))
+        assertEquals(
+            Climb(120.0, 0.0),
+            Elevation.profile(far(3), listOf(500.0, 560.0, 620.0), 10.0),
+        )
     }
 
     @Test
     fun `up then down is reported separately`() {
-        assertEquals(Climb(400.0, 250.0), Elevation.profile(listOf(600.0, 1000.0, 750.0), 10.0))
+        assertEquals(
+            Climb(400.0, 250.0),
+            Elevation.profile(far(3), listOf(600.0, 1000.0, 750.0), 10.0),
+        )
     }
 
     @Test
     fun `a wobble under minRise counts for nothing`() {
         assertEquals(
             Climb(0.0, 0.0),
-            Elevation.profile(listOf(600.0, 609.9, 600.0, 609.9, 590.1), 10.0),
+            Elevation.profile(far(5), listOf(600.0, 609.9, 600.0, 609.9, 590.1), 10.0),
         )
     }
 
     @Test
     fun `a move of exactly minRise counts`() {
-        assertEquals(Climb(10.0, 0.0), Elevation.profile(listOf(600.0, 610.0), 10.0))
-        assertEquals(Climb(0.0, 10.0), Elevation.profile(listOf(600.0, 590.0), 10.0))
+        assertEquals(Climb(10.0, 0.0), Elevation.profile(far(2), listOf(600.0, 610.0), 10.0))
+        assertEquals(Climb(0.0, 10.0), Elevation.profile(far(2), listOf(600.0, 590.0), 10.0))
     }
 
     @Test
     fun `steps are measured from the anchor, not from the last height`() {
-        assertEquals(Climb(11.0, 0.0), Elevation.profile(listOf(600.0, 605.0, 611.0), 10.0))
+        assertEquals(
+            Climb(11.0, 0.0),
+            Elevation.profile(far(3), listOf(600.0, 605.0, 611.0), 10.0),
+        )
     }
 
     @Test
     fun `the default filter is MIN_RISE_M`() {
-        assertEquals(Climb(0.0, 0.0), Elevation.profile(listOf(600.0, 609.99, 600.0)))
-        assertEquals(Climb(50.0, 0.0), Elevation.profile(listOf(600.0, 650.0)))
+        // 49 m of undulation is below the default threshold; 60 m is over it.
+        assertEquals(Climb(0.0, 0.0), Elevation.profile(far(3), listOf(600.0, 649.0, 600.0)))
+        assertEquals(Climb(60.0, 0.0), Elevation.profile(far(2), listOf(600.0, 660.0)))
+        assertEquals(50.0, Elevation.MIN_RISE_M, 1e-9)
+    }
+
+    @Test
+    fun `a tunnel's phantom mountain is clamped to what a road could climb`() {
+        // 500 m apart, so MAX_ROAD_GRADE allows 40 m a step. The DEM reports the ridge
+        // over the tunnel: without the clamp this is 1000 m of ascent and 1000 of descent.
+        val climb = Elevation.profile(line(3, 0.5), listOf(600.0, 1600.0, 600.0), 10.0)
+        assertEquals(40.0, climb.ascentMeters, 0.01)
+        assertEquals(40.0, climb.descentMeters, 0.01)
+    }
+
+    @Test
+    fun `a climb a road could actually make is left alone`() {
+        // 500 m apart and 30 m up is 6%, inside MAX_ROAD_GRADE.
+        assertEquals(
+            30.0,
+            Elevation.profile(line(2, 0.5), listOf(600.0, 630.0), 10.0).ascentMeters,
+            0.01,
+        )
+        assertEquals(0.08, Elevation.MAX_ROAD_GRADE, 1e-9)
+    }
+
+    @Test
+    fun `the clamp carries forward, so a long tunnel does not spike at its far end`() {
+        // Four 500 m steps at 40 m each: the road creeps up, it does not jump and return.
+        val climb = Elevation.profile(
+            line(5, 0.5),
+            listOf(600.0, 2000.0, 2000.0, 2000.0, 600.0),
+            10.0,
+        )
+        // Three 40 m steps up; coming back down, only the last step is a real drop.
+        assertEquals(120.0, climb.ascentMeters, 0.01)
+        assertEquals(40.0, climb.descentMeters, 0.01)
+    }
+
+    @Test
+    fun `a stop's height counts only where the stop actually sits`() {
+        val at = LatLng(46.19302, 7.82714)
+        val stop = Stop(id = "s", location = at, elevation = StopElevation(at, 1469))
+        assertEquals(1469, Elevation.ofStop(stop))
+        assertEquals(null, Elevation.ofStop(stop.copy(elevation = null)))
+        // Pin moved since it was measured.
+        assertEquals(null, Elevation.ofStop(stop.copy(location = LatLng(46.5, 7.9))))
+        assertEquals(null, Elevation.ofStop(stop.copy(location = null)))
     }
 }

--- a/app/src/test/java/com/nuelto/camperexperience/domain/FuelEstimatorTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/domain/FuelEstimatorTest.kt
@@ -4,10 +4,12 @@ import com.nuelto.camperexperience.data.model.Expense
 import com.nuelto.camperexperience.data.model.ExpenseType
 import com.nuelto.camperexperience.data.model.LatLng
 import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.StopLeg
 import com.nuelto.camperexperience.data.model.StopState
 import com.nuelto.camperexperience.data.model.UserSettings
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class FuelEstimatorTest {
@@ -119,6 +121,133 @@ class FuelEstimatorTest {
             direct * 1.25,
             FuelEstimator.defaultTripDistanceKm(stops, UserSettings(roadDistanceFactor = 1.25)),
             1e-9,
+        )
+    }
+
+    @Test
+    fun `routed legs beat the road factor, and mix with legs that have none`() {
+        val a = LatLng(47.0, 8.0)
+        val b = LatLng(48.0, 8.0)
+        val c = LatLng(48.0, 9.0)
+        val stops = listOf(
+            Stop(id = "a", location = a, orderIndex = 0),
+            Stop(id = "b", location = b, orderIndex = 1, leg = routeLeg(a, b, 150_000)),
+            Stop(id = "c", location = c, orderIndex = 2),
+        )
+        val settings = UserSettings(roadDistanceFactor = 1.25)
+        val km = FuelEstimator.defaultTripDistanceKm(stops, settings)
+        assertEquals(150.0 + GeoUtils.haversineKm(b, c) * 1.25, km, 1e-9)
+        assertEquals(243.0, km, 0.01)
+    }
+
+    @Test
+    fun `a leg that no longer matches its stops falls back to the road factor`() {
+        val a = LatLng(47.0, 8.0)
+        val moved = LatLng(48.0, 9.0)
+        val settings = UserSettings(roadDistanceFactor = 1.25)
+        val fallback = GeoUtils.haversineKm(a, moved) * 1.25
+        // Routed to (48,8); the stop has since been dragged east.
+        val movedTo = listOf(
+            Stop(id = "a", location = a, orderIndex = 0),
+            Stop(id = "b", location = moved, orderIndex = 1, leg = routeLeg(a, LatLng(48.0, 8.0), 999_000)),
+        )
+        assertEquals(fallback, FuelEstimator.defaultTripDistanceKm(movedTo, settings), 1e-9)
+        assertTrue(FuelEstimator.defaultTripDistanceKm(movedTo, settings) < 200.0)
+        // Same the other way round: the stop it was routed from is not the one before it now.
+        val movedFrom = listOf(
+            Stop(id = "a", location = a, orderIndex = 0),
+            Stop(id = "b", location = moved, orderIndex = 1, leg = routeLeg(LatLng(46.0, 8.0), moved, 999_000)),
+        )
+        assertEquals(fallback, FuelEstimator.defaultTripDistanceKm(movedFrom, settings), 1e-9)
+    }
+
+    @Test
+    fun `lifting one tonne 100 m burns about 86 millilitres`() {
+        assertEquals(0.086, FuelEstimator.liftLiters(1000.0, 100.0), 5e-4)
+        assertEquals(0.0, FuelEstimator.liftLiters(3500.0, 0.0), 1e-12)
+        assertEquals(
+            2.0 * FuelEstimator.liftLiters(1000.0, 100.0),
+            FuelEstimator.liftLiters(2000.0, 100.0),
+            1e-12,
+        )
+    }
+
+    @Test
+    fun `climbing costs nothing without an elevation figure, or on the flat`() {
+        val a = LatLng(47.0, 8.0)
+        val b = LatLng(48.0, 8.0)
+        val unrouted = listOf(
+            Stop(id = "a", location = a, orderIndex = 0),
+            Stop(id = "b", location = b, orderIndex = 1),
+        )
+        assertEquals(0.0, FuelEstimator.climbLiters(unrouted, UserSettings()), 1e-12)
+        // Routed, but the DEM never answered.
+        val noElevation = listOf(
+            Stop(id = "a", location = a, orderIndex = 0),
+            Stop(id = "b", location = b, orderIndex = 1, leg = routeLeg(a, b, 120_000)),
+        )
+        assertEquals(0.0, FuelEstimator.climbLiters(noElevation, UserSettings()), 1e-12)
+        val flat = listOf(
+            Stop(id = "a", location = a, orderIndex = 0),
+            Stop(id = "b", location = b, orderIndex = 1, leg = routeLeg(a, b, 120_000, 0, 0)),
+        )
+        assertEquals(0.0, FuelEstimator.climbLiters(flat, UserSettings()), 1e-12)
+    }
+
+    @Test
+    fun `a pure climb costs the lift, and a descent gives part of it back`() {
+        val climb = FuelEstimator.climbLiters(hillyTrip(1000, 0, 90_000), UserSettings())
+        assertEquals(2.99712, climb, 1e-5)
+
+        // 90 km split 60/30 by the heights: recovery is 0.85 x lifting 3.5 t over 500 m.
+        val rolling = FuelEstimator.climbLiters(hillyTrip(1000, 500, 90_000), UserSettings())
+        assertEquals(1.72334, rolling, 1e-5)
+        assertTrue(rolling > 0.0 && rolling < climb)
+    }
+
+    @Test
+    fun `descent recovery is capped by the fuel that stretch would have burned`() {
+        // 2 km of road losing 2000 m: the potential energy dwarfs the fuel on offer.
+        val settings = UserSettings(fuelConsumptionL100km = 10.0, vehicleMassKg = 3500.0)
+        val recovered = -FuelEstimator.climbLiters(hillyTrip(0, 2000, 2_000), settings)
+        assertEquals(0.17, recovered, 1e-9)
+        assertTrue(recovered < 0.85 * FuelEstimator.liftLiters(3500.0, 2000.0))
+    }
+
+    @Test
+    fun `auto trip fuel cost pays for the climb as well as the distance`() {
+        val settings = UserSettings(fuelConsumptionL100km = 10.0, fuelPricePerLiter = 1.8)
+        val flat = FuelEstimator.autoTripFuelCost(hillyTrip(null, 0, 100_000), emptyList(), settings)!!
+        val climbing = FuelEstimator.autoTripFuelCost(hillyTrip(1000, 0, 100_000), emptyList(), settings)!!
+        assertEquals(18.0, flat, 1e-9)
+        assertEquals(23.394815, climbing, 1e-5)
+        assertTrue(climbing > flat)
+
+        val fuel = Expense(id = "e1", type = ExpenseType.FUEL, amount = 90.0)
+        assertNull(FuelEstimator.autoTripFuelCost(hillyTrip(1000, 0, 100_000), listOf(fuel), settings))
+    }
+
+    private fun routeLeg(
+        from: LatLng,
+        to: LatLng,
+        distanceMeters: Int,
+        ascent: Int? = null,
+        descent: Int? = null,
+    ) = StopLeg(
+        from = from,
+        to = to,
+        distanceMeters = distanceMeters,
+        ascentMeters = ascent,
+        descentMeters = descent,
+    )
+
+    /** Two stops 47N-48N apart, joined by one routed leg of the given shape. */
+    private fun hillyTrip(ascent: Int?, descent: Int?, distanceMeters: Int): List<Stop> {
+        val a = LatLng(47.0, 8.0)
+        val b = LatLng(48.0, 8.0)
+        return listOf(
+            Stop(id = "a", location = a, orderIndex = 0),
+            Stop(id = "b", location = b, orderIndex = 1, leg = routeLeg(a, b, distanceMeters, ascent, descent)),
         )
     }
 }

--- a/app/src/test/java/com/nuelto/camperexperience/domain/GooglePlacesTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/domain/GooglePlacesTest.kt
@@ -276,4 +276,10 @@ class GooglePlacesTest {
             assertTrue(it, GooglePlaces.DETAILS_FIELD_MASK.contains(it))
         }
     }
+    @Test
+    fun `home has no category to filter on`() {
+        // An address is not a place type; the search skips its second pass instead.
+        assertEquals(emptyList<String>(), GooglePlaces.preferredTypes(StopKind.HOME))
+    }
+
 }

--- a/app/src/test/java/com/nuelto/camperexperience/domain/GoogleRoutesTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/domain/GoogleRoutesTest.kt
@@ -1,0 +1,201 @@
+package com.nuelto.camperexperience.domain
+
+import com.nuelto.camperexperience.data.model.LatLng
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GoogleRoutesTest {
+
+    private fun points(n: Int) = List(n) { LatLng(46.0 + it, 7.0 + it) }
+
+    private fun waypoint(lat: Double, lng: Double) =
+        """{"location":{"latLng":{"latitude":$lat,"longitude":$lng}}}"""
+
+    // --- windows ------------------------------------------------------------
+
+    @Test
+    fun `fewer than two points is not a drive`() {
+        assertEquals(emptyList<List<LatLng>>(), GoogleRoutes.windows(emptyList()))
+        assertEquals(emptyList<List<LatLng>>(), GoogleRoutes.windows(points(1)))
+    }
+
+    @Test
+    fun `two points are one request`() {
+        assertEquals(listOf(points(2)), GoogleRoutes.windows(points(2)))
+    }
+
+    @Test
+    fun `a full window still costs one request`() {
+        val all = points(GoogleRoutes.MAX_POINTS_PER_REQUEST)
+        assertEquals(listOf(all), GoogleRoutes.windows(all))
+    }
+
+    @Test
+    fun `one point too many splits, and the second window starts where the first ended`() {
+        val all = points(13)
+        val windows = GoogleRoutes.windows(all)
+        assertEquals(2, windows.size)
+        assertEquals(listOf(12, 2), windows.map { it.size })
+        assertEquals(all.take(12), windows[0])
+        assertEquals(all.subList(11, 13), windows[1])
+        // The overlap is the whole contract: the legs join up only if the point is shared.
+        assertEquals(windows[0].last(), windows[1].first())
+        assertEquals(all[11], windows[1].first())
+    }
+
+    @Test
+    fun `two full windows overlap by exactly one point`() {
+        val all = points(23)
+        val windows = GoogleRoutes.windows(all)
+        assertEquals(listOf(12, 12), windows.map { it.size })
+        assertEquals(all[11], windows[1].first())
+        assertEquals(all[22], windows[1].last())
+    }
+
+    @Test
+    fun `however a trip is split, the windows cover every leg exactly once`() {
+        for (n in 2..40) {
+            val windows = GoogleRoutes.windows(points(n))
+            assertEquals("$n points", n - 1, windows.sumOf { it.size - 1 })
+            assertTrue("$n points", windows.all { it.size in 2..GoogleRoutes.MAX_POINTS_PER_REQUEST })
+            windows.zipWithNext { a, b -> assertEquals("$n points", a.last(), b.first()) }
+        }
+    }
+
+    // --- request ------------------------------------------------------------
+
+    @Test
+    fun `two points need no intermediates at all`() {
+        val body = GoogleRoutes.computeRoutesBody(listOf(LatLng(46.0, 7.0), LatLng(47.5, 8.25)))
+        assertEquals(
+            """{"origin":${waypoint(46.0, 7.0)},"destination":${waypoint(47.5, 8.25)},""" +
+                """"travelMode":"DRIVE","routingPreference":"TRAFFIC_UNAWARE",""" +
+                """"polylineQuality":"HIGH_QUALITY"}""",
+            body,
+        )
+        assertFalse(body.contains("intermediates"))
+    }
+
+    @Test
+    fun `every middle point becomes an intermediate, in order`() {
+        assertEquals(
+            """{"origin":${waypoint(46.0, 7.0)},"destination":${waypoint(49.0, 10.0)},""" +
+                """"intermediates":[${waypoint(47.0, 8.0)},${waypoint(48.0, 9.0)}],""" +
+                """"travelMode":"DRIVE","routingPreference":"TRAFFIC_UNAWARE",""" +
+                """"polylineQuality":"HIGH_QUALITY"}""",
+            GoogleRoutes.computeRoutesBody(points(4)),
+        )
+        assertTrue(
+            GoogleRoutes.computeRoutesBody(points(3))
+                .contains(""","intermediates":[${waypoint(47.0, 8.0)}],"travelMode"""),
+        )
+    }
+
+    @Test
+    fun `the request pins driving, no live traffic and full geometry`() {
+        val body = GoogleRoutes.computeRoutesBody(points(3))
+        assertTrue(body.contains(""""travelMode":"DRIVE""""))
+        // Live traffic is meaningless weeks out and jumps to the Pro SKU.
+        assertTrue(body.contains(""""routingPreference":"TRAFFIC_UNAWARE""""))
+        assertTrue(body.contains(""""polylineQuality":"HIGH_QUALITY""""))
+    }
+
+    @Test
+    fun `the field mask asks for the per-leg numbers only`() {
+        assertEquals(
+            "routes.legs.distanceMeters,routes.legs.duration,routes.legs.polyline.encodedPolyline",
+            GoogleRoutes.FIELD_MASK,
+        )
+        assertFalse(GoogleRoutes.FIELD_MASK.contains("*"))
+        assertEquals(
+            "https://routes.googleapis.com/directions/v2:computeRoutes",
+            GoogleRoutes.COMPUTE_ROUTES_URL,
+        )
+    }
+
+    // --- response -----------------------------------------------------------
+
+    private fun response(vararg legs: String) =
+        """{"routes":[{"legs":[${legs.joinToString(",")}]}]}"""
+
+    @Test
+    fun `a routed window comes back one leg per pair of stops`() {
+        val legs = GoogleRoutes.parseLegs(
+            response(
+                """{"distanceMeters":12345,"duration":"1234s","polyline":{"encodedPolyline":"abc"}}""",
+                """{"distanceMeters":6789,"duration":"678.6s","polyline":{"encodedPolyline":"def"}}""",
+            ),
+        )
+        assertEquals(2, legs.size)
+        assertEquals(RoutedLeg("abc", 12345, 1234), legs[0])
+        assertEquals(RoutedLeg("def", 6789, 679), legs[1])
+    }
+
+    @Test
+    fun `proto3 drops zeroes, so an empty leg is a zero leg, not a missing one`() {
+        assertEquals(listOf(RoutedLeg("", 0, 0)), GoogleRoutes.parseLegs(response("{}")))
+    }
+
+    @Test
+    fun `unusable fields fall back rather than dropping the leg`() {
+        assertEquals(
+            listOf(RoutedLeg("", 0, 0)),
+            GoogleRoutes.parseLegs(
+                response(
+                    """{"distanceMeters":"12345","duration":"nope","polyline":{"encodedPolyline":""}}""",
+                ),
+            ),
+        )
+        assertEquals(
+            listOf(RoutedLeg("", 0, 0)),
+            GoogleRoutes.parseLegs(response("""{"duration":12,"polyline":"abc"}""")),
+        )
+    }
+
+    @Test
+    fun `one malformed leg discards the whole window rather than shifting the rest`() {
+        // Leg i is the drive to stop i+1; a shorter list would silently misalign them all.
+        assertEquals(
+            emptyList<RoutedLeg>(),
+            GoogleRoutes.parseLegs(
+                response(
+                    """{"distanceMeters":1,"duration":"1s"}""",
+                    "42",
+                    """{"distanceMeters":2,"duration":"2s"}""",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `nothing routable yields no legs`() {
+        assertTrue(GoogleRoutes.parseLegs("""{"routes":[]}""").isEmpty())
+        assertTrue(GoogleRoutes.parseLegs("""{"routes":[{}]}""").isEmpty())
+        assertTrue(GoogleRoutes.parseLegs("""{"routes":[{"legs":{}}]}""").isEmpty())
+        assertTrue(GoogleRoutes.parseLegs("""{"routes":{"a":1}}""").isEmpty())
+        assertTrue(GoogleRoutes.parseLegs("{}").isEmpty())
+        assertTrue(GoogleRoutes.parseLegs("[]").isEmpty())
+        assertTrue(GoogleRoutes.parseLegs("<html>404</html>").isEmpty())
+        assertTrue(GoogleRoutes.parseLegs("").isEmpty())
+    }
+
+    // --- durations ----------------------------------------------------------
+
+    @Test
+    fun `protobuf durations are seconds, rounded`() {
+        assertEquals(120, GoogleRoutes.parseDuration("120s"))
+        assertEquals(4, GoogleRoutes.parseDuration("3.5s"))
+        assertEquals(3, GoogleRoutes.parseDuration("3.4s"))
+        assertEquals(0, GoogleRoutes.parseDuration("0s"))
+    }
+
+    @Test
+    fun `anything else is no duration`() {
+        assertNull(GoogleRoutes.parseDuration("soon"))
+        assertNull(GoogleRoutes.parseDuration("s"))
+        assertNull(GoogleRoutes.parseDuration(""))
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/domain/HomeStopTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/domain/HomeStopTest.kt
@@ -1,0 +1,59 @@
+package com.nuelto.camperexperience.domain
+
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.data.model.StopKind
+import com.nuelto.camperexperience.data.model.UserSettings
+import com.nuelto.camperexperience.data.model.isStay
+import java.time.LocalDate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class HomeStopTest {
+
+    private val start = LocalDate.of(2027, 6, 10)
+    private val home = LatLng(47.0502, 8.3093)
+
+    @Test
+    fun `no home set means a plan starts wherever you add first`() {
+        assertNull(HomeStop.forNewPlan("t1", UserSettings(), start))
+        // A name on its own is not somewhere to start from.
+        assertNull(HomeStop.forNewPlan("t1", UserSettings(homeName = "Luzern"), start))
+    }
+
+    @Test
+    fun `the home stop is the plan's first row, on its start date`() {
+        val stop = HomeStop.forNewPlan(
+            "t1",
+            UserSettings(homeName = "Luzern", homeLocation = home),
+            start,
+        )!!
+        assertEquals("t1", stop.tripId)
+        assertEquals("Luzern", stop.name)
+        assertEquals(home, stop.location)
+        assertEquals(start, stop.arrivalDate)
+        assertEquals(0, stop.orderIndex)
+        assertEquals(StopKind.HOME, stop.kind)
+    }
+
+    @Test
+    fun `home is somewhere you leave, not somewhere you stay`() {
+        val stop = HomeStop.forNewPlan("t1", UserSettings(homeLocation = home), start)!!
+        assertEquals(0, stop.nights)
+        assertEquals(0.0, stop.campingCostTotal, 1e-9)
+        assertFalse(stop.kind.isStay)
+    }
+
+    @Test
+    fun `an unnamed home is called Home`() {
+        val stop = HomeStop.forNewPlan("t1", UserSettings(homeLocation = home), start)!!
+        assertEquals(HomeStop.DEFAULT_NAME, stop.name)
+        assertEquals("Home", HomeStop.DEFAULT_NAME)
+        // Blank is not a name either.
+        assertEquals(
+            "Home",
+            HomeStop.forNewPlan("t1", UserSettings(homeName = "  ", homeLocation = home), start)!!.name,
+        )
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/domain/LiveDriveTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/domain/LiveDriveTest.kt
@@ -1,0 +1,58 @@
+package com.nuelto.camperexperience.domain
+
+import com.nuelto.camperexperience.data.model.LatLng
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LiveDriveTest {
+
+    private val here = LatLng(46.8709, 8.2492)
+    private val there = LatLng(46.1591, 8.7853)
+
+    /** [meters] north of [from], close enough that a degree of latitude is a straight ruler. */
+    private fun north(from: LatLng, meters: Double) =
+        LatLng(from.latitude + meters / 111_195.0, from.longitude)
+
+    private fun drive(from: LatLng, to: LatLng) =
+        DriveFromHere(from, to, distanceMeters = 90_000, durationSeconds = 5_400)
+
+    @Test
+    fun `you have arrived just inside the threshold, and not just outside it`() {
+        assertTrue(LiveDrive.arrived(there, north(there, 149.0)))
+        assertFalse(LiveDrive.arrived(there, north(there, 151.0)))
+        assertEquals(150.0, LiveDrive.ARRIVED_WITHIN_METERS, 1e-9)
+    }
+
+    @Test
+    fun `standing on the stop counts as arrived`() {
+        assertTrue(LiveDrive.arrived(there, there))
+    }
+
+    @Test
+    fun `nothing held means fetch`() {
+        assertTrue(LiveDrive.needsFetch(null, here, there))
+    }
+
+    @Test
+    fun `a different destination is fetched however little you moved`() {
+        val held = drive(here, there)
+        // One metre from the recorded fix, but heading somewhere else now.
+        assertTrue(LiveDrive.needsFetch(held, north(here, 1.0), LatLng(47.0, 8.0)))
+    }
+
+    @Test
+    fun `staying put does not spend a route`() {
+        val held = drive(here, there)
+        assertFalse(LiveDrive.needsFetch(held, here, there))
+        assertFalse(LiveDrive.needsFetch(held, north(here, 1_999.0), there))
+    }
+
+    @Test
+    fun `moving the refresh distance fetches again`() {
+        val held = drive(here, there)
+        assertTrue(LiveDrive.needsFetch(held, north(here, 2_001.0), there))
+        assertEquals(2_000.0, LiveDrive.REFRESH_AFTER_METERS, 1e-9)
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/domain/MapOverlayTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/domain/MapOverlayTest.kt
@@ -3,6 +3,7 @@ package com.nuelto.camperexperience.domain
 import com.nuelto.camperexperience.data.model.LatLng
 import com.nuelto.camperexperience.data.model.Stop
 import com.nuelto.camperexperience.data.model.StopKind
+import com.nuelto.camperexperience.data.model.StopLeg
 import com.nuelto.camperexperience.data.model.StopState
 import com.nuelto.camperexperience.data.model.Trip
 import com.nuelto.camperexperience.data.model.TripStatus
@@ -171,5 +172,99 @@ class MapOverlayTest {
             MapFrame.Bounds(west = 7.0, south = 45.0, east = 9.0, north = 46.0),
             MapOverlay.frame(listOf(LatLng(46.0, 7.0), LatLng(45.0, 9.0), LatLng(45.5, 8.0))),
         )
+    }
+
+    // --- routes: road geometry -----------------------------------------------
+
+    /** (46,7) (46.4,7.3) (46.7,7.6) (47,8) — the drive from stop a to stop b. */
+    private val roadAB = "_kwwG_evi@_cmA_ry@_ry@_ry@_ry@_cmA"
+
+    /** (47,8) (47.5,8.4) (48,9) — on from b to c, starting where [roadAB] ends. */
+    private val roadBC = "_uz}G_oyo@_t`B_cmA_t`B_etB"
+
+    /** (46,7) (46.5,7.5) (46.99,7.99) — a road that ends just short of b's pin. */
+    private val roadShortOfB = "_kwwG_evi@_t`B_t`Bou~Aou~A"
+
+    /** (46.5,7.5) — a single point, too little to draw a line with. */
+    private val onePoint = "_`yzG_zwl@"
+
+    private fun Stop.road(from: Stop, polyline: String) =
+        copy(leg = StopLeg(from = from.location!!, to = location!!, polyline = polyline))
+
+    @Test
+    fun `a leg's road replaces the straight hop between the two pins`() {
+        val a = stop("a", 0)
+        val b = stop("b", 1).road(a, roadAB)
+        val points = MapOverlay.routes(data(TripStatus.DONE, listOf(a, b))).single().points
+        assertTrue(points.size > 2)
+        assertEquals(Polyline.decode(roadAB), points)
+    }
+
+    @Test
+    fun `a leg whose endpoints no longer match the stops falls back to the pins`() {
+        val a = stop("a", 0)
+        val moved = stop("b", 1).road(a, roadAB).copy(location = LatLng(47.5, 8.5))
+        assertEquals(
+            listOf(LatLng(46.0, 7.0), LatLng(47.5, 8.5)),
+            MapOverlay.routes(data(TripStatus.DONE, listOf(a, moved))).single().points,
+        )
+    }
+
+    @Test
+    fun `a polyline with fewer than two points falls back to the pins`() {
+        val a = stop("a", 0)
+        assertEquals(1, Polyline.decode(onePoint).size)
+        listOf("", onePoint).forEach { polyline ->
+            val b = stop("b", 1).road(a, polyline)
+            assertEquals(
+                listOf(LatLng(46.0, 7.0), LatLng(47.0, 8.0)),
+                MapOverlay.routes(data(TripStatus.DONE, listOf(a, b))).single().points,
+            )
+        }
+    }
+
+    @Test
+    fun `two roads meeting at a stop share that vertex once`() {
+        val a = stop("a", 0)
+        val b = stop("b", 1).road(a, roadAB)
+        val c = stop("c", 2).road(b, roadBC)
+        val points = MapOverlay.routes(data(TripStatus.DONE, listOf(a, b, c))).single().points
+        assertEquals(Polyline.decode(roadAB) + Polyline.decode(roadBC).drop(1), points)
+        assertEquals(6, points.size)
+        assertEquals(1, points.count { it == LatLng(47.0, 8.0) })
+    }
+
+    @Test
+    fun `a road ending short of the pin keeps the pin the next hop starts from`() {
+        val a = stop("a", 0)
+        val b = stop("b", 1).road(a, roadShortOfB)
+        val points = MapOverlay.routes(data(TripStatus.DONE, listOf(a, b, stop("c", 2)))).single().points
+        assertEquals(
+            Polyline.decode(roadShortOfB) + listOf(LatLng(47.0, 8.0), LatLng(48.0, 9.0)),
+            points,
+        )
+        assertEquals(5, points.size)
+    }
+
+    @Test
+    fun `an active trip splits into three roads where it has them`() {
+        // (46,7) (46.5,7.5) (47,8)
+        val travelled = "_kwwG_evi@_t`B_t`B_t`B_t`B"
+        // (47,8) (47.5,8.6) (48,9)
+        val current = "_uz}G_oyo@_t`B_etB_t`B_cmA"
+        // (48,9) (48.5,9.5) (49,10)
+        val ahead = "__~cH_y|u@_t`B_t`B_t`B_t`B"
+        val d1 = stop("d1", 0, state = StopState.DONE)
+        val d2 = stop("d2", 1, state = StopState.DONE).road(d1, travelled)
+        val u1 = stop("u1", 2).road(d2, current)
+        val u2 = stop("u2", 3).road(u1, ahead)
+        val routes = MapOverlay.routes(data(TripStatus.ACTIVE, listOf(d1, d2, u1, u2)))
+        assertEquals(
+            listOf(MapAccent.DONE, MapAccent.CURRENT, MapAccent.PLANNED),
+            routes.map { it.accent },
+        )
+        assertEquals(Polyline.decode(travelled), routes[0].points)
+        assertEquals(Polyline.decode(current), routes[1].points)
+        assertEquals(Polyline.decode(ahead), routes[2].points)
     }
 }

--- a/app/src/test/java/com/nuelto/camperexperience/domain/PolylineTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/domain/PolylineTest.kt
@@ -1,0 +1,66 @@
+package com.nuelto.camperexperience.domain
+
+import com.nuelto.camperexperience.data.model.LatLng
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PolylineTest {
+
+    /** One complete point: (38.5, -120.2). */
+    private val firstPoint = "_p~iF~ps|U"
+
+    private fun assertPoint(lat: Double, lng: Double, actual: LatLng) {
+        assertEquals(lat, actual.latitude, 1e-9)
+        assertEquals(lng, actual.longitude, 1e-9)
+    }
+
+    @Test
+    fun `google's worked example decodes to its three points`() {
+        val points = Polyline.decode("_p~iF~ps|U_ulLnnqC_mqNvxq`@")
+        assertEquals(3, points.size)
+        assertPoint(38.5, -120.2, points[0])
+        assertPoint(40.7, -120.95, points[1])
+        assertPoint(43.252, -126.453, points[2])
+    }
+
+    @Test
+    fun `an empty string decodes to no points`() {
+        assertEquals(emptyList<LatLng>(), Polyline.decode(""))
+    }
+
+    @Test
+    fun `a string ending mid-latitude keeps the points read so far`() {
+        val points = Polyline.decode(firstPoint + "_")
+        assertEquals(1, points.size)
+        assertPoint(38.5, -120.2, points[0])
+    }
+
+    @Test
+    fun `a string ending mid-longitude drops the half-read point`() {
+        val points = Polyline.decode(firstPoint + "_ulL" + "_")
+        assertEquals(1, points.size)
+        assertPoint(38.5, -120.2, points[0])
+    }
+
+    @Test
+    fun `a lone continuation chunk decodes to nothing`() {
+        assertEquals(emptyList<LatLng>(), Polyline.decode("_"))
+    }
+
+    @Test
+    fun `an odd zig-zag value comes back negative`() {
+        val points = Polyline.decode("_ibE~hbE")
+        assertEquals(1, points.size)
+        assertPoint(1.0, -1.0, points[0])
+        assertTrue(points[0].longitude < 0.0)
+    }
+
+    @Test
+    fun `deltas accumulate rather than restart`() {
+        val points = Polyline.decode("_ibE_ibE_ibE_ibE")
+        assertEquals(2, points.size)
+        assertPoint(1.0, 1.0, points[0])
+        assertPoint(2.0, 2.0, points[1])
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/domain/RouteCacheTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/domain/RouteCacheTest.kt
@@ -1,0 +1,157 @@
+package com.nuelto.camperexperience.domain
+
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.StopLeg
+import com.nuelto.camperexperience.data.model.StopState
+import java.time.LocalDate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RouteCacheTest {
+
+    private val today = LocalDate.of(2026, 9, 1)
+    private val a = LatLng(46.1712, 8.7936)
+    private val b = LatLng(46.5610, 8.3390)
+    private val c = LatLng(47.0502, 8.3093)
+
+    private fun stop(
+        id: String,
+        order: Int,
+        location: LatLng? = a,
+        state: StopState = StopState.PLANNED,
+        leg: StopLeg? = null,
+    ) = Stop(id = id, tripId = "t1", name = id, location = location, orderIndex = order, state = state, leg = leg)
+
+    private fun leg(from: LatLng, to: LatLng, meters: Int = 42_000, fetchedAt: LocalDate = today) =
+        StopLeg(from = from, to = to, polyline = "abc", distanceMeters = meters, fetchedAt = fetchedAt)
+
+    @Test
+    fun `routed orders the stops and drops what the route cannot run through`() {
+        val stops = listOf(
+            stop("third", 2, c),
+            stop("skipped", 1, b, state = StopState.SKIPPED),
+            stop("unpinned", 1, location = null),
+            stop("first", 0, a),
+        )
+        assertEquals(listOf("first", "third"), RouteCache.routed(stops).map { it.id })
+        assertTrue(RouteCache.routed(emptyList()).isEmpty())
+    }
+
+    @Test
+    fun `drives are the consecutive pairs of routed stops`() {
+        val stops = listOf(stop("s1", 0, a), stop("s2", 1, b), stop("s3", 2, c))
+        assertEquals(
+            listOf("s1" to "s2", "s2" to "s3"),
+            RouteCache.drives(stops).map { (from, to) -> from.id to to.id },
+        )
+    }
+
+    @Test
+    fun `fewer than two routable stops is no drive at all`() {
+        assertTrue(RouteCache.drives(emptyList()).isEmpty())
+        assertTrue(RouteCache.drives(listOf(stop("only", 0, a))).isEmpty())
+        assertTrue(
+            RouteCache.drives(listOf(stop("s1", 0, a), stop("s2", 1, b, state = StopState.SKIPPED))).isEmpty(),
+        )
+        assertTrue(RouteCache.drives(listOf(stop("s1", 0, a), stop("s2", 1, location = null))).isEmpty())
+    }
+
+    @Test
+    fun `a leg is usable while it still describes the drive`() {
+        val from = stop("s1", 0, a)
+        val stored = leg(a, b)
+        assertEquals(stored, RouteCache.usable(from, stop("s2", 1, b, leg = stored)))
+    }
+
+    @Test
+    fun `a leg with no coordinates in common with the drive is not usable`() {
+        val from = stop("s1", 0, a)
+        assertNull(RouteCache.usable(from, stop("s2", 1, b, leg = null)))
+        assertNull(RouteCache.usable(stop("s1", 0, c), stop("s2", 1, b, leg = leg(a, b))))
+        assertNull(RouteCache.usable(from, stop("s2", 1, c, leg = leg(a, b))))
+    }
+
+    @Test
+    fun `byStop keys each drive by the stop it arrives at`() {
+        val stops = listOf(
+            stop("s1", 0, a),
+            stop("s2", 1, b, leg = leg(a, b, meters = 11_000)),
+            stop("s3", 2, c, leg = leg(b, c, meters = 22_000)),
+        )
+        val byStop = RouteCache.byStop(stops)
+        assertEquals(setOf("s2", "s3"), byStop.keys)
+        assertEquals(11_000, byStop.getValue("s2").distanceMeters)
+        assertEquals(22_000, byStop.getValue("s3").distanceMeters)
+    }
+
+    @Test
+    fun `byStop leaves out a leg that no longer matches its drive`() {
+        val stops = listOf(
+            stop("s1", 0, a),
+            stop("s2", 1, b, leg = leg(a, b)),
+            stop("s3", 2, c, leg = leg(a, c)),
+        )
+        assertEquals(setOf("s2"), RouteCache.byStop(stops).keys)
+    }
+
+    @Test
+    fun `a routed leg lasts exactly thirty days`() {
+        assertFalse(RouteCache.isExpired(leg(a, b, fetchedAt = today.minusDays(29)), today))
+        // Day 30 is the first day it must be gone.
+        assertTrue(RouteCache.isExpired(leg(a, b, fetchedAt = today.minusDays(30)), today))
+        assertTrue(RouteCache.isExpired(leg(a, b, fetchedAt = today.minusDays(31)), today))
+        assertEquals(30L, RouteCache.RETENTION_DAYS)
+    }
+
+    @Test
+    fun `stale picks out the legs that no longer describe an arrival here`() {
+        val stops = listOf(
+            stop("first", 0, a, leg = leg(a, b)),
+            stop("second", 1, b, leg = leg(a, b)),
+            stop("third", 2, c, leg = leg(a, c)),
+            stop("fourth", 3, a, leg = leg(c, a, fetchedAt = today.minusDays(30))),
+            stop("fifth", 4, b),
+        )
+        assertEquals(listOf("first", "third", "fourth"), RouteCache.stale(stops, today).map { it.id })
+    }
+
+    @Test
+    fun `a leg on a stop that dropped out of the route goes with it`() {
+        val stops = listOf(
+            stop("s1", 0, a),
+            stop("skipped", 1, b, state = StopState.SKIPPED, leg = leg(a, b)),
+            stop("unpinned", 2, location = null, leg = leg(b, c)),
+            stop("s4", 3, c, leg = leg(a, c)),
+        )
+        assertEquals(listOf("skipped", "unpinned"), RouteCache.stale(stops, today).map { it.id })
+        assertTrue(RouteCache.stale(emptyList(), today).isEmpty())
+    }
+
+    @Test
+    fun `nothing needs fetching while every drive has a fresh matching leg`() {
+        val stops = listOf(
+            stop("s1", 0, a),
+            stop("s2", 1, b, leg = leg(a, b, fetchedAt = today.minusDays(29))),
+            stop("s3", 2, c, leg = leg(b, c)),
+        )
+        assertFalse(RouteCache.needsFetch(stops, today))
+        assertFalse(RouteCache.needsFetch(listOf(stop("only", 0, a)), today))
+    }
+
+    @Test
+    fun `a missing or expired leg is a drive that must be fetched`() {
+        val s1 = stop("s1", 0, a)
+        val s3 = stop("s3", 2, c, leg = leg(b, c))
+        assertTrue(RouteCache.needsFetch(listOf(s1, stop("s2", 1, b), s3), today))
+        assertTrue(
+            RouteCache.needsFetch(
+                listOf(s1, stop("s2", 1, b, leg = leg(a, b, fetchedAt = today.minusDays(30))), s3),
+                today,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/domain/RouteRefresherTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/domain/RouteRefresherTest.kt
@@ -3,6 +3,7 @@ package com.nuelto.camperexperience.domain
 import com.nuelto.camperexperience.data.InMemoryTripRepository
 import com.nuelto.camperexperience.data.model.LatLng
 import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.StopElevation
 import com.nuelto.camperexperience.data.model.StopLeg
 import java.time.LocalDate
 import kotlinx.coroutines.CompletableDeferred
@@ -175,7 +176,8 @@ class RouteRefresherTest {
         }.refresh("t1", today)
 
         assertEquals(1, result.fetched)
-        assertEquals(listOf(Polyline.decode(geometry)), sampled)
+        // Both stops' own heights, then the leg's sampled geometry.
+        assertEquals(listOf(listOf(here, there), Polyline.decode(geometry)), sampled)
         val drive = stop("b").leg!!
         assertEquals(151, drive.ascentMeters)
         assertEquals(50, drive.descentMeters)
@@ -207,7 +209,8 @@ class RouteRefresherTest {
         }.refresh("t1", today)
 
         assertEquals(1, result.fetched)
-        assertTrue(sampled.isEmpty())
+        // Only the two stops' own heights — nothing to sample along an empty polyline.
+        assertEquals(listOf(listOf(here, there)), sampled)
         val drive = stop("b").leg!!
         assertEquals(500, drive.distanceMeters)
         assertNull(drive.ascentMeters)
@@ -344,6 +347,62 @@ class RouteRefresherTest {
 
         assertEquals(300, stop("b").leg!!.ascentMeters)
         assertEquals(150, stop("b").leg!!.descentMeters)
+    }
+
+    @Test
+    fun `every located stop gets its own height, in one call`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1)
+        addStop("c", location = null, index = 2)
+
+        val result = refresher(heights = { listOf(1469.4, 492.6) }) {
+            listOf(RoutedLeg(geometry, 1_000, 60))
+        }.refresh("t1", today)
+
+        assertEquals(2, result.elevated)
+        assertEquals(1469, Elevation.ofStop(stop("a")))
+        assertEquals(493, Elevation.ofStop(stop("b")))
+        // No pin, no height to ask for.
+        assertNull(stop("c").elevation)
+        // One call for both stops, not one each.
+        assertEquals(listOf(here, there), sampled.first())
+    }
+
+    @Test
+    fun `a height already measured where the stop sits is not fetched again`() = runTest {
+        addStop("a", here, index = 0)
+        repository.upsertStop(stop("a").copy(elevation = StopElevation(here, 1200)))
+
+        val result = refresher(heights = { listOf(999.0) }) { null }.refresh("t1", today)
+
+        assertEquals(0, result.elevated)
+        assertEquals(1200, Elevation.ofStop(stop("a")))
+        assertTrue(sampled.isEmpty())
+    }
+
+    @Test
+    fun `moving the pin re-measures the height`() = runTest {
+        addStop("a", there, index = 0)
+        repository.upsertStop(stop("a").copy(elevation = StopElevation(here, 1200)))
+
+        refresher(heights = { listOf(640.0) }) { null }.refresh("t1", today)
+
+        assertEquals(640, Elevation.ofStop(stop("a")))
+    }
+
+    @Test
+    fun `an unreachable elevation service leaves the heights alone`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1)
+
+        val result = refresher(heights = { null }) {
+            listOf(RoutedLeg(geometry, 1_000, 60))
+        }.refresh("t1", today)
+
+        assertEquals(0, result.elevated)
+        assertNull(stop("a").elevation)
+        // The route still landed: a missing height is not a failed refresh.
+        assertEquals(1, result.fetched)
     }
 
 }

--- a/app/src/test/java/com/nuelto/camperexperience/domain/RouteRefresherTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/domain/RouteRefresherTest.kt
@@ -1,0 +1,349 @@
+package com.nuelto.camperexperience.domain
+
+import com.nuelto.camperexperience.data.InMemoryTripRepository
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.StopLeg
+import java.time.LocalDate
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RouteRefresherTest {
+
+    private val today = LocalDate.of(2026, 9, 1)
+    private val here = LatLng(46.1712, 8.7936)
+    private val there = LatLng(46.9, 8.4)
+    private val elsewhere = LatLng(47.5, 7.6)
+
+    /** Google's own example string: three points, enough for the elevation path. */
+    private val geometry = "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
+
+    private val repository = InMemoryTripRepository(seed = false)
+    private val windows = mutableListOf<List<LatLng>>()
+    private val sampled = mutableListOf<List<LatLng>>()
+
+    private fun refresher(
+        heights: suspend (List<LatLng>) -> List<Double>? = { null },
+        route: suspend (List<LatLng>) -> List<RoutedLeg>?,
+    ) = RouteRefresher(
+        repository,
+        { points -> windows += points; route(points) },
+        { points -> sampled += points; heights(points) },
+    )
+
+    private suspend fun addStop(
+        id: String,
+        location: LatLng? = here,
+        index: Int = 0,
+        leg: StopLeg? = null,
+    ) = repository.upsertStop(
+        Stop(id = id, tripId = "t1", name = id, location = location, orderIndex = index, leg = leg),
+    )
+
+    private fun leg(from: LatLng, to: LatLng, fetchedAt: LocalDate, distance: Int = 1_000) = StopLeg(
+        from = from,
+        to = to,
+        polyline = geometry,
+        distanceMeters = distance,
+        durationSeconds = 600,
+        fetchedAt = fetchedAt,
+    )
+
+    private suspend fun stop(id: String) = repository.stops("t1").first().single { it.id == id }
+
+    @Test
+    fun `a missing leg is fetched onto the stop it arrives at`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1)
+
+        val result = refresher { listOf(RoutedLeg(geometry, 42_000, 3_600)) }.refresh("t1", today)
+
+        assertEquals(1, result.fetched)
+        assertEquals(0, result.cleared)
+        assertTrue(result.touched)
+        assertEquals(listOf(listOf(here, there)), windows)
+        assertNull(stop("a").leg)
+        val drive = stop("b").leg!!
+        assertEquals(here, drive.from)
+        assertEquals(there, drive.to)
+        assertEquals(geometry, drive.polyline)
+        assertEquals(42_000, drive.distanceMeters)
+        assertEquals(3_600, drive.durationSeconds)
+        assertEquals(today, drive.fetchedAt)
+        assertNull(drive.ascentMeters)
+        assertNull(drive.descentMeters)
+    }
+
+    @Test
+    fun `a trip whose legs all still describe it is never routed`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1, leg = leg(here, there, today.minusDays(29), distance = 7_000))
+
+        val result = refresher { listOf(RoutedLeg(geometry, 1, 1)) }.refresh("t1", today)
+
+        assertFalse(result.touched)
+        assertEquals(0, result.fetched)
+        assertEquals(0, result.cleared)
+        assertTrue(windows.isEmpty())
+        assertEquals(7_000, stop("b").leg!!.distanceMeters)
+    }
+
+    @Test
+    fun `a leg whose endpoints moved is cleared even with no network`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1, leg = leg(elsewhere, there, today))
+
+        val result = refresher { null }.refresh("t1", today)
+
+        assertEquals(1, result.cleared)
+        assertEquals(0, result.fetched)
+        assertTrue(result.touched)
+        assertNull(stop("b").leg)
+        assertEquals(listOf(listOf(here, there)), windows)
+    }
+
+    @Test
+    fun `a leg past the thirty-day window is cleared`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1, leg = leg(here, there, today.minusDays(30)))
+
+        val result = refresher { null }.refresh("t1", today)
+
+        assertEquals(1, result.cleared)
+        assertEquals(0, result.fetched)
+        assertNull(stop("b").leg)
+    }
+
+    @Test
+    fun `an expired leg is cleared and refetched in the same pass, dated today`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1, leg = leg(here, there, LocalDate.now().minusDays(30)))
+
+        val result = refresher { listOf(RoutedLeg(geometry, 9_000, 900)) }.refresh("t1")
+
+        assertEquals(1, result.cleared)
+        assertEquals(1, result.fetched)
+        val drive = stop("b").leg!!
+        assertEquals(9_000, drive.distanceMeters)
+        assertEquals(LocalDate.now(), drive.fetchedAt)
+    }
+
+    @Test
+    fun `a failed fetch leaves the legs that still hold`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1, leg = leg(here, there, today, distance = 7_000))
+        addStop("c", elsewhere, index = 2)
+
+        val result = refresher { null }.refresh("t1", today)
+
+        assertEquals(0, result.fetched)
+        assertEquals(0, result.cleared)
+        assertFalse(result.touched)
+        assertEquals(7_000, stop("b").leg!!.distanceMeters)
+        assertNull(stop("c").leg)
+    }
+
+    @Test
+    fun `a response with the wrong number of legs writes nothing`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1)
+
+        val result = refresher {
+            listOf(RoutedLeg(geometry, 1, 1), RoutedLeg(geometry, 2, 2))
+        }.refresh("t1", today)
+
+        assertEquals(0, result.fetched)
+        assertFalse(result.touched)
+        assertNull(stop("b").leg)
+    }
+
+    @Test
+    fun `a height profile lands on the leg, rounded`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1)
+
+        val result = refresher(heights = { listOf(100.0, 250.6, 200.2) }) {
+            listOf(RoutedLeg(geometry, 42_000, 3_600))
+        }.refresh("t1", today)
+
+        assertEquals(1, result.fetched)
+        assertEquals(listOf(Polyline.decode(geometry)), sampled)
+        val drive = stop("b").leg!!
+        assertEquals(151, drive.ascentMeters)
+        assertEquals(50, drive.descentMeters)
+    }
+
+    @Test
+    fun `heights that do not line up with the samples are discarded`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1)
+
+        val result = refresher(heights = { listOf(100.0, 250.0) }) {
+            listOf(RoutedLeg(geometry, 42_000, 3_600))
+        }.refresh("t1", today)
+
+        assertEquals(1, result.fetched)
+        val drive = stop("b").leg!!
+        assertEquals(42_000, drive.distanceMeters)
+        assertNull(drive.ascentMeters)
+        assertNull(drive.descentMeters)
+    }
+
+    @Test
+    fun `a leg with no geometry is written without asking for heights`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1)
+
+        val result = refresher(heights = { listOf(100.0, 250.0) }) {
+            listOf(RoutedLeg("", 500, 60))
+        }.refresh("t1", today)
+
+        assertEquals(1, result.fetched)
+        assertTrue(sampled.isEmpty())
+        val drive = stop("b").leg!!
+        assertEquals(500, drive.distanceMeters)
+        assertNull(drive.ascentMeters)
+    }
+
+    @Test
+    fun `a long trip is routed in overlapping windows and every leg is written`() = runTest {
+        repeat(13) { addStop("s$it", LatLng(46.0 + it, 8.0), index = it) }
+
+        val result = refresher { window ->
+            window.zipWithNext().map { (_, to) -> RoutedLeg(geometry, to.latitude.toInt(), 60) }
+        }.refresh("t1", today)
+
+        assertEquals(12, result.fetched)
+        assertEquals(listOf(12, 2), windows.map { it.size })
+        assertNull(stop("s0").leg)
+        (1..12).forEach { index ->
+            val drive = stop("s$index").leg!!
+            assertEquals(46 + index, drive.distanceMeters)
+            assertEquals(LatLng(45.0 + index, 8.0), drive.from)
+            assertEquals(LatLng(46.0 + index, 8.0), drive.to)
+        }
+    }
+
+    @Test
+    fun `a window that fails discards the whole chain`() = runTest {
+        repeat(13) { addStop("s$it", LatLng(46.0 + it, 8.0), index = it) }
+
+        val result = refresher { window ->
+            if (window.size == 2) null else window.zipWithNext().map { RoutedLeg(geometry, 1, 1) }
+        }.refresh("t1", today)
+
+        assertEquals(0, result.fetched)
+        assertEquals(listOf(12, 2), windows.map { it.size })
+        assertTrue(repository.stops("t1").first().all { it.leg == null })
+    }
+
+    @Test
+    fun `a trip with nothing to drive between is never routed`() = runTest {
+        addStop("lonely", here, index = 0)
+
+        val result = refresher { listOf(RoutedLeg(geometry, 1, 1)) }.refresh("t1", today)
+
+        assertFalse(result.touched)
+        assertTrue(windows.isEmpty())
+        assertNull(stop("lonely").leg)
+    }
+
+    @Test
+    fun `an edit made while the route was in flight is not reverted`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1)
+        val gate = CompletableDeferred<Unit>()
+        val running = launch {
+            RouteRefresher(repository, route = { gate.await(); listOf(RoutedLeg(geometry, 12_000, 600)) })
+                .refresh("t1", today)
+        }
+        runCurrent()
+
+        repository.upsertStop(stop("b").copy(name = "Gotthard", nights = 3))
+        gate.complete(Unit)
+        running.join()
+
+        val arrived = stop("b")
+        assertEquals("Gotthard", arrived.name)
+        assertEquals(3, arrived.nights)
+        assertEquals(12_000, arrived.leg!!.distanceMeters)
+    }
+
+    @Test
+    fun `a stop deleted while the route was in flight is skipped`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1)
+        val gate = CompletableDeferred<Unit>()
+        var result: RouteRefresher.Result? = null
+        val running = launch {
+            result = RouteRefresher(repository, route = { gate.await(); listOf(RoutedLeg(geometry, 1, 1)) })
+                .refresh("t1", today)
+        }
+        runCurrent()
+
+        repository.deleteStop("t1", "b")
+        gate.complete(Unit)
+        running.join()
+
+        assertEquals(0, result!!.fetched)
+        assertFalse(result!!.touched)
+        assertNull(stop("a").leg)
+    }
+    @Test
+    fun `a failed elevation call keeps the climb already measured for that drive`() = runTest {
+        val measured = leg(here, there, LocalDate.now()).copy(ascentMeters = 900, descentMeters = 300)
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1, leg = measured)
+        addStop("c", elsewhere, index = 2)
+
+        // The new stop makes the whole chain re-route; the DEM service is down meanwhile.
+        val result = refresher(heights = { null }) { points ->
+            points.zipWithNext().map { RoutedLeg(geometry, 5_000, 1_200) }
+        }.refresh("t1")
+
+        assertEquals(2, result.fetched)
+        val kept = stop("b").leg!!
+        assertEquals(900, kept.ascentMeters)
+        assertEquals(300, kept.descentMeters)
+        // The rest of the leg is the fresh one, not the old one.
+        assertEquals(5_000, kept.distanceMeters)
+        // Nothing to keep for the drive that never had a climb.
+        assertEquals(null, stop("c").leg!!.ascentMeters)
+    }
+
+    @Test
+    fun `a climb is not carried over to a different drive`() = runTest {
+        val elsewhereLeg = leg(here, elsewhere, LocalDate.now()).copy(ascentMeters = 900)
+        addStop("a", here, index = 0)
+        // The stored leg describes a drive from somewhere this stop no longer follows.
+        addStop("b", there, index = 1, leg = elsewhereLeg)
+
+        refresher(heights = { null }) { listOf(RoutedLeg(geometry, 5_000, 1_200)) }.refresh("t1")
+
+        assertEquals(null, stop("b").leg!!.ascentMeters)
+    }
+
+    @Test
+    fun `a fresh climb wins over the stored one`() = runTest {
+        val measured = leg(here, there, LocalDate.now()).copy(ascentMeters = 900, descentMeters = 300)
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1, leg = measured)
+        addStop("c", elsewhere, index = 2)
+
+        refresher(heights = { listOf(100.0, 400.0, 250.0) }) { points ->
+            points.zipWithNext().map { RoutedLeg(geometry, 5_000, 1_200) }
+        }.refresh("t1")
+
+        assertEquals(300, stop("b").leg!!.ascentMeters)
+        assertEquals(150, stop("b").leg!!.descentMeters)
+    }
+
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/FormatTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/FormatTest.kt
@@ -135,14 +135,9 @@ class FormatTest {
     }
 
     @Test
-    fun `the climb is mentioned from 200 m up, never below`() {
-        assertEquals("10 km · 12 min", formatDrive(leg(10_000, 700, 199)))
-        assertEquals("10 km · 12 min · ↑ 200 m", formatDrive(leg(10_000, 700, 200)))
-        assertEquals("10 km · 12 min · ↑ 1450 m", formatDrive(leg(10_000, 700, 1450)))
-    }
-
-    @Test
-    fun `an unknown climb is left out`() {
+    fun `the drive is distance and time only, never the climb`() {
+        // Cumulative ascent beside a place name reads as the height of the place.
+        assertEquals("10 km · 12 min", formatDrive(leg(10_000, 700, 1450)))
         assertEquals("10 km · 12 min", formatDrive(leg(10_000, 700, null)))
     }
 }

--- a/app/src/test/java/com/nuelto/camperexperience/ui/FormatTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/FormatTest.kt
@@ -140,4 +140,10 @@ class FormatTest {
         assertEquals("10 km · 12 min", formatDrive(leg(10_000, 700, 1450)))
         assertEquals("10 km · 12 min", formatDrive(leg(10_000, 700, null)))
     }
+    @Test
+    fun `the live drive says it is measured from where you are`() {
+        assertEquals("47 km · 55 min from here", formatDriveFromHere(47_000, 3_300))
+        assertEquals("800 m · 2 min from here", formatDriveFromHere(800, 100))
+    }
+
 }

--- a/app/src/test/java/com/nuelto/camperexperience/ui/FormatTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/FormatTest.kt
@@ -4,6 +4,10 @@ import com.nuelto.camperexperience.data.model.StopLeg
 import com.nuelto.camperexperience.data.model.Trip
 import com.nuelto.camperexperience.data.model.TripStatus
 import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 import java.util.Locale
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -140,10 +144,49 @@ class FormatTest {
         assertEquals("10 km · 12 min", formatDrive(leg(10_000, 700, 1450)))
         assertEquals("10 km · 12 min", formatDrive(leg(10_000, 700, null)))
     }
+    private val midday = LocalDateTime.of(2026, 9, 1, 15, 47)
+    private val evening = LocalDateTime.of(2026, 9, 1, 22, 30)
+
+    /**
+     * The clock time as the platform writes it. Spelling it out here would pin CLDR's
+     * spacing (it puts U+202F before "PM"), not our arithmetic — which is the part worth
+     * asserting: that the arrival really is now plus the drive.
+     */
+    private fun at(hour: Int, minute: Int): String =
+        DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT).format(LocalTime.of(hour, minute))
+
     @Test
-    fun `the live drive says it is measured from where you are`() {
-        assertEquals("47 km · 55 min from here", formatDriveFromHere(47_000, 3_300))
-        assertEquals("800 m · 2 min from here", formatDriveFromHere(800, 100))
+    fun `the live drive says how far, how long, and when you get there`() {
+        assertEquals(
+            "47 km · 55 min from here · arrive ${at(16, 42)}",
+            formatDriveFromHere(47_000, 3_300, midday),
+        )
+        assertEquals(
+            "800 m · 2 min from here · arrive ${at(15, 49)}",
+            formatDriveFromHere(800, 100, midday),
+        )
+    }
+
+    @Test
+    fun `arrival is now plus the drive`() {
+        assertEquals("arrive ${at(16, 42)}", formatArrival(3_300, midday))
+        assertEquals("arrive ${at(15, 47)}", formatArrival(0, midday))
+    }
+
+    @Test
+    fun `an arrival past midnight names the day`() {
+        // Four hours on: the same clock time tomorrow would otherwise read as this morning.
+        assertEquals("arrive ${at(2, 30)} tomorrow", formatArrival(4 * 3_600, evening))
+        // Just before midnight is still today.
+        assertEquals("arrive ${at(23, 59)}", formatArrival(89 * 60, evening))
+    }
+
+    @Test
+    fun `an arrival further out names the date`() {
+        assertEquals(
+            "arrive ${at(22, 30)} on ${formatDate(LocalDate.of(2026, 9, 3))}",
+            formatArrival(2 * 24 * 3_600, evening),
+        )
     }
 
 }

--- a/app/src/test/java/com/nuelto/camperexperience/ui/FormatTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/FormatTest.kt
@@ -1,5 +1,6 @@
 package com.nuelto.camperexperience.ui
 
+import com.nuelto.camperexperience.data.model.StopLeg
 import com.nuelto.camperexperience.data.model.Trip
 import com.nuelto.camperexperience.data.model.TripStatus
 import java.time.LocalDate
@@ -81,5 +82,67 @@ class FormatTest {
             "${formatDate(start)} – ${formatDate(end)}",
             formatTripDates(Trip(startDate = start, endDate = end, status = TripStatus.PLANNED)),
         )
+    }
+
+    @Test
+    fun `distance stays in metres below a kilometre and flips at 1000`() {
+        assertEquals("0 m", formatDistance(0))
+        assertEquals("999 m", formatDistance(999))
+        assertEquals("1 km", formatDistance(1000))
+    }
+
+    @Test
+    fun `kilometres round to the nearest whole one`() {
+        assertEquals("1 km", formatDistance(1499))
+        assertEquals("2 km", formatDistance(1500))
+        assertEquals("124 km", formatDistance(124_400))
+    }
+
+    @Test
+    fun `a duration under an hour is minutes only`() {
+        assertEquals("0 min", formatDuration(0))
+        assertEquals("45 min", formatDuration(2700))
+        assertEquals("59 min", formatDuration(3540))
+    }
+
+    @Test
+    fun `whole hours drop the minutes`() {
+        assertEquals("1 h", formatDuration(3600))
+        assertEquals("2 h", formatDuration(7200))
+    }
+
+    @Test
+    fun `hours carry their leftover minutes`() {
+        assertEquals("1 h 1 min", formatDuration(3660))
+        assertEquals("1 h 45 min", formatDuration(6300))
+    }
+
+    @Test
+    fun `seconds round to the nearest minute`() {
+        assertEquals("0 min", formatDuration(29))
+        assertEquals("1 min", formatDuration(30))
+        assertEquals("1 min", formatDuration(89))
+        assertEquals("2 min", formatDuration(90))
+    }
+
+    private fun leg(meters: Int, seconds: Int, ascent: Int? = null) =
+        StopLeg(distanceMeters = meters, durationSeconds = seconds, ascentMeters = ascent)
+
+    @Test
+    fun `a drive joins distance and duration`() {
+        assertEquals("124 km · 1 h 45 min", formatDrive(leg(124_400, 6300)))
+        assertEquals("800 m · 12 min", formatDrive(leg(800, 700)))
+    }
+
+    @Test
+    fun `the climb is mentioned from 200 m up, never below`() {
+        assertEquals("10 km · 12 min", formatDrive(leg(10_000, 700, 199)))
+        assertEquals("10 km · 12 min · ↑ 200 m", formatDrive(leg(10_000, 700, 200)))
+        assertEquals("10 km · 12 min · ↑ 1450 m", formatDrive(leg(10_000, 700, 1450)))
+    }
+
+    @Test
+    fun `an unknown climb is left out`() {
+        assertEquals("10 km · 12 min", formatDrive(leg(10_000, 700, null)))
     }
 }

--- a/app/src/test/java/com/nuelto/camperexperience/ui/nav/AppNavHostTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/nav/AppNavHostTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nuelto.camperexperience.testutil.TestCamperApp
@@ -155,4 +156,29 @@ class AppNavHostTest {
         compose.onNodeWithContentDescription("Back").performClick()
         compose.onNodeWithText("Trips").assertIsDisplayed()
     }
+    @Test
+    fun `home is picked on the map, exactly as a stop's location is`() {
+        setContent()
+        compose.onNodeWithContentDescription("Settings").performClick()
+        compose.onNodeWithText("Home").performScrollTo().assertIsDisplayed()
+        compose.onNodeWithText("  Pick on map").performScrollTo().performClick()
+
+        compose.onNodeWithText("Pick location").assertIsDisplayed()
+        compose.onNodeWithTag("map-placeholder").performClick()
+        compose.onNodeWithText("Use this place").performClick()
+
+        // Back in Settings, with somewhere for new plans to start from.
+        compose.onNodeWithText("Set — new plans start here.").performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun `picking home can be cancelled`() {
+        setContent()
+        compose.onNodeWithContentDescription("Settings").performClick()
+        compose.onNodeWithText("  Pick on map").performScrollTo().performClick()
+        compose.onNodeWithContentDescription("Cancel").performClick()
+        compose.onNodeWithText("Not set. Pick it below and new plans will start from it.")
+            .performScrollTo().assertIsDisplayed()
+    }
+
 }

--- a/app/src/test/java/com/nuelto/camperexperience/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/settings/SettingsScreenTest.kt
@@ -6,6 +6,8 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.nuelto.camperexperience.data.model.LatLng
+import org.junit.Assert.assertNull
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -55,8 +57,8 @@ class SettingsScreenTest {
         compose.onNodeWithText("10.0").assertIsDisplayed() // consumption
         compose.onNodeWithText("1.8").assertIsDisplayed() // fuel price
         compose.onNodeWithText("1.25").assertIsDisplayed() // road factor
-        compose.onNodeWithText("45.0").assertIsDisplayed() // campsite per night
-        compose.onNodeWithText("15.0").assertIsDisplayed() // stellplatz per night
+        compose.onNodeWithText("45.0").performScrollTo().assertIsDisplayed() // campsite per night
+        compose.onNodeWithText("15.0").performScrollTo().assertIsDisplayed() // stellplatz per night
     }
 
     @Test
@@ -164,9 +166,39 @@ class SettingsScreenTest {
                 "fuel the flat-road consumption above does not account for.",
         ).performScrollTo().assertIsDisplayed()
     }
+
+    @Test
+    fun `home says whether it is set, and takes a name`() {
+        setContent()
+        compose.onNodeWithText("Home").performScrollTo().assertIsDisplayed()
+        compose.onNodeWithText("Not set. Pick it below and new plans will start from it.")
+            .performScrollTo().assertIsDisplayed()
+        compose.onNodeWithText("Clear home").assertDoesNotExist()
+
+        runBlocking {
+            settingsRepository.update(
+                settingsRepository.settings().first().copy(homeLocation = LatLng(47.05, 8.31)),
+            )
+        }
+        compose.onNodeWithText("Set — new plans start here.").performScrollTo().assertIsDisplayed()
+        compose.onNodeWithText("Clear home").performScrollTo().performClick()
+        runBlocking {
+            assertNull(settingsRepository.settings().first().homeLocation)
+        }
+    }
+
+    @Test
+    fun `naming home stores it`() {
+        setContent()
+        compose.onNodeWithText("Name").performScrollTo().performTextReplacement("Luzern")
+        runBlocking {
+            assertEquals("Luzern", settingsRepository.settings().first().homeName)
+        }
+    }
 }
 
 /** Stands in for the Google provider, which cannot be composed under Robolectric. */
 private object AttributedMapProvider : MapProvider by PlaceholderMapProvider {
     override val attribution = "Map data and places © Google"
+
 }

--- a/app/src/test/java/com/nuelto/camperexperience/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/settings/SettingsScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nuelto.camperexperience.BuildConfig
@@ -107,21 +108,21 @@ class SettingsScreenTest {
     fun `sign out delegates to the auth repository`() {
         val auth = FakeAuthRepository()
         setContent(auth)
-        compose.onNodeWithText("Sign out").performClick()
+        compose.onNodeWithText("Sign out").performScrollTo().performClick()
         assertEquals(1, auth.signOutCalls)
     }
 
     @Test
     fun `shows the app version, and no attribution line when there is no map`() {
         setContent()
-        compose.onNodeWithText("Version ${BuildConfig.VERSION_NAME}").assertIsDisplayed()
+        compose.onNodeWithText("Version ${BuildConfig.VERSION_NAME}").performScrollTo().assertIsDisplayed()
         compose.onNodeWithText("Map data and places © Google").assertDoesNotExist()
     }
 
     @Test
     fun `attribution follows the map provider`() {
         setContent(provider = AttributedMapProvider)
-        compose.onNodeWithText("Map data and places © Google").assertIsDisplayed()
+        compose.onNodeWithText("Map data and places © Google").performScrollTo().assertIsDisplayed()
     }
 
     @Test
@@ -129,6 +130,39 @@ class SettingsScreenTest {
         setContent()
         compose.onNodeWithContentDescription("Back").performClick()
         assertEquals(listOf("back"), events)
+    }
+
+    @Test
+    fun `vehicle weight edits are committed while typing`() {
+        setContent()
+        compose.onNodeWithText("3500.0").performScrollTo().performTextReplacement("3200")
+        runBlocking {
+            assertEquals(3200.0, settingsRepository.settings().first().vehicleMassKg, 1e-9)
+        }
+    }
+
+    @Test
+    fun `an unusable vehicle weight is not committed`() {
+        setContent()
+        compose.onNodeWithText("3500.0").performScrollTo().performTextReplacement("0")
+        compose.onNodeWithText("0").performTextReplacement("heavy")
+        runBlocking {
+            assertEquals(3500.0, settingsRepository.settings().first().vehicleMassKg, 1e-9)
+        }
+    }
+
+    @Test
+    fun `explains that the road factor only fills in, and what the weight is for`() {
+        setContent()
+        compose.onNodeWithText(
+            "Distance comes from the road Google routes between stops. This factor " +
+                "only fills in for legs with no route yet — no map key, or no signal " +
+                "when they were added.",
+        ).performScrollTo().assertIsDisplayed()
+        compose.onNodeWithText(
+            "Used to price the climbing on a route: lifting the van over a pass costs " +
+                "fuel the flat-road consumption above does not account for.",
+        ).performScrollTo().assertIsDisplayed()
     }
 }
 

--- a/app/src/test/java/com/nuelto/camperexperience/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/settings/SettingsViewModelTest.kt
@@ -2,6 +2,8 @@ package com.nuelto.camperexperience.ui.settings
 
 import app.cash.turbine.test
 import com.nuelto.camperexperience.data.InMemorySettingsRepository
+import com.nuelto.camperexperience.data.model.LatLng
+import kotlinx.coroutines.flow.first
 import com.nuelto.camperexperience.data.model.UserSettings
 import com.nuelto.camperexperience.testutil.FakeAuthRepository
 import com.nuelto.camperexperience.testutil.MainDispatcherRule
@@ -50,4 +52,55 @@ class SettingsViewModelTest {
     fun `sign out without auth repository is a no-op`() {
         SettingsViewModel(settingsRepository, null).signOut() // must not throw
     }
+    @Test
+    fun `setting home keeps the name when the pick has none`() = runTest {
+        val vm = SettingsViewModel(settingsRepository, null)
+        vm.settings.test {
+            awaitItem()
+            vm.update(UserSettings(homeName = "Luzern"))
+            awaitItem()
+            vm.setHome(LatLng(47.05, 8.31))
+            val stored = awaitItem()!!
+            assertEquals(LatLng(47.05, 8.31), stored.homeLocation)
+            // A dropped pin has no name; the one already there survives.
+            assertEquals("Luzern", stored.homeName)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `a named pick renames home`() = runTest {
+        val vm = SettingsViewModel(settingsRepository, null)
+        vm.settings.test {
+            awaitItem()
+            vm.setHome(LatLng(47.05, 8.31), "Camping Lido")
+            val stored = awaitItem()!!
+            assertEquals("Camping Lido", stored.homeName)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `clearing home drops both the pin and the name`() = runTest {
+        val vm = SettingsViewModel(settingsRepository, null)
+        vm.settings.test {
+            awaitItem()
+            vm.setHome(LatLng(47.05, 8.31), "Luzern")
+            awaitItem()
+            vm.clearHome()
+            val stored = awaitItem()!!
+            assertNull(stored.homeLocation)
+            assertEquals("", stored.homeName)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `home cannot be set before the settings have loaded`() = runTest {
+        val vm = SettingsViewModel(settingsRepository, null)
+        vm.setHome(LatLng(47.05, 8.31))
+        vm.clearHome()
+        assertNull(settingsRepository.settings().first().homeLocation)
+    }
+
 }

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/ExpenseEditSheetTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/ExpenseEditSheetTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -13,6 +14,7 @@ import com.nuelto.camperexperience.data.model.Expense
 import com.nuelto.camperexperience.data.model.ExpenseType
 import com.nuelto.camperexperience.data.model.LatLng
 import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.StopLeg
 import com.nuelto.camperexperience.data.model.UserSettings
 import com.nuelto.camperexperience.testutil.TestCamperApp
 import java.time.LocalDate
@@ -143,5 +145,80 @@ class ExpenseEditSheetTest {
     fun `zero amount on an existing expense shows an empty field`() {
         setContent(Expense(id = "e1", tripId = "t1", amount = 0.0))
         compose.onNodeWithText("Save").assertIsNotEnabled()
+    }
+
+    /** The same drive, routed at 80 km, with the climb figures under test. */
+    private fun routedStops(ascentMeters: Int?, descentMeters: Int?) = listOf(
+        locatedStops[0],
+        locatedStops[1].copy(
+            leg = StopLeg(
+                from = LatLng(47.0, 7.0),
+                to = LatLng(47.5, 7.5),
+                distanceMeters = 80_000,
+                ascentMeters = ascentMeters,
+                descentMeters = descentMeters,
+            ),
+        ),
+    )
+
+    @Test
+    fun `a climbing leg is priced on top of the flat estimate`() {
+        setContent(stops = routedStops(ascentMeters = 1500, descentMeters = 0))
+        compose.onNodeWithText("Estimate from distance…").performClick()
+        compose.onNodeWithText("Plus 4.5 l for the climbing on the way.")
+            .performScrollTo().assertIsDisplayed()
+        compose.onNodeWithText("Use this amount").performClick()
+        compose.onNodeWithText("Save").performClick()
+        // 80 km x 10 l/100km x 1.80 = 14.40 flat, plus 4.50 l of lift at 1.80.
+        assertTrue(saved.single().amount > 14.40)
+        assertEquals(22.49, saved.single().amount, 1e-9)
+    }
+
+    @Test
+    fun `a leg with no elevation prices the distance alone`() {
+        setContent(stops = routedStops(ascentMeters = null, descentMeters = null))
+        compose.onNodeWithText("Estimate from distance…").performClick()
+        compose.onNodeWithText("for the climbing on the way", substring = true)
+            .assertDoesNotExist()
+        compose.onNodeWithText("Use this amount").performClick()
+        compose.onNodeWithText("Save").performClick()
+        assertEquals(14.40, saved.single().amount, 1e-9)
+    }
+
+    @Test
+    fun `a descent gives fuel back, and says so`() {
+        setContent(stops = routedStops(ascentMeters = 100, descentMeters = 1800))
+        compose.onNodeWithText("Estimate from distance…").performClick()
+        compose.onNodeWithText("given back on the way down", substring = true)
+            .performScrollTo().assertIsDisplayed()
+        compose.onNodeWithText("Use this amount").performClick()
+        compose.onNodeWithText("Save").performClick()
+        assertTrue(saved.single().amount < 14.40)
+        assertTrue(saved.single().amount > 0.0)
+    }
+
+    @Test
+    fun `shortening the distance prices only that share of the climb`() {
+        setContent(stops = routedStops(ascentMeters = 1500, descentMeters = 0))
+        compose.onNodeWithText("Estimate from distance…").performClick()
+        compose.onNodeWithText("80").performScrollTo().performTextReplacement("40")
+        // Half the routed drive, so half the lift: 40 x 10/100 x 1.80 + 2.248 x 1.80.
+        compose.onNodeWithText("Plus 2.2 l for the climbing on the way.")
+            .performScrollTo().assertIsDisplayed()
+        compose.onNodeWithText("Use this amount").performClick()
+        compose.onNodeWithText("Save").performClick()
+        assertEquals(11.25, saved.single().amount, 1e-9)
+    }
+
+    @Test
+    fun `a descent credit can never drive the estimate below zero`() {
+        setContent(stops = routedStops(ascentMeters = 100, descentMeters = 1800))
+        compose.onNodeWithText("Estimate from distance…").performClick()
+        // Well under the consumption the credit was capped against, which is what used to
+        // let the credit outgrow the fuel it stands in for.
+        compose.onNodeWithText("10.0").performScrollTo().performTextReplacement("1")
+        compose.onNodeWithText("Use this amount").performClick()
+        compose.onNodeWithText("Save").performClick()
+        assertEquals(0.0, saved.single().amount, 1e-9)
     }
 }

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreenTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreenTest.kt
@@ -2,6 +2,16 @@ package com.nuelto.camperexperience.ui.tripdetail
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.geometry.Offset
+import android.Manifest
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import com.nuelto.camperexperience.domain.RoutedLeg
+import org.robolectric.Shadows.shadowOf
+import androidx.activity.result.ActivityResultRegistry
+import androidx.activity.result.ActivityResultRegistryOwner
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.activity.compose.LocalActivityResultRegistryOwner
+import androidx.core.app.ActivityOptionsCompat
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasContentDescription
@@ -132,14 +142,24 @@ class TripDetailScreenTest {
         )
     }
 
-    private fun setContent(tripId: String = "t1") {
-        val viewModel = TripDetailViewModel(
+    private fun setContent(
+        tripId: String = "t1",
+        viewModel: TripDetailViewModel = TripDetailViewModel(
             SavedStateHandle(mapOf("tripId" to tripId)),
             tripRepository,
             settingsRepository,
-        )
+        ),
+        // Answers any permission request with this, so the grant flow can be driven.
+        permissionAnswer: Boolean? = null,
+    ) {
+        val registryOwner = object : ActivityResultRegistryOwner {
+            override val activityResultRegistry = answeringRegistry(permissionAnswer ?: false)
+        }
         compose.setContent {
-            CompositionLocalProvider(LocalMapProvider provides PlaceholderMapProvider) {
+            CompositionLocalProvider(
+                LocalMapProvider provides PlaceholderMapProvider,
+                LocalActivityResultRegistryOwner provides registryOwner,
+            ) {
                 TripDetailScreen(
                     onBack = { events += "back" },
                     onEditTrip = { events += "edit:$it" },
@@ -701,6 +721,98 @@ class TripDetailScreenTest {
         compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camping Delta"))
         compose.onNodeWithContentDescription("Height above sea level", useUnmergedTree = true)
             .assertExists()
+    }
+
+    // --- distance from here ------------------------------------------------------------
+
+    private fun grantLocation() {
+        shadowOf(ApplicationProvider.getApplicationContext<Application>())
+            .grantPermissions(Manifest.permission.ACCESS_FINE_LOCATION)
+    }
+
+    private fun locatingViewModel(fix: LatLng?, leg: RoutedLeg?) = TripDetailViewModel(
+        SavedStateHandle(mapOf("tripId" to "a1")),
+        tripRepository,
+        settingsRepository,
+        currentLocation = { fix },
+        drive = { _, _ -> leg },
+    )
+
+    @Test
+    fun `tonight's stop shows how far it is from where you are`() {
+        seedActive()
+        grantLocation()
+        setContent("a1", locatingViewModel(LatLng(46.9, 8.5), RoutedLeg("", 47_000, 3_300)))
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
+        compose.onNodeWithText("47 km · 55 min from here", useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun `without the location permission it offers to find out`() {
+        seedActive()
+        setContent("a1", locatingViewModel(LatLng(46.9, 8.5), RoutedLeg("", 47_000, 3_300)))
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
+        compose.onNodeWithText("Show distance from here", useUnmergedTree = true).assertIsDisplayed()
+        compose.onAllNodesWithText("from here", substring = true).assertCountEquals(1)
+    }
+
+    @Test
+    fun `with permission but no fix the planned drive stays`() {
+        seedActive()
+        grantLocation()
+        runBlocking {
+            val cur = tripRepository.stops("a1").first().first { it.id == "cur" }
+            tripRepository.upsertStop(
+                cur.copy(
+                    leg = StopLeg(
+                        from = LatLng(46.9, 8.5), to = LatLng(46.16, 8.79),
+                        distanceMeters = 124_000, durationSeconds = 6_300,
+                    ),
+                ),
+            )
+        }
+        setContent("a1", locatingViewModel(fix = null, leg = null))
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
+        compose.onAllNodesWithText("from here", substring = true).assertCountEquals(0)
+    }
+
+    /** A registry that answers a permission request immediately, without a system dialog. */
+    @Suppress("UNCHECKED_CAST")
+    private fun answeringRegistry(granted: Boolean) = object : ActivityResultRegistry() {
+        override fun <I, O> onLaunch(
+            requestCode: Int,
+            contract: ActivityResultContract<I, O>,
+            input: I,
+            options: ActivityOptionsCompat?,
+        ) {
+            dispatchResult(requestCode, granted as O)
+        }
+    }
+
+    @Test
+    fun `granting the permission fills the distance in`() {
+        seedActive()
+        setContent(
+            "a1",
+            locatingViewModel(LatLng(46.9, 8.5), RoutedLeg("", 47_000, 3_300)),
+            permissionAnswer = true,
+        )
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
+        compose.onNodeWithText("Show distance from here", useUnmergedTree = true).performClick()
+        compose.onNodeWithText("47 km · 55 min from here", useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun `refusing the permission leaves the offer standing`() {
+        seedActive()
+        setContent(
+            "a1",
+            locatingViewModel(LatLng(46.9, 8.5), RoutedLeg("", 47_000, 3_300)),
+            permissionAnswer = false,
+        )
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
+        compose.onNodeWithText("Show distance from here", useUnmergedTree = true).performClick()
+        compose.onAllNodesWithText("47 km", substring = true).assertCountEquals(0)
     }
 
 }

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreenTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreenTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
@@ -25,6 +26,7 @@ import com.nuelto.camperexperience.data.model.ExpenseType
 import com.nuelto.camperexperience.data.model.LatLng
 import com.nuelto.camperexperience.data.model.Stop
 import com.nuelto.camperexperience.data.model.StopKind
+import com.nuelto.camperexperience.data.model.StopElevation
 import com.nuelto.camperexperience.data.model.StopLeg
 import com.nuelto.camperexperience.data.model.StopState
 import com.nuelto.camperexperience.data.model.Trip
@@ -633,4 +635,33 @@ class TripDetailScreenTest {
         compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camping Delta"))
         compose.onAllNodes(hasText("\u2192", substring = true)).assertCountEquals(0)
     }
+    @Test
+    fun `a stop shows how high it sits`() {
+        seedPlan()
+        runBlocking {
+            val s2 = tripRepository.stops("p1").first().first { it.id == "s2" }
+            tripRepository.upsertStop(
+                s2.copy(elevation = StopElevation(LatLng(46.16, 8.79), 1469)),
+            )
+        }
+        setContent("p1")
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camping Delta"))
+        compose.onNodeWithText("1469 m", substring = true, useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a height measured somewhere else is not shown`() {
+        seedPlan()
+        runBlocking {
+            val s2 = tripRepository.stops("p1").first().first { it.id == "s2" }
+            // Pin moved since the height was measured.
+            tripRepository.upsertStop(
+                s2.copy(elevation = StopElevation(LatLng(46.99, 8.01), 1469)),
+            )
+        }
+        setContent("p1")
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camping Delta"))
+        compose.onAllNodesWithText("1469 m", substring = true).assertCountEquals(0)
+    }
+
 }

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreenTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreenTest.kt
@@ -46,6 +46,7 @@ import com.nuelto.camperexperience.data.model.TripStatus
 import com.nuelto.camperexperience.testutil.TestCamperApp
 import com.nuelto.camperexperience.ui.map.LocalMapProvider
 import com.nuelto.camperexperience.ui.map.PlaceholderMapProvider
+import com.nuelto.camperexperience.ui.formatDate
 import com.nuelto.camperexperience.ui.formatDriveFromHere
 import java.time.LocalDateTime
 import java.time.LocalDate
@@ -855,6 +856,30 @@ class TripDetailScreenTest {
         setContent("a1", locatingViewModel(LatLng(46.9, 8.5), RoutedLeg("", 47_000, 3_300)))
         compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
         compose.onAllNodesWithText("Show distance from here").assertCountEquals(0)
+    }
+
+    @Test
+    fun `the home stop reads as the start, with a home icon`() {
+        runBlocking {
+            tripRepository.upsertTrip(
+                Trip(id = "h1", name = "Plan", startDate = LocalDate.of(2027, 6, 10), status = TripStatus.PLANNED),
+            )
+            tripRepository.upsertStop(
+                Stop(
+                    id = "home", tripId = "h1", name = "Luzern", orderIndex = 0, nights = 0,
+                    kind = StopKind.HOME, location = LatLng(47.05, 8.31),
+                    arrivalDate = LocalDate.of(2027, 6, 10),
+                ),
+            )
+        }
+        setContent("h1")
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Luzern"))
+        compose.onAllNodesWithContentDescription("Home").onFirst().assertExists()
+        // The row's own line: the start date and nothing about nights or a price.
+        compose.onNodeWithText(
+            "${formatDate(LocalDate.of(2027, 6, 10))} · start",
+            useUnmergedTree = true,
+        ).assertIsDisplayed()
     }
 
 }

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreenTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreenTest.kt
@@ -25,6 +25,7 @@ import com.nuelto.camperexperience.data.model.ExpenseType
 import com.nuelto.camperexperience.data.model.LatLng
 import com.nuelto.camperexperience.data.model.Stop
 import com.nuelto.camperexperience.data.model.StopKind
+import com.nuelto.camperexperience.data.model.StopLeg
 import com.nuelto.camperexperience.data.model.StopState
 import com.nuelto.camperexperience.data.model.Trip
 import com.nuelto.camperexperience.data.model.TripStatus
@@ -602,5 +603,34 @@ class TripDetailScreenTest {
         assertEquals(1, events.size)
         assertTrue(events[0].startsWith("open:"))
         runBlocking { assertEquals(2, tripRepository.trips().first().size) }
+    }
+
+    // --- drive lines -----------------------------------------------------------------
+
+    @Test
+    fun `a stop whose leg still matches shows the drive arriving there`() {
+        seedPlan()
+        runBlocking {
+            val s2 = tripRepository.stops("p1").first().first { it.id == "s2" }
+            tripRepository.upsertStop(
+                s2.copy(
+                    leg = StopLeg(
+                        from = LatLng(47.05, 8.31), to = LatLng(46.16, 8.79),
+                        distanceMeters = 124_000, durationSeconds = 6_300,
+                    ),
+                ),
+            )
+        }
+        setContent("p1")
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("\u2192 124 km \u00b7 1 h 45 min"))
+        compose.onNodeWithText("\u2192 124 km \u00b7 1 h 45 min", useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a stop with no leg shows no drive line`() {
+        seedPlan()
+        setContent("p1")
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camping Delta"))
+        compose.onAllNodes(hasText("\u2192", substring = true)).assertCountEquals(0)
     }
 }

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreenTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreenTest.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onAllNodesWithText
+import com.nuelto.camperexperience.ui.tripedit.displayName
+import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
@@ -662,6 +664,43 @@ class TripDetailScreenTest {
         setContent("p1")
         compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camping Delta"))
         compose.onAllNodesWithText("1469 m", substring = true).assertCountEquals(0)
+    }
+
+    @Test
+    fun `each kind of spot gets its own icon beside the name`() {
+        runBlocking {
+            tripRepository.upsertTrip(
+                Trip(id = "k1", name = "Kinds", startDate = LocalDate.of(2027, 6, 10), status = TripStatus.PLANNED),
+            )
+            StopKind.entries.forEachIndexed { index, kind ->
+                tripRepository.upsertStop(
+                    Stop(
+                        id = "k-$kind", tripId = "k1", name = kind.name, orderIndex = index,
+                        kind = kind, nights = if (kind == StopKind.VISIT) 0 else 1,
+                        location = LatLng(47.0 + index, 8.0),
+                        arrivalDate = LocalDate.of(2027, 6, 10 + index),
+                    ),
+                )
+            }
+        }
+        setContent("k1")
+        StopKind.entries.forEach { kind ->
+            compose.onNodeWithTag("timeline").performScrollToNode(hasText(kind.name))
+            compose.onAllNodesWithContentDescription(kind.displayName).onFirst().assertExists()
+        }
+    }
+
+    @Test
+    fun `the height carries an icon that says what it is`() {
+        seedPlan()
+        runBlocking {
+            val s2 = tripRepository.stops("p1").first().first { it.id == "s2" }
+            tripRepository.upsertStop(s2.copy(elevation = StopElevation(LatLng(46.16, 8.79), 1469)))
+        }
+        setContent("p1")
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camping Delta"))
+        compose.onNodeWithContentDescription("Height above sea level", useUnmergedTree = true)
+            .assertExists()
     }
 
 }

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreenTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreenTest.kt
@@ -46,6 +46,8 @@ import com.nuelto.camperexperience.data.model.TripStatus
 import com.nuelto.camperexperience.testutil.TestCamperApp
 import com.nuelto.camperexperience.ui.map.LocalMapProvider
 import com.nuelto.camperexperience.ui.map.PlaceholderMapProvider
+import com.nuelto.camperexperience.ui.formatDriveFromHere
+import java.time.LocalDateTime
 import java.time.LocalDate
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -744,7 +746,8 @@ class TripDetailScreenTest {
         grantLocation()
         setContent("a1", locatingViewModel(LatLng(46.9, 8.5), RoutedLeg("", 47_000, 3_300)))
         compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
-        compose.onNodeWithText("47 km · 55 min from here", useUnmergedTree = true).assertIsDisplayed()
+        compose.onNodeWithText("47 km · 55 min from here", substring = true, useUnmergedTree = true)
+            .assertIsDisplayed()
     }
 
     @Test
@@ -799,7 +802,8 @@ class TripDetailScreenTest {
         )
         compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
         compose.onNodeWithText("Show distance from here", useUnmergedTree = true).performClick()
-        compose.onNodeWithText("47 km · 55 min from here", useUnmergedTree = true).assertIsDisplayed()
+        compose.onNodeWithText("47 km · 55 min from here", substring = true, useUnmergedTree = true)
+            .assertIsDisplayed()
     }
 
     @Test
@@ -813,6 +817,44 @@ class TripDetailScreenTest {
         compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
         compose.onNodeWithText("Show distance from here", useUnmergedTree = true).performClick()
         compose.onAllNodesWithText("47 km", substring = true).assertCountEquals(0)
+    }
+
+    @Test
+    fun `the drive line says when you get there`() {
+        seedActive()
+        grantLocation()
+        setContent("a1", locatingViewModel(LatLng(46.9, 8.5), RoutedLeg("", 47_000, 3_300)))
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
+        val expected = formatDriveFromHere(47_000, 3_300, LocalDateTime.now())
+        compose.onNodeWithText(expected, useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun `checking in stops showing how far away it is`() {
+        seedActive()
+        grantLocation()
+        runBlocking {
+            // Tonight's stop, arrived at: CurrentStop keeps it current through the stay.
+            val cur = tripRepository.stops("a1").first().first { it.id == "cur" }
+            tripRepository.upsertStop(cur.copy(state = StopState.DONE, arrivalDate = LocalDate.now()))
+        }
+        setContent("a1", locatingViewModel(LatLng(46.9, 8.5), RoutedLeg("", 47_000, 3_300)))
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
+        compose.onNodeWithText("Checked in", useUnmergedTree = true).assertIsDisplayed()
+        compose.onAllNodesWithText("from here", substring = true).assertCountEquals(0)
+        compose.onAllNodesWithText("arrive", substring = true).assertCountEquals(0)
+    }
+
+    @Test
+    fun `a checked-in stop is not even offered the distance`() {
+        seedActive()
+        runBlocking {
+            val cur = tripRepository.stops("a1").first().first { it.id == "cur" }
+            tripRepository.upsertStop(cur.copy(state = StopState.DONE, arrivalDate = LocalDate.now()))
+        }
+        setContent("a1", locatingViewModel(LatLng(46.9, 8.5), RoutedLeg("", 47_000, 3_300)))
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
+        compose.onAllNodesWithText("Show distance from here").assertCountEquals(0)
     }
 
 }

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModelTest.kt
@@ -9,11 +9,14 @@ import com.nuelto.camperexperience.data.model.Expense
 import com.nuelto.camperexperience.data.model.ExpenseType
 import com.nuelto.camperexperience.data.model.LatLng
 import com.nuelto.camperexperience.data.model.Stop
+import com.nuelto.camperexperience.data.model.StopLeg
 import com.nuelto.camperexperience.data.model.StopState
 import com.nuelto.camperexperience.data.model.Trip
 import com.nuelto.camperexperience.data.model.TripStatus
 import com.nuelto.camperexperience.domain.VignetteTable
 import com.nuelto.camperexperience.domain.PlaceCacheSweeper
+import com.nuelto.camperexperience.domain.RoutedLeg
+import com.nuelto.camperexperience.domain.RouteRefresher
 import com.nuelto.camperexperience.testutil.MainDispatcherRule
 import java.time.LocalDate
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -417,5 +420,98 @@ class TripDetailViewModelTest {
         val stop = tripRepository.stops("t1").first().single()
         assertNull(stop.location)
         assertEquals("ChIJ1", stop.placeId)
+    }
+
+    // --- drives -----------------------------------------------------------------------
+
+    private fun leg(from: LatLng, to: LatLng) =
+        StopLeg(from = from, to = to, distanceMeters = 124_000, durationSeconds = 6_300)
+
+    private fun refreshingViewModel(refresher: RouteRefresher) =
+        TripDetailViewModel(
+            SavedStateHandle(mapOf("tripId" to "t1")),
+            tripRepository,
+            settingsRepository,
+            routeRefresher = refresher,
+        )
+
+    /** Routes one leg per pair and records the points every request was made for. */
+    private fun refresher(asked: MutableList<List<LatLng>>) = RouteRefresher(
+        tripRepository,
+        { points ->
+            asked += points
+            points.zipWithNext().map { RoutedLeg(polyline = "", distanceMeters = 124_000, durationSeconds = 6_300) }
+        },
+    )
+
+    @Test
+    fun `drives key the leg by the stop it arrives at`() = runTest {
+        seedTrip()
+        tripRepository.upsertStop(
+            stops().first { it.id == "s2" }.copy(leg = leg(LatLng(47.0, 7.0), LatLng(47.5, 7.5))),
+        )
+        viewModel().uiState.test {
+            val drives = awaitItem().drives
+            assertEquals(listOf("s2"), drives.keys.toList()) // nothing drives to the first stop
+            assertEquals(124_000, drives.getValue("s2").distanceMeters)
+            assertEquals(6_300, drives.getValue("s2").durationSeconds)
+        }
+    }
+
+    @Test
+    fun `a leg whose endpoints no longer match its stops is left out`() = runTest {
+        seedTrip()
+        tripRepository.upsertStop(
+            stops().first { it.id == "s2" }.copy(leg = leg(LatLng(47.0, 7.0), LatLng(47.5, 7.5))),
+        )
+        // Re-pinned departure: the stored leg describes a drive nobody makes any more.
+        tripRepository.upsertStop(stops().first { it.id == "s1" }.copy(location = LatLng(46.0, 6.0)))
+        viewModel().uiState.test {
+            assertTrue(awaitItem().drives.isEmpty())
+        }
+    }
+
+    @Test
+    fun `a route refresher fills the drives in`() = runTest {
+        seedTrip()
+        val asked = mutableListOf<List<LatLng>>()
+        refreshingViewModel(refresher(asked)).uiState.test {
+            assertEquals(listOf(listOf(LatLng(47.0, 7.0), LatLng(47.5, 7.5))), asked)
+            val drive = awaitItem().drives.getValue("s2")
+            assertEquals(124_000, drive.distanceMeters)
+            assertEquals(6_300, drive.durationSeconds)
+            assertEquals(LatLng(47.0, 7.0), drive.from)
+            assertEquals(LatLng(47.5, 7.5), drive.to)
+            assertEquals(LocalDate.now(), drive.fetchedAt)
+        }
+        assertNotNull(stops().first { it.id == "s2" }.leg)
+    }
+
+    @Test
+    fun `writing the fetched legs back does not fetch again`() = runTest {
+        seedTrip()
+        val asked = mutableListOf<List<LatLng>>()
+        val vm = refreshingViewModel(refresher(asked))
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect { } }
+        testScheduler.advanceUntilIdle()
+        assertEquals(1, asked.size) // the legs it just wrote are not a new set of drives
+
+        // A real change to the drives does re-route — once.
+        tripRepository.upsertStop(stops().first { it.id == "s2" }.copy(location = LatLng(46.0, 6.0)))
+        testScheduler.advanceUntilIdle()
+        assertEquals(2, asked.size)
+        assertEquals(listOf(LatLng(47.0, 7.0), LatLng(46.0, 6.0)), asked.last())
+    }
+
+    @Test
+    fun `without a refresher nothing is routed and the trip still reads`() = runTest {
+        seedTrip()
+        viewModel().uiState.test {
+            val state = awaitItem()
+            assertTrue(state.drives.isEmpty())
+            assertFalse(state.loading)
+            assertEquals(listOf("s1", "s2"), state.stops.map { it.id })
+        }
+        assertNull(stops().first { it.id == "s2" }.leg)
     }
 }

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModelTest.kt
@@ -616,4 +616,22 @@ class TripDetailViewModelTest {
         assertNull(vm.uiState.value.driveFromHere)
     }
 
+    @Test
+    fun `checking in drops the distance and buys no more routes`() = runTest {
+        val target = LatLng(46.1591, 8.7853)
+        seedOnTheRoad(target)
+        var calls = 0
+        val vm = locatingViewModel({ hereFix }) { _, _ -> calls++; RoutedLeg("", 90_000, 5_400) }
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect { } }
+        vm.refreshDriveFromHere()
+        assertEquals(90_000, vm.uiState.value.driveFromHere!!.distanceMeters)
+
+        vm.arrived("s1")
+
+        assertNull(vm.uiState.value.driveFromHere)
+        vm.refreshDriveFromHere()
+        assertEquals(1, calls)
+        assertNull(vm.uiState.value.driveFromHere)
+    }
+
 }

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModelTest.kt
@@ -514,4 +514,106 @@ class TripDetailViewModelTest {
         }
         assertNull(stops().first { it.id == "s2" }.leg)
     }
+    // --- distance from here ------------------------------------------------------------
+
+    private val hereFix = LatLng(46.8709, 8.2492)
+
+    /** An ACTIVE trip whose current stop is [target]. */
+    private suspend fun seedOnTheRoad(target: LatLng = LatLng(46.1591, 8.7853)) {
+        tripRepository.upsertTrip(
+            Trip(id = "t1", name = "On the road", startDate = LocalDate.now(), status = TripStatus.ACTIVE),
+        )
+        tripRepository.upsertStop(
+            Stop(
+                id = "s1", tripId = "t1", name = "Tonight", orderIndex = 0, location = target,
+                arrivalDate = LocalDate.now(), nights = 1,
+            ),
+        )
+    }
+
+    private fun locatingViewModel(
+        fix: suspend () -> LatLng?,
+        drive: suspend (LatLng, LatLng) -> RoutedLeg?,
+    ) = TripDetailViewModel(
+        SavedStateHandle(mapOf("tripId" to "t1")),
+        tripRepository,
+        settingsRepository,
+        currentLocation = fix,
+        drive = drive,
+    )
+
+    @Test
+    fun `the drive from here is routed from the current fix to tonight's stop`() = runTest {
+        val target = LatLng(46.1591, 8.7853)
+        seedOnTheRoad(target)
+        val asked = mutableListOf<Pair<LatLng, LatLng>>()
+        val vm = locatingViewModel({ hereFix }) { from, to ->
+            asked += from to to
+            RoutedLeg("", 90_000, 5_400)
+        }
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect { } }
+        vm.refreshDriveFromHere()
+
+        assertEquals(listOf(hereFix to target), asked)
+        val live = vm.uiState.value.driveFromHere!!
+        assertEquals(hereFix, live.from)
+        assertEquals(target, live.to)
+        assertEquals(90_000, live.distanceMeters)
+        assertEquals(5_400, live.durationSeconds)
+    }
+
+    @Test
+    fun `standing at the stop shows no distance and spends no route`() = runTest {
+        val target = LatLng(46.1591, 8.7853)
+        seedOnTheRoad(target)
+        var calls = 0
+        // 50 m away: inside LiveDrive.ARRIVED_WITHIN_METERS.
+        val nearly = LatLng(target.latitude + 50 / 111_195.0, target.longitude)
+        val vm = locatingViewModel({ nearly }) { _, _ -> calls++; RoutedLeg("", 1, 1) }
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect { } }
+        vm.refreshDriveFromHere()
+
+        assertNull(vm.uiState.value.driveFromHere)
+        assertEquals(0, calls)
+    }
+
+    @Test
+    fun `a second fix in the same place does not spend another route`() = runTest {
+        seedOnTheRoad()
+        var calls = 0
+        val vm = locatingViewModel({ hereFix }) { _, _ -> calls++; RoutedLeg("", 90_000, 5_400) }
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect { } }
+        vm.refreshDriveFromHere()
+        vm.refreshDriveFromHere()
+
+        assertEquals(1, calls)
+        assertEquals(90_000, vm.uiState.value.driveFromHere!!.distanceMeters)
+    }
+
+    @Test
+    fun `no fix and no route both leave the card alone`() = runTest {
+        seedOnTheRoad()
+        val noFix = locatingViewModel({ null }) { _, _ -> RoutedLeg("", 1, 1) }
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { noFix.uiState.collect { } }
+        noFix.refreshDriveFromHere()
+        assertNull(noFix.uiState.value.driveFromHere)
+
+        val noRoute = locatingViewModel({ hereFix }) { _, _ -> null }
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { noRoute.uiState.collect { } }
+        noRoute.refreshDriveFromHere()
+        assertNull(noRoute.uiState.value.driveFromHere)
+    }
+
+    @Test
+    fun `a trip with nowhere to drive to asks for nothing`() = runTest {
+        seedTrip(TripStatus.DONE)
+        var fixes = 0
+        val vm = locatingViewModel({ fixes++; hereFix }) { _, _ -> RoutedLeg("", 1, 1) }
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect { } }
+        vm.refreshDriveFromHere()
+
+        assertEquals(0, fixes)
+        assertNull(vm.uiState.value.driveFromHere)
+    }
+
 }

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/StopEditViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/StopEditViewModelTest.kt
@@ -405,7 +405,7 @@ class StopEditViewModelTest {
         vm.setKind(StopKind.VISIT)
         assertEquals(0, vm.uiState.value.nights)
         assertEquals("", vm.uiState.value.campingCost)
-        assertTrue(vm.uiState.value.isVisit)
+        assertFalse(vm.uiState.value.isStay)
         vm.setKind(StopKind.STELLPLATZ)
         assertEquals(1, vm.uiState.value.nights)
     }

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/TripEditViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/TripEditViewModelTest.kt
@@ -2,6 +2,9 @@ package com.nuelto.camperexperience.ui.tripedit
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.camperexperience.data.InMemorySettingsRepository
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.data.model.StopKind
 import com.nuelto.camperexperience.data.InMemoryTripRepository
 import com.nuelto.camperexperience.data.model.Stop
 import com.nuelto.camperexperience.data.model.Trip
@@ -172,4 +175,80 @@ class TripEditViewModelTest {
         vm.save { _, _ -> }
         assertEquals(TripStatus.PLANNED, tripRepository.trip("p1").first()!!.status)
     }
+    // --- home as the plan's starting point ----------------------------------------------
+
+    private val settingsRepository = InMemorySettingsRepository()
+
+    private fun planViewModel() = TripEditViewModel(
+        SavedStateHandle(mapOf("planned" to true)),
+        tripRepository,
+        settingsRepository,
+    )
+
+    private suspend fun setHome(name: String = "Luzern") {
+        settingsRepository.update(
+            settingsRepository.settings().first()
+                .copy(homeName = name, homeLocation = LatLng(47.0502, 8.3093)),
+        )
+    }
+
+    @Test
+    fun `a new plan starts at home`() = runTest {
+        setHome()
+        val vm = planViewModel()
+        vm.setName("Ticino")
+        vm.setStartDate(LocalDate.of(2027, 6, 10))
+        var created: String? = null
+        vm.save { id, _ -> created = id }
+
+        val stops = tripRepository.stops(created!!).first()
+        val home = stops.single()
+        assertEquals("Luzern", home.name)
+        assertEquals(StopKind.HOME, home.kind)
+        assertEquals(LatLng(47.0502, 8.3093), home.location)
+        assertEquals(0, home.orderIndex)
+        assertEquals(LocalDate.of(2027, 6, 10), home.arrivalDate)
+    }
+
+    @Test
+    fun `with no home set a new plan starts empty`() = runTest {
+        val vm = planViewModel()
+        vm.setName("Ticino")
+        var created: String? = null
+        vm.save { id, _ -> created = id }
+
+        assertTrue(tripRepository.stops(created!!).first().isEmpty())
+    }
+
+    @Test
+    fun `a logged trip does not get a home stop`() = runTest {
+        setHome()
+        val vm = TripEditViewModel(SavedStateHandle(), tripRepository, settingsRepository)
+        vm.setName("Last weekend")
+        var created: String? = null
+        vm.save { id, _ -> created = id }
+
+        assertTrue(tripRepository.stops(created!!).first().isEmpty())
+    }
+
+    @Test
+    fun `editing an existing plan does not add a second home`() = runTest {
+        setHome()
+        val first = planViewModel()
+        first.setName("Ticino")
+        var created: String? = null
+        first.save { id, _ -> created = id }
+        assertEquals(1, tripRepository.stops(created!!).first().size)
+
+        val again = TripEditViewModel(
+            SavedStateHandle(mapOf("tripId" to created!!)),
+            tripRepository,
+            settingsRepository,
+        )
+        again.setName("Ticino-Tour")
+        again.save { _, _ -> }
+
+        assertEquals(1, tripRepository.stops(created!!).first().size)
+    }
+
 }


### PR DESCRIPTION
Closes #12. Routes between stops now follow the road, the timeline says how long each drive
takes, and the fuel estimate accounts for climbing.

## What changed

**Routes follow roads.** `domain/GoogleRoutes` builds the Routes API `computeRoutes` call
(pure body + field mask + parse), `location/RouteServices` makes it, and each drive is
stored on the arriving stop as `Stop.leg` — encoded polyline, distance, duration,
ascent/descent. `domain/Polyline` decodes the geometry; `MapOverlay.routes` draws the real
road where there is one and a straight hop where there is not.

**Per-leg driving time.** Each timeline row shows `→ 53 km · 1 h 1 min` for the drive that
arrives there.

**Elevation.** Stops show their own height above sea level, beside the name. The per-leg
climb feeds the fuel estimate via the gravity term of the road-load equation
(`FuelEstimator.liftLiters`, ~0.086 l per tonne per 100 m), with a descent giving back at
most the fuel that stretch would have burned anyway.

Along the way the stop rows also gained a kind icon (tent / RV hookup / forest / camera)
carrying the existing lifecycle tint, so shape says what a spot is and colour still says
where it is in the trip.

## Decisions worth reviewing

**Staying on the cheap billing tier is a design constraint, not an accident.** Traffic-aware
routing, waypoint optimisation, or 11+ intermediates each double the per-call price
(Compute Routes Essentials $5/1k → Pro $10/1k). So `GoogleRoutes.windows` splits a long trip
into ≤12-point requests, `routingPreference` is pinned to `TRAFFIC_UNAWARE`, and
optimisation is off. Tests pin all three.

**Invalidation is by comparison, not bookkeeping.** A leg records the two coordinates it was
routed between, so a moved pin, a skip or a drag invalidates it automatically —
`RouteCache.usable` simply stops matching. Nothing has to remember to clear anything.

**Caching is capped at 30 days.** SST §19.3 grants the Routes API the same window as the
Places §14.3 rule already implemented here. It does *not* name the polyline — but §11.8
names polyline/distance/duration explicitly for another API, so the omission looks
deliberate and the conservative reading is that a polyline (a sequence of coordinates)
inherits the limit. `RouteRefresher` deletes expired legs whether or not the network is up,
mirroring `PlaceCacheSweeper`.

**Elevation is Open-Meteo (Copernicus DEM), not Google.** Google's Elevation API policies
forbid caching or storing results at all, which makes a stored per-leg climb impossible.

## Two caveats a reviewer should know

**The fuel constants are physics, not measurement.** `liftLiters` is the right gravity term,
but the 0.32 drivetrain efficiency is a single number standing in for a whole engine map.
Marked as unvalidated in the code and CLAUDE.md; it wants checking against a real tankful.

**Cumulative ascent is inherently approximate.** It does not converge — sampling one 215 km
route 16× more finely grew the total from 4894 m to 9243 m — and a DEM returns ground level,
which through a tunnel is the mountain overhead (one Swiss route sampled a road at 2876 m,
above every pass in the country). `Elevation.profile` therefore clamps each step to
`MAX_ROAD_GRADE` before applying `MIN_RISE_M` hysteresis, which holds the figure to 6% across
that same range. It is deliberately never displayed — only the stop's own height is, which
has neither problem.

## Setup this needs

**Enable Routes API on the Maps key and add it to the key's API restrictions.** One key covers
map, places and routes — verified against a live `computeRoutes` call. Note Places and Routes
are both called as plain web services, so adding an Android *application* restriction to the
key would break both unless `X-Android-Package`/`X-Android-Cert` headers are added.
GOOGLE_MAPS_SETUP.md covers it. Without the API enabled, everything degrades to straight
lines and the road-distance factor.

## Verification

- 518 tests, 100% line coverage, 94% mutation score (threshold 80), APK builds.
- The request body, field mask and per-leg response checked against the **live** API.
- The full numeric chain checked end to end on a real route: the decoder gives 32.6 km against
  Google's 32.582, sampling lands on both endpoints, elevation reads 597 m → 2140 m
  (Meiringen to the Grimsel Pass).
- The edge-to-edge fix reproduced and confirmed on the emulator in both three-button and
  gesture navigation. Robolectric renders no system bars, so no unit test can catch that
  class of bug — noted in CLAUDE.md.

## Follow-ups, deliberately out of scope

- Routes are fetched when a trip is opened, so the all-trips map shows straight lines for
  trips not yet visited.
- #3's other half — a GPS breadcrumb of the track actually driven — is untouched. That issue
  should now be narrowed to just that, or closed as a duplicate of the routing half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
