### PR TITLE
Add stops between stops, and stop asking for their names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,10 +105,13 @@ There is no lint/format tooling configured.
   TripDetailViewModel) refreshes them via Place Details or **deletes** them. Coordinates
   from GPS or a dropped pin have no `locationCachedAt` and never expire. With OSM gone
   there is no non-expiring search source, so this path is not optional.
-- **Choosing a named place names the stop**, always — it is an explicit act, so it wins
-  over whatever the field held, including a hand-typed name. Type over it afterwards and
-  that sticks until a different place is picked. A dropped pin has no name and so goes
-  through `setLocation`, where the reverse geocode still only fills a blank name.
+- **A stop is named by the place you pick**, so a *new* stop has no name field at all —
+  it shows the picked name where the field used to be, and Save needs a name *or* a
+  location (`savedName` falls back to the reverse-geocoded place, then to the kind, so an
+  unnameable pin still saves as "Free camp"). The field is back when editing an existing
+  stop; typing over the name sticks until a different place is picked, which always wins.
+  A dropped pin has no name and so goes through `setLocation`, where the reverse geocode
+  still only fills a blank name.
 - Choosing a hit fetches **what the place is like** (`PlaceDetails`: type, rating, editorial
   summary, top review, one photo) in the same Place Details call that resolves its
   coordinate; a tapped POI is enriched the same way. Photos come back as bytes and are
@@ -161,7 +164,12 @@ MVVM + repository, hand-rolled DI — no Hilt, no Room. Package root:
   from the dates and never stored. Any row can be long-press dragged
   (`ui/components/Reorderable.kt` gesture + `ReorderState` math; `Timeline.move` rules —
   DONE stops are anchors nothing may cross, gaps stay between two stops), and gaps are
-  resizable/deletable. Every such edit writes `reorderStops` + `DateCascade.resequence`,
+  resizable/deletable. Between two rows sits a **+ slot** offering a stop or one
+  unplanned night — shown only where the row below could also be dragged, so never in
+  front of what has already happened. `Timeline.insertion` turns the row key (carried to
+  the editor as `StopEditRoute.insertBefore`) into the order index and the start date the
+  new row takes over, and `DateCascade.shift` moves the rest of the plan back by the
+  nights it takes. Every such edit writes `reorderStops` + `DateCascade.resequence`,
   which re-dates the plan from the row order (a pure reorder keeps the trip's start and
   length); nights/arrival changes instead shift downstream dates (`DateCascade.shift`).
   Color language everywhere (lists, timeline, maps):

--- a/app/src/main/java/com/nuelto/camperexperience/domain/Timeline.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/domain/Timeline.kt
@@ -28,6 +28,9 @@ data class GapRow(val nights: Int, val from: LocalDate, val before: Stop) : Time
     }
 }
 
+/** Where something inserted in front of a row goes: whose place it takes, and its day. */
+data class Insertion(val orderIndex: Int, val date: LocalDate)
+
 /**
  * The timeline as the screen shows it. Gaps are derived from the dates, never stored:
  * every empty night between one stop's departure and the next one's arrival becomes a
@@ -53,6 +56,23 @@ object Timeline {
             departure = stop.arrivalDate.plusDays(stop.nights.toLong())
         }
         return rows
+    }
+
+    /**
+     * Where a row inserted in front of [key] lands: it takes that row's place in the
+     * order, and starts the day that row starts — the day after the stop before it
+     * leaves, or, in front of a gap, the first of its empty nights. Null if [key] is
+     * not on the timeline (it went away while the editor was open).
+     */
+    fun insertion(rows: List<TimelineRow>, key: String): Insertion? {
+        val row = rows.find { it.key == key } ?: return null
+        return Insertion(
+            orderIndex = row.anchor.orderIndex,
+            date = when (row) {
+                is StopRow -> row.stop.arrivalDate
+                is GapRow -> row.from
+            },
+        )
     }
 
     /**

--- a/app/src/main/java/com/nuelto/camperexperience/ui/nav/AppNavHost.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/nav/AppNavHost.kt
@@ -39,7 +39,9 @@ fun AppNavHost() {
             TripDetailScreen(
                 onBack = { navController.popBackStack() },
                 onEditTrip = { tripId -> navController.navigate(TripEditRoute(tripId)) },
-                onAddStop = { tripId -> navController.navigate(StopEditRoute(tripId)) },
+                onAddStop = { tripId, insertBefore ->
+                    navController.navigate(StopEditRoute(tripId, insertBefore = insertBefore))
+                },
                 onEditStop = { tripId, stopId -> navController.navigate(StopEditRoute(tripId, stopId)) },
                 onOpenTripMap = { tripId -> navController.navigate(AllTripsMapRoute(tripId)) },
                 // Start-as-copy and plan-again land on the freshly created trip.

--- a/app/src/main/java/com/nuelto/camperexperience/ui/nav/Routes.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/nav/Routes.kt
@@ -11,8 +11,9 @@ data class TripDetailRoute(val tripId: String)
 @Serializable
 data class TripEditRoute(val tripId: String? = null, val planned: Boolean = false)
 
+/** [insertBefore] is the timeline row key a new stop goes in front of; null appends. */
 @Serializable
-data class StopEditRoute(val tripId: String, val stopId: String? = null)
+data class StopEditRoute(val tripId: String, val stopId: String? = null, val insertBefore: String? = null)
 
 @Serializable
 data class AllTripsMapRoute(val tripId: String? = null)

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -57,6 +58,8 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FloatingActionButton
@@ -144,7 +147,8 @@ val ExpenseType.displayName: String
 fun TripDetailScreen(
     onBack: () -> Unit,
     onEditTrip: (String) -> Unit,
-    onAddStop: (String) -> Unit,
+    // The row key a new stop goes in front of, or null to add it at the end.
+    onAddStop: (tripId: String, insertBefore: String?) -> Unit,
     onEditStop: (String, String) -> Unit,
     onOpenTripMap: (String) -> Unit,
     onOpenTrip: (String) -> Unit,
@@ -270,7 +274,7 @@ fun TripDetailScreen(
                             ExtendedFloatingActionButton(
                                 onClick = {
                                     fabMenuExpanded = false
-                                    onAddStop(trip.id)
+                                    onAddStop(trip.id, null)
                                 },
                                 icon = { Icon(Icons.Default.Place, contentDescription = null) },
                                 text = { Text("Stop") },
@@ -395,11 +399,22 @@ fun TripDetailScreen(
                     )
                 }
             }
-            items(state.rows, key = { it.key }) { row ->
+            itemsIndexed(state.rows, key = { _, row -> row.key }) { index, row ->
                 val movable = row.key in movableKeys
                 val rowModifier = Modifier
                     .testTag("row-${row.key}")
                     .reorderable(reorder, row.key, listState, enabled = movable)
+                // A slot between two rows only: a plan starts at its first stop, and the
+                // FAB adds to the end. Where a row cannot be moved it cannot be pushed
+                // back either — nothing goes in front of what has already happened.
+                // (A lazy item may emit several rows; these stack.)
+                if (index > 0 && movable) {
+                    InsertSlot(
+                        onStop = { onAddStop(trip.id, row.key) },
+                        onNothingPlanned = { viewModel.insertGap(row.key) },
+                        modifier = Modifier.testTag("insert-${row.key}"),
+                    )
+                }
                 when (row) {
                     is GapRow -> GapCard(
                         row = row,
@@ -689,6 +704,48 @@ private fun NowCard(
 }
 
 /** Nights nobody planned: resize them, drop them, or drag them elsewhere in the plan. */
+/**
+ * The "+" between two rows. What goes in the slot is either a stop or nights you
+ * leave unplanned; either way the rest of the plan moves back by the nights it takes.
+ */
+@Composable
+private fun InsertSlot(
+    onStop: () -> Unit,
+    onNothingPlanned: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var open by remember { mutableStateOf(false) }
+    Row(
+        // Its own gap to the row below: lazy items space themselves, their contents don't.
+        modifier = modifier.fillMaxWidth().padding(bottom = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        HorizontalDivider(Modifier.weight(1f))
+        Box {
+            IconButton(onClick = { open = true }, modifier = Modifier.size(32.dp)) {
+                Icon(
+                    Icons.Default.Add,
+                    contentDescription = "Insert here",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+            DropdownMenu(expanded = open, onDismissRequest = { open = false }) {
+                DropdownMenuItem(
+                    text = { Text("Stop") },
+                    onClick = { open = false; onStop() },
+                )
+                DropdownMenuItem(
+                    text = { Text("Nothing planned") },
+                    onClick = { open = false; onNothingPlanned() },
+                )
+            }
+        }
+        HorizontalDivider(Modifier.weight(1f))
+    }
+}
+
 @Composable
 private fun GapCard(
     row: GapRow,

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModel.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModel.kt
@@ -285,6 +285,14 @@ class TripDetailViewModel(
         return Timeline.keyAt(rows, rows.indexOfFirst { it.key == key })
     }
 
+    /** An unplanned night in front of [key]: everything from there on moves a day back. */
+    fun insertGap(key: String) {
+        val at = Timeline.insertion(uiState.value.rows, key) ?: return
+        viewModelScope.launch {
+            writeLock.withLock { shiftAfter(at.orderIndex - 1, 1) }
+        }
+    }
+
     /** Resizes a gap; [nights] of 0 deletes it and pulls the rest of the plan forward. */
     fun setGapNights(key: String, nights: Int) {
         applyRows(

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripedit/StopEditScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripedit/StopEditScreen.kt
@@ -95,13 +95,20 @@ fun StopEditScreen(
                     )
                 }
             }
-            OutlinedTextField(
-                value = state.name,
-                onValueChange = viewModel::setName,
-                label = { Text(if (state.isStay) "Campsite / place" else "Place") },
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth(),
-            )
+            if (state.isNew) {
+                // The place you pick names the stop — nothing to type. Blank until then.
+                if (state.name.isNotBlank()) {
+                    Text(state.name, style = MaterialTheme.typography.headlineSmall)
+                }
+            } else {
+                OutlinedTextField(
+                    value = state.name,
+                    onValueChange = viewModel::setName,
+                    label = { Text(if (state.isStay) "Campsite / place" else "Place") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
             DateField(
                 label = "Arrival",
                 date = state.arrivalDate,

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripedit/StopEditViewModel.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripedit/StopEditViewModel.kt
@@ -18,6 +18,7 @@ import com.nuelto.camperexperience.data.model.TripStatus
 import com.nuelto.camperexperience.data.model.UserSettings
 import com.nuelto.camperexperience.domain.DateCascade
 import com.nuelto.camperexperience.domain.MapsUri
+import com.nuelto.camperexperience.domain.Timeline
 import com.nuelto.camperexperience.domain.nearestLocated
 import com.nuelto.camperexperience.location.PlaceNameResolver
 import com.nuelto.camperexperience.ui.components.parseDecimal
@@ -49,7 +50,8 @@ data class StopEditUiState(
     val placeId: String? = null,
     val locationCachedAt: LocalDate? = null,
 ) {
-    val canSave: Boolean get() = name.isNotBlank()
+    // A new stop has no name field: somewhere to be is enough, [savedName] finds it a name.
+    val canSave: Boolean get() = name.isNotBlank() || location != null
     /** Nights and a price only make sense where you actually stay. */
     val isStay: Boolean get() = kind.isStay
     val pickerStart: LatLng? get() = location ?: nearbyLocation
@@ -64,6 +66,10 @@ data class StopEditUiState(
             ?: "Not set"
 }
 
+/** A pin nothing could name still needs one: the place if we know it, else the kind. */
+private fun StopEditUiState.savedName(): String =
+    name.trim().ifBlank { locationName ?: kind.displayName }
+
 class StopEditViewModel(
     savedStateHandle: SavedStateHandle,
     private val tripRepository: TripRepository,
@@ -75,6 +81,8 @@ class StopEditViewModel(
     val tripId: String get() = route.tripId
     private var existing: Stop? = null
     private var tripStatus: TripStatus? = null
+    // Order index a stop inserted between two rows takes over; null when it appends.
+    private var insertAt: Int? = null
 
     // Last name we auto-filled from reverse geocoding or a suggestion; anything else was
     // typed by the user and must never be overwritten.
@@ -92,9 +100,17 @@ class StopEditViewModel(
             val stops = tripRepository.stops(route.tripId).first()
 
             if (route.stopId == null) {
-                // A new stop lands at the end, so the whole trip is "before" it.
-                _uiState.update { it.copy(nearbyLocation = nearestLocated(stops, Int.MAX_VALUE)) }
-                if (trip == null || trip.status == TripStatus.ACTIVE) {
+                // Inserted in front of a row, or — with no key — landing at the end,
+                // where the whole trip is "before" it.
+                val at = route.insertBefore?.let { Timeline.insertion(Timeline.rows(stops), it) }
+                insertAt = at?.orderIndex
+                _uiState.update {
+                    it.copy(nearbyLocation = nearestLocated(stops, at?.orderIndex ?: Int.MAX_VALUE))
+                }
+                if (at != null) {
+                    // The slot says which day this starts on; no GPS fix improves on that.
+                    _uiState.update { it.copy(arrivalDate = at.date) }
+                } else if (trip == null || trip.status == TripStatus.ACTIVE) {
                     // Logging where you are: immediately try a GPS fix.
                     _uiState.update { it.copy(autoLocatePending = true) }
                 } else {
@@ -229,7 +245,7 @@ class StopEditViewModel(
                     (old != null && old.costKnown && old.campingCostTotal == 0.0 && old.kind == state.kind)
                 tripRepository.upsertStop(
                     base.copy(
-                        name = state.name.trim(),
+                        name = state.savedName(),
                         arrivalDate = state.arrivalDate,
                         nights = nights,
                         campingCostTotal = if (state.isStay) parsed ?: 0.0 else 0.0,
@@ -241,14 +257,15 @@ class StopEditViewModel(
                         locationCachedAt = state.locationCachedAt,
                     ),
                 )
+                // An inserted stay pushes the rest of the plan back by the nights it takes.
+                insertAt?.let { at -> shiftAfter(at, nights.toLong()) }
                 // A moved departure shifts the downstream planned schedule along.
                 if (old != null) {
                     val days = ChronoUnit.DAYS.between(
                         old.arrivalDate.plusDays(old.nights.toLong()),
                         state.arrivalDate.plusDays(nights.toLong()),
                     )
-                    DateCascade.shift(tripRepository.stops(route.tripId).first(), old.orderIndex, days)
-                        .forEach { tripRepository.upsertStop(it) }
+                    shiftAfter(old.orderIndex, days)
                 }
                 onSaved()
             } finally {
@@ -257,21 +274,34 @@ class StopEditViewModel(
         }
     }
 
+    private suspend fun shiftAfter(orderIndex: Int, days: Long) {
+        DateCascade.shift(tripRepository.stops(route.tripId).first(), orderIndex, days)
+            .forEach { tripRepository.upsertStop(it) }
+    }
+
     /**
-     * New stops append — except mid-trip with check-ins, where a spontaneous stop
-     * slots in right after the last done stop (upcoming stops move down one).
+     * New stops append — except when one is inserted in front of a row, and mid-trip
+     * with check-ins, where a spontaneous stop slots in right after the last done stop.
+     * Either way the stops from there on move down one.
      */
     private suspend fun newOrderIndex(): Int {
         val stops = tripRepository.stops(route.tripId).first()
+        insertAt?.let { at ->
+            shoveDown(stops, at)
+            return at
+        }
         val lastDone = stops.filter { it.state == StopState.DONE }.maxOfOrNull { it.orderIndex }
         if (tripStatus != TripStatus.ACTIVE || lastDone == null) {
             return (stops.maxOfOrNull { it.orderIndex } ?: -1) + 1
         }
-        val insertAt = lastDone + 1
-        stops.filter { it.orderIndex >= insertAt }.forEach {
-            tripRepository.upsertStop(it.copy(orderIndex = it.orderIndex + 1))
-        }
-        return insertAt
+        val at = lastDone + 1
+        shoveDown(stops, at)
+        return at
+    }
+
+    private suspend fun shoveDown(stops: List<Stop>, from: Int) {
+        stops.filter { it.orderIndex >= from }
+            .forEach { tripRepository.upsertStop(it.copy(orderIndex = it.orderIndex + 1)) }
     }
 
     fun delete(onDeleted: () -> Unit) {

--- a/app/src/test/java/com/nuelto/camperexperience/ScreenshotsTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ScreenshotsTest.kt
@@ -75,7 +75,7 @@ class ScreenshotsTest {
     @Test
     fun tripDetail() = shoot("trip-detail") {
         TripDetailScreen(
-            onBack = {}, onEditTrip = {}, onAddStop = {}, onEditStop = { _, _ -> },
+            onBack = {}, onEditTrip = {}, onAddStop = { _, _ -> }, onEditStop = { _, _ -> },
             onOpenTripMap = {}, onOpenTrip = {},
             viewModel = TripDetailViewModel(
                 SavedStateHandle(mapOf("tripId" to "demo-provence")),
@@ -88,7 +88,7 @@ class ScreenshotsTest {
     @Test
     fun activeTrip() = shoot("active-trip") {
         TripDetailScreen(
-            onBack = {}, onEditTrip = {}, onAddStop = {}, onEditStop = { _, _ -> },
+            onBack = {}, onEditTrip = {}, onAddStop = { _, _ -> }, onEditStop = { _, _ -> },
             onOpenTripMap = {}, onOpenTrip = {},
             viewModel = TripDetailViewModel(
                 SavedStateHandle(mapOf("tripId" to "demo-vierwald")),
@@ -101,7 +101,7 @@ class ScreenshotsTest {
     @Test
     fun plannedTour() = shoot("planned-tour") {
         TripDetailScreen(
-            onBack = {}, onEditTrip = {}, onAddStop = {}, onEditStop = { _, _ -> },
+            onBack = {}, onEditTrip = {}, onAddStop = { _, _ -> }, onEditStop = { _, _ -> },
             onOpenTripMap = {}, onOpenTrip = {},
             viewModel = TripDetailViewModel(
                 SavedStateHandle(mapOf("tripId" to "demo-jura")),

--- a/app/src/test/java/com/nuelto/camperexperience/domain/TimelineTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/domain/TimelineTest.kt
@@ -36,6 +36,20 @@ class TimelineTest {
     }
 
     @Test
+    fun `an insertion takes the place and the first day of the row it lands in front of`() {
+        val stops = listOf(
+            stop("a", 0, base, nights = 2), // leaves the 3rd
+            stop("b", 1, base.plusDays(4)), // arrives the 5th
+        )
+        val rows = Timeline.rows(stops)
+        // In front of the empty nights: the day after A leaves, taking B's index.
+        assertEquals(Insertion(1, base.plusDays(2)), Timeline.insertion(rows, "gap-b"))
+        // In front of B itself: after those nights have been spent.
+        assertEquals(Insertion(1, base.plusDays(4)), Timeline.insertion(rows, "b"))
+        assertNull(Timeline.insertion(rows, "gone"))
+    }
+
+    @Test
     fun `back-to-back and overlapping stops leave no gap`() {
         val stops = listOf(
             stop("a", 0, base, nights = 2),

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreenTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailScreenTest.kt
@@ -166,7 +166,7 @@ class TripDetailScreenTest {
                 TripDetailScreen(
                     onBack = { events += "back" },
                     onEditTrip = { events += "edit:$it" },
-                    onAddStop = { events += "addStop:$it" },
+                    onAddStop = { _, insertBefore -> events += "addStop:${insertBefore ?: "end"}" },
                     onEditStop = { tripId2, stopId -> events += "editStop:$tripId2:$stopId" },
                     onOpenTripMap = { events += "map:$it" },
                     onOpenTrip = { events += "open:$it" },
@@ -280,7 +280,7 @@ class TripDetailScreenTest {
         setContent()
         compose.onNodeWithContentDescription("Add").performClick()
         compose.onNodeWithText("Stop", useUnmergedTree = true).performClick()
-        assertEquals(listOf("addStop:t1"), events)
+        assertEquals(listOf("addStop:end"), events)
     }
 
     @Test
@@ -437,7 +437,8 @@ class TripDetailScreenTest {
             tripRepository.upsertStop(s2.copy(arrivalDate = LocalDate.of(2027, 6, 14)))
         }
         setContent("p1")
-        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Nothing planned"))
+        // One row past the gap, so its buttons sit clear of the floating action button.
+        compose.onNodeWithTag("timeline").performScrollToNode(hasTestTag("row-s2"))
         compose.onNodeWithText("Nothing planned").assertIsDisplayed()
 
         compose.onNodeWithContentDescription("One unplanned night more").performClick()
@@ -448,6 +449,45 @@ class TripDetailScreenTest {
         compose.onNodeWithContentDescription("Remove the unplanned nights").performClick()
         assertEquals(LocalDate.of(2027, 6, 12), arrivalOf("s2")) // straight after s1's stay
         compose.onAllNodes(hasText("Nothing planned")).assertCountEquals(0)
+    }
+
+    @Test
+    fun `the slot between two rows adds a stop there`() {
+        seedPlan()
+        setContent("p1")
+        compose.onNodeWithTag("timeline").performScrollToNode(hasTestTag("insert-s2"))
+        // Nothing goes in front of the first stop — the plan starts there.
+        compose.onNodeWithTag("insert-s1").assertDoesNotExist()
+        // It sits between the two rows, not on top of the one it belongs to.
+        val slot = compose.onNodeWithTag("insert-s2").fetchSemanticsNode().boundsInRoot
+        val stop = compose.onNodeWithTag("row-s2").fetchSemanticsNode().boundsInRoot
+        assertTrue("$slot overlaps $stop", slot.bottom <= stop.top)
+
+        compose.onNodeWithContentDescription("Insert here").performClick()
+        compose.onNodeWithText("Stop").performClick()
+        assertEquals(listOf("addStop:s2"), events)
+    }
+
+    @Test
+    fun `a slot can be filled with nothing planned, moving the rest back`() {
+        seedPlan()
+        setContent("p1")
+        compose.onNodeWithTag("timeline").performScrollToNode(hasTestTag("insert-s2"))
+        compose.onNodeWithContentDescription("Insert here").performClick()
+        compose.onNodeWithText("Nothing planned").performClick()
+        assertEquals(LocalDate.of(2027, 6, 13), arrivalOf("s2"))
+        // The night is now a row of its own, in front of the stop it pushed back.
+        compose.onNodeWithTag("timeline").performScrollToNode(hasTestTag("row-gap-s2"))
+        compose.onNodeWithText("Nothing planned").assertIsDisplayed()
+    }
+
+    @Test
+    fun `nothing can be inserted in front of what has already happened`() {
+        seedActive()
+        setContent("a1")
+        compose.onNodeWithTag("timeline").performScrollToNode(hasTestTag("insert-up"))
+        compose.onNodeWithTag("insert-done").assertDoesNotExist()
+        compose.onNodeWithTag("insert-cur").assertDoesNotExist()
     }
 
     @Test

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripdetail/TripDetailViewModelTest.kt
@@ -299,6 +299,19 @@ class TripDetailViewModelTest {
     }
 
     @Test
+    fun `an unplanned night inserted in front of a stop moves the rest of the plan back`() = runTest {
+        seedTrip(status = TripStatus.PLANNED)
+        val vm = hotViewModel()
+        vm.insertGap("s2")
+        assertEquals(LocalDate.of(2026, 7, 1), stops().first { it.id == "s1" }.arrivalDate) // untouched
+        assertEquals(LocalDate.of(2026, 7, 4), stops().first { it.id == "s2" }.arrivalDate)
+        assertEquals(listOf("s1", "gap-s2", "s2"), vm.uiState.value.rows.map { it.key })
+        // A row that is no longer there cannot be inserted in front of.
+        vm.insertGap("gone")
+        assertEquals(LocalDate.of(2026, 7, 4), stops().first { it.id == "s2" }.arrivalDate)
+    }
+
+    @Test
     fun `a gap dragged past a stop is renamed after the stop it lands in front of`() = runTest {
         tripRepository.upsertTrip(Trip(id = "t1", name = "P", startDate = LocalDate.of(2026, 7, 1)))
         listOf(

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/StopEditScreenTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/StopEditScreenTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -38,9 +39,11 @@ class StopEditScreenTest {
     private val tripRepository = InMemoryTripRepository(seed = false)
     private val events = mutableListOf<String>()
 
+    private lateinit var viewModel: StopEditViewModel
+
     private fun setContent(stopId: String? = null, withLocationSection: Boolean = false) {
         val args = if (stopId == null) mapOf("tripId" to "t1") else mapOf("tripId" to "t1", "stopId" to stopId)
-        val viewModel = StopEditViewModel(SavedStateHandle(args), tripRepository, InMemorySettingsRepository(), null)
+        viewModel = StopEditViewModel(SavedStateHandle(args), tripRepository, InMemorySettingsRepository(), null)
         compose.setContent {
             if (withLocationSection) {
                 StopEditScreen(
@@ -68,7 +71,10 @@ class StopEditScreenTest {
         compose.onNodeWithContentDescription("Fewer nights").performClick()
         compose.onNodeWithText("1").assertIsDisplayed()
 
-        compose.onNodeWithText("Campsite / place").performTextInput("Aire")
+        // Nothing to type: the picked place is the name, shown where the field used to be.
+        compose.onNodeWithText("Campsite / place").assertDoesNotExist()
+        compose.runOnIdle { viewModel.setPickedLocation(LatLng(46.5, 7.5), "Aire", "Route 1") }
+        compose.onNodeWithText("Aire").assertIsDisplayed()
         compose.onNodeWithText("Camping cost (total for stay)").performTextInput("25")
         compose.onNodeWithText("Save").performClick()
         assertEquals(listOf("back"), events)
@@ -101,6 +107,18 @@ class StopEditScreenTest {
     }
 
     @Test
+    fun `an existing stop can still be renamed`() {
+        runBlocking { tripRepository.upsertStop(Stop(id = "s1", tripId = "t1", name = "Camp")) }
+        setContent("s1")
+        compose.onNodeWithText("Campsite / place").performTextClearance()
+        compose.onNodeWithText("Campsite / place").performTextInput("Grandma's driveway")
+        compose.onNodeWithText("Save").performClick()
+        runBlocking {
+            assertEquals("Grandma's driveway", tripRepository.stops("t1").first().single().name)
+        }
+    }
+
+    @Test
     fun `cancel navigates back`() {
         setContent()
         compose.onNodeWithContentDescription("Cancel").performClick()
@@ -113,7 +131,7 @@ class StopEditScreenTest {
         compose.onNodeWithText("Visit").performClick()
         compose.onNodeWithText("Nights").assertDoesNotExist()
         compose.onNodeWithText("Camping cost (total for stay)").assertDoesNotExist()
-        compose.onNodeWithText("Place").performTextInput("Aareschlucht")
+        compose.runOnIdle { viewModel.setPickedLocation(LatLng(46.7, 8.2), "Aareschlucht", "Meiringen") }
         compose.onNodeWithText("Save").performClick()
         runBlocking {
             val stop = tripRepository.stops("t1").first().single()

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/StopEditViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/StopEditViewModelTest.kt
@@ -153,11 +153,31 @@ class StopEditViewModelTest {
     }
 
     @Test
-    fun `save without a name is refused`() = runTest {
+    fun `save without a name or a place is refused`() = runTest {
         var saved = false
         newStopViewModel().save { saved = true }
         assertFalse(saved)
         assertTrue(tripRepository.stops("t1").first().isEmpty())
+    }
+
+    @Test
+    fun `a pin nothing can name saves under its kind`() = runTest {
+        // No resolver, no field on a new stop: the kind is all the name there is.
+        val vm = StopEditViewModel(SavedStateHandle(mapOf("tripId" to "t1")), tripRepository, settingsRepository)
+        vm.setLocation(LatLng(46.0, 7.0))
+        assertTrue(vm.uiState.value.canSave)
+        vm.setKind(StopKind.FREE_CAMP)
+        vm.save {}
+        assertEquals("Free camp", tripRepository.stops("t1").first().single().name)
+    }
+
+    @Test
+    fun `clearing the name of an existing stop falls back to the place`() = runTest {
+        tripRepository.upsertStop(Stop(id = "s1", tripId = "t1", name = "Camp", location = LatLng(46.0, 7.0)))
+        val vm = editViewModel("s1")
+        vm.setName("  ")
+        vm.save {}
+        assertEquals("Place@46.0", tripRepository.stops("t1").first().single().name)
     }
 
     @Test
@@ -180,6 +200,67 @@ class StopEditViewModelTest {
         vm.setKind(StopKind.CAMPSITE)
         vm.save {}
         assertFalse(tripRepository.stops("t1").first().single().costKnown)
+    }
+
+    private fun insertViewModel(before: String) = StopEditViewModel(
+        SavedStateHandle(mapOf("tripId" to "t1", "insertBefore" to before)),
+        tripRepository,
+        settingsRepository,
+        resolver,
+    )
+
+    @Test
+    fun `a stop inserted in front of another takes its slot and pushes the plan back`() = runTest {
+        tripRepository.upsertStop(
+            Stop(id = "a", tripId = "t1", name = "A", orderIndex = 0, nights = 2, arrivalDate = LocalDate.of(2027, 6, 10)),
+        )
+        tripRepository.upsertStop(
+            Stop(id = "b", tripId = "t1", name = "B", orderIndex = 1, nights = 1, arrivalDate = LocalDate.of(2027, 6, 12)),
+        )
+        val vm = insertViewModel("b")
+        // It arrives the day A leaves, and no GPS fix is asked for.
+        assertEquals(LocalDate.of(2027, 6, 12), vm.uiState.value.arrivalDate)
+        assertFalse(vm.uiState.value.autoLocatePending)
+        vm.setName("Between")
+        vm.setNights(2)
+        vm.save {}
+        val stops = tripRepository.stops("t1").first().sortedBy { it.orderIndex }
+        assertEquals(listOf("A", "Between", "B"), stops.map { it.name })
+        assertEquals(LocalDate.of(2027, 6, 14), stops.last().arrivalDate) // pushed back two nights
+    }
+
+    @Test
+    fun `a stop inserted in front of unplanned nights starts on the first of them`() = runTest {
+        tripRepository.upsertStop(
+            Stop(id = "a", tripId = "t1", name = "A", orderIndex = 0, nights = 2, arrivalDate = LocalDate.of(2027, 6, 10)),
+        )
+        tripRepository.upsertStop(
+            Stop(id = "b", tripId = "t1", name = "B", orderIndex = 1, nights = 1, arrivalDate = LocalDate.of(2027, 6, 15)),
+        )
+        val vm = insertViewModel("gap-b")
+        assertEquals(LocalDate.of(2027, 6, 12), vm.uiState.value.arrivalDate)
+        vm.setName("Between")
+        vm.setNights(1)
+        vm.save {}
+        val stops = tripRepository.stops("t1").first().sortedBy { it.orderIndex }
+        assertEquals(listOf("A", "Between", "B"), stops.map { it.name })
+        // The three empty nights survive the insert, now after it.
+        assertEquals(LocalDate.of(2027, 6, 16), stops.last().arrivalDate)
+    }
+
+    @Test
+    fun `a stop inserted in front of a row that is gone just appends`() = runTest {
+        tripRepository.upsertTrip(
+            Trip(id = "t1", name = "Plan", startDate = LocalDate.of(2027, 6, 10), status = TripStatus.PLANNED),
+        )
+        tripRepository.upsertStop(
+            Stop(id = "a", tripId = "t1", name = "A", orderIndex = 0, nights = 2, arrivalDate = LocalDate.of(2027, 6, 10)),
+        )
+        val vm = insertViewModel("gone")
+        assertEquals(LocalDate.of(2027, 6, 12), vm.uiState.value.arrivalDate) // chained off A
+        vm.setName("Last")
+        vm.save {}
+        assertEquals(listOf("A", "Last"), tripRepository.stops("t1").first().sortedBy { it.orderIndex }.map { it.name })
     }
 
     @Test


### PR DESCRIPTION
Two bits of unnecessary typing in the stop flow.

## No name field when adding a stop

Places come from Google now, so choosing one already names the stop — the field was
just something to type into. A new stop shows the picked name where the field used to
be; the field itself is back when you reopen an existing stop, so renaming to
"Grandma's driveway" still works.

Save now takes a name **or** a location. A pin that nothing could name (no geocode, no
network) falls back to the reverse-geocoded place, then to the kind — "Free camp" —
so it can never become a dead end where Save is disabled and there is nothing to type
into.

## A + between each pair of timeline rows

Tapping it offers **Stop** or **Nothing planned**:

- **Stop** opens the editor for that slot. The new stop takes the following row's place
  in the order and starts on the day that row started — in front of a gap, the first of
  its empty nights. The row key travels as `StopEditRoute.insertBefore`;
  `Timeline.insertion` turns it into the order index and the date.
- **Nothing planned** inserts one empty night. The gap row appears by itself, since gaps
  are derived from the dates, and its ± controls grow it from there.

Either way the rest of the plan moves back by the nights it takes (`DateCascade.shift`).

Slots appear only where a row could also be dragged: never in front of the first stop
(the plan starts there — the FAB still adds to the end), never in front of a done stop
or the one you are heading for, and not at all on a finished trip.

## For the reviewer

- A lazy item emits the slot and the card as two stacked placeables rather than wrapping
  them in a Column — a wrapper added a composable lambda whose skip path the tests never
  reach, which broke the 100% coverage gate. `the slot between two rows adds a stop
  there` asserts the two do not overlap.
- One existing test needed a fix: the taller list pushed the gap card's remove button
  under the floating action button, where the injected click hit the FAB instead. It now
  scrolls one row further. **That overlap is real on a device too** — any row control
  that lands in the FAB's corner mid-scroll is unreachable until you scroll on. Not
  addressed here.
- `./gradlew test :app:coverageVerify` and `:app:pitest` (94% killed) pass. Verified
  visually through `ScreenshotsTest`, not on the emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)