### PR TITLE
Take a place shared from Google Maps onto a trip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ app/google-services.json
 *.jks
 keystore.properties
 notes.txt
+.kotlin/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,20 @@ MVVM + repository, hand-rolled DI — no Hilt, no Room. Package root:
   the timeline, map, distance and fuel all count it without knowing what home is. It is
   editable and deletable like any other stop; HOME is hidden from the kind chips so a
   second one cannot be made by hand.
+- **A shared place** arrives as `ACTION_SEND` text/plain (Google Maps' share sheet) or a
+  `geo:` `ACTION_VIEW`, and is parsed by pure `domain/SharedPlace`: the payload is scanned
+  as a haystack, not parsed as a URL, because Maps sends the name on the line above the link.
+  `!3d`/`!4d` is the place and beats `/@`, which is only the map camera and marks the hit
+  `approximate`; a place id is kept **only** from `query_place_id` (never an ftid or cid —
+  a wrong one would have PlaceCacheSweeper delete the pin 30 days on); redirects are
+  followed only for four allowlisted short-link hosts, by `location/ShareLinkResolver`
+  (one HEAD, redirects off). `MainActivity` offers the result to `domain/ShareIntake` on
+  the container — not to the Activity, since in Firebase mode the share must outlive the
+  sign-in screen — and `AppNavHost` routes it **once** into `AddToTripRoute`, after which
+  it rides the back stack. `ui/share/AddToTripScreen` picks the trip; that opens
+  `StopEditRoute` with the place args over a pushed `TripDetailRoute`, so Save lands on
+  the timeline. A shared coordinate **never** gets `locationCachedAt`: it came from a
+  link, not from the Places API, so no §14.3 clock applies to it.
 - **Navigation** (`ui/nav/`): type-safe kotlinx-serialization routes. The location picker
   returns its result through the **previous** back-stack entry's `SavedStateHandle` under
   `PICKED_LOCATION_KEY` (a `DoubleArray`); `AppNavHost` observes it and feeds
@@ -233,6 +247,9 @@ swaps the Maps SDK for a stand-in (`ui/map/MapProvider.kt`). Fakes live in `test
 - **ViewModel tests**: plain JUnit with `MainDispatcherRule` (testutil) and Turbine
   for flow assertions. Async races (late geocode result, slow sign-in) use the gated
   fakes: `FakeAuthRepository.gate`, `FakePlaceNameResolver.gates`.
+- **Never replace the activity's intent in `MainActivity.onCreate`** (`setIntent(...)`):
+  `ActivityScenario` then never sees the activity reach RESUMED, and every
+  `createAndroidComposeRule` test in the run hangs — with no failure, just a stuck suite.
 - **Coverage gate** is 100% of non-excluded lines — new code needs tests or, if
   genuinely untestable on the JVM (device/backend-only), an entry in
   `coverageExcludes` in app/build.gradle.kts.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ trips visible on a map.
 - **Locations** via one-shot GPS fix ("I'm here") or the map picker — search a place
   by name and choose from the results, tap a POI Google already shows, or press and
   hold to drop a pin. Results favour whatever kind of stop you're adding.
+- **Share a place into the app** — Google Maps (or anything sending a `geo:` link) →
+  Share → CamperExperience: pick the trip and the stop editor opens on that place.
 - **Cloud sync** via Firebase (Google Sign-In + Firestore with offline persistence).
   Until Firebase is configured the app runs in local demo mode — see
   [FIREBASE_SETUP.md](FIREBASE_SETUP.md).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -204,6 +204,7 @@ tasks.register<JavaExec>("pitest") {
             "com.nuelto.camperexperience.ui.triplist.TripListViewModel",
             "com.nuelto.camperexperience.ui.settings.SettingsViewModel",
             "com.nuelto.camperexperience.ui.map.LocationPickerViewModel",
+            "com.nuelto.camperexperience.ui.share.AddToTripViewModel",
         ).joinToString(","),
         // $$inlined$: synthetic coroutine/flow machinery; avoidCallsTo: compiler null-check noise.
         "--excludedClasses", "*\$Companion,*Test,*Test\$*,*\$\$inlined\$*",
@@ -218,6 +219,7 @@ tasks.register<JavaExec>("pitest") {
             "com.nuelto.camperexperience.ui.triplist.TripListViewModelTest",
             "com.nuelto.camperexperience.ui.settings.SettingsViewModelTest",
             "com.nuelto.camperexperience.ui.map.LocationPickerViewModelTest",
+            "com.nuelto.camperexperience.ui.share.AddToTripViewModelTest",
         ).joinToString(","),
         "--sourceDirs", "src/main/java",
         "--reportDir", layout.buildDirectory.dir("reports/pitest").get().asFile.absolutePath,

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,10 +18,27 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTop"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <!-- Share a place from Google Maps. The label is the share sheet's row.
+                 No https filter: Google hosts those assetlinks.json, so a Maps link
+                 filter can never verify — and enabling it by hand would swallow every
+                 Maps link on the phone. -->
+            <intent-filter android:label="Add to a trip">
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+            <!-- geo: is the open interchange format; no domain verification involved. -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="geo" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/com/nuelto/camperexperience/CamperApp.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/CamperApp.kt
@@ -13,7 +13,9 @@ import com.nuelto.camperexperience.data.InMemoryTripRepository
 import com.nuelto.camperexperience.data.SettingsRepository
 import com.nuelto.camperexperience.data.TripRepository
 import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.domain.ShareIntake
 import com.nuelto.camperexperience.location.LocationProvider
+import com.nuelto.camperexperience.location.ShareLinkResolver
 import com.nuelto.camperexperience.ui.map.PlaceholderMapProvider
 import com.nuelto.camperexperience.ui.map.MapProvider
 
@@ -32,6 +34,10 @@ class AppContainer(
     // One-shot GPS fix. The caller must hold ACCESS_FINE_LOCATION; the screens ask, and
     // this returns null when they have not.
     val currentLocation: suspend () -> LatLng? = { null },
+    // Where a shared place waits for a NavHost to exist. See domain/ShareIntake.
+    val shareIntake: ShareIntake = ShareIntake(),
+    // Follows a shared short link to the Maps URL behind it; null without a connection.
+    val expandShareLink: suspend (String) -> String? = { null },
 ) {
     val firebaseEnabled: Boolean get() = authRepository != null
 
@@ -39,8 +45,10 @@ class AppContainer(
         fun inMemory(
             mapProvider: MapProvider = PlaceholderMapProvider,
             currentLocation: suspend () -> LatLng? = { null },
+            expandShareLink: suspend (String) -> String? = { null },
         ) = AppContainer(
             null, InMemoryTripRepository(), InMemorySettingsRepository(), mapProvider, currentLocation,
+            expandShareLink = expandShareLink,
         )
     }
 }
@@ -59,7 +67,8 @@ open class CamperApp : Application() {
         // No key: the app runs, the map is simply blank.
         val map = googleMapProvider(this) ?: PlaceholderMapProvider
         val locate: suspend () -> LatLng? = { LocationProvider(this).currentLocation() }
-        return firebaseContainer(this, map, locate) ?: AppContainer.inMemory(map, locate)
+        val expand: suspend (String) -> String? = { ShareLinkResolver.expand(it) }
+        return firebaseContainer(this, map, locate, expand) ?: AppContainer.inMemory(map, locate, expand)
     }
 }
 

--- a/app/src/main/java/com/nuelto/camperexperience/FirebaseBackend.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/FirebaseBackend.kt
@@ -18,6 +18,7 @@ fun firebaseContainer(
     app: Application,
     mapProvider: MapProvider,
     currentLocation: suspend () -> LatLng? = { null },
+    expandShareLink: suspend (String) -> String? = { null },
 ): AppContainer? {
     val firebaseApp = FirebaseApp.initializeApp(app) ?: return null
     val db = FirebaseFirestore.getInstance()
@@ -35,5 +36,6 @@ fun firebaseContainer(
         tripRepository = FirestoreTripRepository(db, auth),
         settingsRepository = FirestoreSettingsRepository(db, auth),
         currentLocation = currentLocation,
+        expandShareLink = expandShareLink,
     )
 }

--- a/app/src/main/java/com/nuelto/camperexperience/MainActivity.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.nuelto.camperexperience
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -7,6 +8,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
+import com.nuelto.camperexperience.domain.SharedPlace
 import com.nuelto.camperexperience.ui.auth.SignInScreen
 import com.nuelto.camperexperience.ui.map.LocalMapProvider
 import com.nuelto.camperexperience.ui.nav.AppNavHost
@@ -18,27 +20,45 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         val container = (application as CamperApp).container
+        addOnNewIntentListener(::onShared)
+        // The cold start owns its launch intent; a recreate must not file the share twice,
+        // and neither may a task Android restores with that same intent still attached.
+        if (savedInstanceState == null) container.shareIntake.offer(sharedPlace(intent))
         setContent {
             CamperTheme {
                 AppRoot(container)
             }
         }
     }
+
+    /** A share arriving while the app runs. A plain relaunch is not one, and changes nothing. */
+    internal fun onShared(intent: Intent) {
+        sharedPlace(intent)?.let((application as CamperApp).container.shareIntake::offer)
+    }
+
+    /** EXTRA_TEXT is declared CharSequence: getStringExtra returns null for a styled one. */
+    internal fun sharedPlace(intent: Intent): SharedPlace? = when (intent.action) {
+        Intent.ACTION_SEND -> intent.getCharSequenceExtra(Intent.EXTRA_TEXT)?.toString()
+        Intent.ACTION_VIEW -> intent.dataString
+        else -> null
+    }?.let { SharedPlace.parse(it, intent.getStringExtra(Intent.EXTRA_SUBJECT).orEmpty()) }
 }
 
 @Composable
 internal fun AppRoot(container: AppContainer) {
     CompositionLocalProvider(LocalMapProvider provides container.mapProvider) {
+        val shared by container.shareIntake.pending.collectAsState()
         val authRepository = container.authRepository
         if (authRepository == null) {
             // Local-only mode: Firebase not configured in this build.
-            AppNavHost()
+            AppNavHost(shared, container.shareIntake::consume)
         } else {
             val user by authRepository.authState.collectAsState(initial = authRepository.currentUser)
             if (user == null) {
+                // A share arriving now waits in the intake until there is a NavHost.
                 SignInScreen(authRepository)
             } else {
-                AppNavHost()
+                AppNavHost(shared, container.shareIntake::consume)
             }
         }
     }

--- a/app/src/main/java/com/nuelto/camperexperience/domain/ShareIntake.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/domain/ShareIntake.kt
@@ -1,0 +1,23 @@
+package com.nuelto.camperexperience.domain
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Where a shared place waits between arriving as an Intent and reaching the NavHost. It
+ * lives on the container rather than the Activity because in Firebase mode with nobody
+ * signed in there is no NavHost yet — the share has to outlive the sign-in screen. One
+ * slot: once the chooser is on the back stack the place rides its route arguments.
+ */
+class ShareIntake {
+    private val _pending = MutableStateFlow<SharedPlace?>(null)
+    val pending: StateFlow<SharedPlace?> = _pending
+
+    fun offer(place: SharedPlace?) {
+        _pending.value = place
+    }
+
+    fun consume() {
+        _pending.value = null
+    }
+}

--- a/app/src/main/java/com/nuelto/camperexperience/domain/SharedPlace.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/domain/SharedPlace.kt
@@ -1,0 +1,204 @@
+package com.nuelto.camperexperience.domain
+
+import com.nuelto.camperexperience.data.model.LatLng
+import java.net.URLDecoder
+
+/**
+ * A place somebody shared into the app — Google Maps' share sheet, or any app sending a
+ * `geo:` link — before anything has been looked up.
+ *
+ * The payload is scanned as a haystack, never parsed as a URL: Maps puts the name on the
+ * line above the link, and the link carries the coordinate in one of several places.
+ */
+data class SharedPlace(
+    val name: String = "",
+    val location: LatLng? = null,
+    /** A real Places id, only ever from `query_place_id=` — never an ftid or a cid. A wrong
+     *  id would have [PlaceCacheSweeper] delete the coordinate 30 days on. */
+    val placeId: String = "",
+    /** A short link whose coordinate is one redirect away; blank when there is nothing to fetch. */
+    val link: String = "",
+    /** The coordinate is where the map camera sat, not the place — it can be kilometres out. */
+    val approximate: Boolean = false,
+) {
+    /**
+     * Folds in what following [link] produced. Returns this unchanged — [link] included, so
+     * the fetch can be retried — when the redirect was unreachable or named nowhere.
+     */
+    fun expandedWith(redirect: String?): SharedPlace {
+        val expanded = redirect?.let { parse(it) } ?: return this
+        if (expanded.location == null && expanded.name.isBlank()) return this
+        return copy(
+            // The share sheet's own name beats the URL's: it is what the user saw.
+            name = name.ifBlank { expanded.name },
+            location = expanded.location ?: location,
+            placeId = expanded.placeId.ifBlank { placeId },
+            link = "",
+            approximate = if (expanded.location != null) expanded.approximate else approximate,
+        )
+    }
+
+    companion object {
+        /** Shared text is untrusted; every regex below runs on at most this much of it. */
+        const val MAX_TEXT = 2_000
+
+        /**
+         * Null when the text names nowhere. Deliberately not handled, each being its own
+         * rule set with its own mutants: Plus Codes, DMS, `/maps/dir/` legs (whose `!1d`
+         * is longitude first), `?cid=`, and turning an ftid into a place id.
+         */
+        fun parse(text: String?, subject: String = ""): SharedPlace? {
+            val clean = text.orEmpty().take(MAX_TEXT).replace(CONTROLS, "")
+            // A coordinate typed in plain sight, outside the link — whose own digits are
+            // somebody else's rule. It is the last resort, and fills a link's blank.
+            val loose = coordinateIn(URL.replace(clean, " "))
+            val place = token(clean)?.let(::fromUrl) ?: loose ?: return null
+            return place.copy(
+                name = place.name.ifBlank { nameIn(clean) }.ifBlank { subject.take(MAX_TEXT).trim() },
+                location = place.location ?: loose?.location,
+            )
+        }
+
+        /** Hosts whose redirect we are willing to follow. The exact host, never a suffix. */
+        fun isShortLink(url: String): Boolean = host(url) in SHORT_HOSTS
+    }
+}
+
+// 17 decimals occur in the wild. COORD reads a whole value (a query, a path segment);
+// TEXT_COORD below scans free text, where the rules have to be tighter.
+private const val LAT = """([+-]?\d{1,2}(?:\.\d{1,17})?)"""
+private const val LON = """([+-]?\d{1,3}(?:\.\d{1,17})?)"""
+
+private val CONTROLS = Regex("[\\u200e\\u200f\\u202a-\\u202e]")
+private val URL = Regex("""https?://\S+""")
+private val COORD = Regex("""$LAT,\s*\+?$LON""")
+// Free text is scanned, so whole numbers are out: "Flat 2, 14 Baker Street" is an
+// address, and reading it as a coordinate would drop a pin in Gabon.
+private val TEXT_COORD =
+    Regex("""(?<![\d.])([+-]?\d{1,2}\.\d{1,17}),\s*([+-]?\d{1,3}\.\d{1,17})(?![\d.])""")
+// The place itself, as Maps writes it into the data segment; "@" is only the camera.
+private val DATA_PAIR = Regex("""!3d$LAT!4d$LON""")
+private val CAMERA = Regex("""/@$LAT,$LON""")
+private val PATH_COORD = Regex("""/maps/(?:search|place)/$LAT,\+?$LON""")
+private val PLACE_SEGMENT = Regex("""/maps/place/([^/@?]+)""")
+private val LABEL = Regex("""\(([^)]+)\)""")
+private val PLACE_ID = Regex("""[A-Za-z0-9_-]{10,255}""")
+private val GOOGLE = Regex("""(?:www\.|maps\.)?google(?:\.[a-z]{2,3}){1,2}""")
+// A saved list, a My Maps drawing, somebody's live location: not a place to camp.
+private val NOT_A_PLACE = Regex("""/maps/placelists/|/maps/d/|!2e2""")
+
+private val SHORT_HOSTS = setOf("maps.app.goo.gl", "goo.gl", "app.goo.gl", "g.co")
+// Where the place is named or pinned. Not "ll": that is the map camera, below.
+private val QUERY_KEYS = listOf("q", "query", "daddr", "destination")
+private val JUNK = charArrayOf('.', ',', ';', ':', '!', '?', ']', '}', '>', '"', '\'')
+
+private fun token(text: String): String? {
+    val trimmed = text.trim()
+    // A geo: URI is the whole payload, label and all — "\S+" would cut it at the space.
+    if (trimmed.startsWith("geo:")) return trimmed
+    val url = URL.find(text)?.value?.substringBefore("%3C")?.trimEnd(*JUNK) ?: return null
+    // A trailing ")" closes a "(Label)" as often as it closes a sentence.
+    return if (url.endsWith(")") && !url.contains("(")) url.dropLast(1) else url
+}
+
+private fun fromUrl(url: String): SharedPlace? = when {
+    url.startsWith("geo:") -> fromGeo(url)
+    SharedPlace.isShortLink(url) -> fromShortLink(url)
+    host(url).matches(GOOGLE) -> fromMaps(url)
+    else -> null
+}
+
+/** RFC 5870, and Android's `geo:0,0?q=…` form where the path is only a placeholder. */
+private fun fromGeo(uri: String): SharedPlace? {
+    val query = params(uri.substringAfter('?', ""))["q"].orEmpty()
+    val path = uri.removePrefix("geo:").substringBefore('?').substringBefore(';')
+    val located = coordinateOf(query) ?: coordinateOf(path)
+    // An address nobody geocoded is still worth handing to the stop editor.
+    val name = label(query).ifBlank { if (located == null) nameLike(query.substringBefore('(')) else "" }
+    return place(name, located)
+}
+
+private fun fromShortLink(url: String): SharedPlace {
+    // The dynamic-link form carries the real URL in link=, so that one needs no network.
+    val inner = params(url.substringAfter('?', ""))["link"]?.let(::fromUrl)
+    return inner?.takeIf { it.location != null } ?: SharedPlace(link = url.replaceFirst("http://", "https://"))
+}
+
+private fun fromMaps(url: String): SharedPlace? {
+    if (NOT_A_PLACE.containsMatchIn(url)) return null
+    val path = url.substringBefore('?')
+    val params = params(url.substringAfter('?', ""))
+    val query = QUERY_KEYS.firstNotNullOfOrNull { params[it] }.orEmpty().removePrefix("loc:")
+    // Where Maps writes the place's own coordinate, in the order it can be trusted.
+    val exact = DATA_PAIR.findAll(url).lastOrNull()?.let(::coordinate)
+        ?: coordinateOf(query)
+        ?: PATH_COORD.find(path)?.let(::coordinate)
+    val camera = CAMERA.find(url)?.let(::coordinate) ?: coordinateOf(params["ll"].orEmpty())
+    val name = placeSegment(path)
+        .ifBlank { label(query) }
+        // A query that is not a coordinate is the place's name — or its address.
+        .ifBlank { if (exact == null) nameLike(query.substringBefore('(')) else "" }
+    return place(
+        name = name,
+        location = exact ?: camera,
+        placeId = params["query_place_id"]?.takeIf { PLACE_ID.matches(it) }.orEmpty(),
+        approximate = exact == null && camera != null,
+    )
+}
+
+/** The name Maps puts in the path, when there is one. */
+private fun placeSegment(path: String): String =
+    nameLike(PLACE_SEGMENT.find(path)?.groupValues?.get(1)?.let(::decode).orEmpty())
+
+/** A query value is a coordinate or it is a name — the whole of it, either way. */
+private fun coordinateOf(value: String): LatLng? =
+    COORD.matchEntire(value.substringBefore('(').trim())?.let(::coordinate)
+
+/** Text that is really a coordinate names nothing — in the path or in the query. */
+private fun nameLike(text: String): String =
+    text.trim().takeIf { COORD.matchEntire(it) == null }.orEmpty()
+
+/** The first line that is neither a link nor a coordinate: the share sheet's own name. */
+private fun nameIn(text: String): String = text.lineSequence()
+    .map { it.trim() }
+    .firstOrNull {
+        it.isNotBlank() && !it.startsWith("geo:") &&
+            !URL.containsMatchIn(it) && !TEXT_COORD.containsMatchIn(it)
+    }
+    .orEmpty()
+
+private fun coordinateIn(text: String): SharedPlace? =
+    TEXT_COORD.find(text)?.let(::coordinate)?.let { SharedPlace(location = it) }
+
+/** Rejects anything off the globe, and the 0,0 sentinel `geo:` uses for "no coordinate". */
+private fun coordinate(match: MatchResult): LatLng? {
+    val latitude = match.groupValues[1].toDouble()
+    val longitude = match.groupValues[2].toDouble()
+    val nowhere = latitude !in -90.0..90.0 || longitude !in -180.0..180.0 ||
+        (latitude == 0.0 && longitude == 0.0)
+    return if (nowhere) null else LatLng(latitude, longitude)
+}
+
+private fun place(
+    name: String,
+    location: LatLng?,
+    placeId: String = "",
+    approximate: Boolean = false,
+): SharedPlace? =
+    if (name.isBlank() && location == null) null
+    else SharedPlace(name, location, placeId, approximate = approximate)
+
+private fun label(query: String): String = LABEL.find(query)?.groupValues?.get(1)?.trim().orEmpty()
+
+private fun params(query: String): Map<String, String> = query.split('&')
+    .filter { it.contains('=') }
+    .associate { it.substringBefore('=') to decode(it.substringAfter('=')) }
+
+private fun decode(value: String): String =
+    runCatching { URLDecoder.decode(value, "UTF-8") }.getOrDefault(value)
+
+/** Userinfo and port stripped: `https://maps.app.goo.gl@evil.com/x` is evil.com's. */
+private fun host(url: String): String = url.substringAfter("://", "")
+    .substringBefore('/').substringBefore('?').substringBefore('#')
+    .substringAfterLast('@').substringBefore(':')
+    .lowercase()

--- a/app/src/main/java/com/nuelto/camperexperience/location/ShareLinkResolver.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/location/ShareLinkResolver.kt
@@ -1,0 +1,38 @@
+package com.nuelto.camperexperience.location
+
+import com.nuelto.camperexperience.BuildConfig
+import com.nuelto.camperexperience.domain.SharedPlace
+import java.net.HttpURLConnection
+import java.net.URL
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Turns a `maps.app.goo.gl` short link into the Maps URL it stands for. One HEAD with
+ * redirects off: the first Location header already carries the whole answer, and not
+ * following it keeps us off the HTML (and its consent interstitial) entirely.
+ *
+ * Best-effort like every other network call here — null when there is no signal, and the
+ * chooser offers a retry.
+ */
+object ShareLinkResolver {
+
+    suspend fun expand(url: String): String? = withContext(Dispatchers.IO) {
+        // Only the hosts the parser vouched for: a redirect decides where a stop lands.
+        if (!SharedPlace.isShortLink(url)) return@withContext null
+        runCatching {
+            (URL(url).openConnection() as HttpURLConnection).run {
+                requestMethod = "HEAD"
+                instanceFollowRedirects = false
+                connectTimeout = 5_000
+                readTimeout = 5_000
+                setRequestProperty("User-Agent", "CamperExperience/${BuildConfig.VERSION_NAME}")
+                try {
+                    getHeaderField("Location")
+                } finally {
+                    disconnect()
+                }
+            }
+        }.getOrNull()
+    }
+}

--- a/app/src/main/java/com/nuelto/camperexperience/ui/nav/AppNavHost.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/nav/AppNavHost.kt
@@ -5,26 +5,45 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.toRoute
 import com.nuelto.camperexperience.data.model.LatLng
 import com.nuelto.camperexperience.data.model.StopKind
+import com.nuelto.camperexperience.domain.SharedPlace
 import com.nuelto.camperexperience.ui.map.AllTripsMapScreen
 import com.nuelto.camperexperience.ui.map.LocationPickerScreen
 import com.nuelto.camperexperience.ui.map.LocationSection
 import com.nuelto.camperexperience.ui.settings.SettingsScreen
 import com.nuelto.camperexperience.ui.settings.SettingsViewModel
+import com.nuelto.camperexperience.ui.share.AddToTripScreen
 import com.nuelto.camperexperience.ui.tripdetail.TripDetailScreen
 import com.nuelto.camperexperience.ui.tripedit.StopEditScreen
 import com.nuelto.camperexperience.ui.tripedit.StopEditViewModel
 import com.nuelto.camperexperience.ui.tripedit.TripEditScreen
 import com.nuelto.camperexperience.ui.triplist.TripListScreen
 
+/** [pending] is a place shared into the app, if one is waiting (see domain/ShareIntake). */
 @Composable
-fun AppNavHost() {
+fun AppNavHost(pending: SharedPlace? = null, onPendingConsumed: () -> Unit = {}) {
     val navController = rememberNavController()
+
+    // Routed exactly once: consuming empties the intake, and from here the place rides
+    // the back stack, so neither a rotation nor process death replays or loses it.
+    LaunchedEffect(pending) {
+        pending?.let {
+            navController.navigate(
+                AddToTripRoute(
+                    it.name, it.location?.latitude, it.location?.longitude,
+                    it.placeId, it.link, it.approximate,
+                ),
+            )
+            onPendingConsumed()
+        }
+    }
 
     NavHost(navController = navController, startDestination = TripListRoute) {
         composable<TripListRoute> {
@@ -52,9 +71,20 @@ fun AppNavHost() {
             TripEditScreen(
                 onBack = { navController.popBackStack() },
                 onSaved = { tripId, isNew ->
+                    // A tour planned to hold a shared place goes back to the chooser,
+                    // which now lists it; anything else opens the new trip.
+                    val fromChooser = navController.previousBackStackEntry
+                        ?.destination?.hasRoute<AddToTripRoute>() == true
                     navController.popBackStack()
-                    if (isNew) navController.navigate(TripDetailRoute(tripId))
+                    if (isNew && !fromChooser) navController.navigate(TripDetailRoute(tripId))
                 },
+            )
+        }
+        composable<AddToTripRoute> {
+            AddToTripScreen(
+                onCancel = { navController.popBackStack() },
+                onPlanTrip = { navController.navigate(TripEditRoute(planned = true)) },
+                onAddTo = navController::addToTrip,
             )
         }
         composable<StopEditRoute> { backStackEntry ->
@@ -165,6 +195,21 @@ fun AppNavHost() {
             )
         }
     }
+}
+
+/** The trip's timeline goes under the editor, so saving lands where the stop landed. */
+private fun NavController.addToTrip(tripId: String, place: SharedPlace) {
+    navigate(TripDetailRoute(tripId)) { popUpTo<AddToTripRoute> { inclusive = true } }
+    navigate(
+        StopEditRoute(
+            tripId,
+            lat = place.location?.latitude,
+            lon = place.location?.longitude,
+            placeName = place.name.ifBlank { null },
+            placeId = place.placeId.ifBlank { null },
+            fromShare = true,
+        ),
+    )
 }
 
 private const val PICKED_LOCATION_KEY = "picked_location"

--- a/app/src/main/java/com/nuelto/camperexperience/ui/nav/Routes.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/nav/Routes.kt
@@ -11,9 +11,39 @@ data class TripDetailRoute(val tripId: String)
 @Serializable
 data class TripEditRoute(val tripId: String? = null, val planned: Boolean = false)
 
-/** [insertBefore] is the timeline row key a new stop goes in front of; null appends. */
+/**
+ * [insertBefore] is the timeline row key a new stop goes in front of; null appends.
+ * The place arguments are how a shared location arrives — the same scalars the map
+ * picker hands back, minus the Places clock (see StopEditViewModel.applyShared).
+ */
 @Serializable
-data class StopEditRoute(val tripId: String, val stopId: String? = null, val insertBefore: String? = null)
+data class StopEditRoute(
+    val tripId: String,
+    val stopId: String? = null,
+    val insertBefore: String? = null,
+    val lat: Double? = null,
+    val lon: Double? = null,
+    val placeName: String? = null,
+    val placeId: String? = null,
+    // Sharing a place says you are not standing at it: no GPS fix on top, even when the
+    // share turned out to carry neither a name nor a coordinate.
+    val fromShare: Boolean = false,
+)
+
+/**
+ * A place shared into the app, waiting for a trip to belong to. Parsed scalars rather
+ * than the raw share text: they are already host-checked and range-checked here, and
+ * they survive process death on the back stack.
+ */
+@Serializable
+data class AddToTripRoute(
+    val name: String?,
+    val lat: Double?,
+    val lon: Double?,
+    val placeId: String?,
+    val link: String?,
+    val approximate: Boolean,
+)
 
 @Serializable
 data class AllTripsMapRoute(val tripId: String? = null)

--- a/app/src/main/java/com/nuelto/camperexperience/ui/share/AddToTripScreen.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/share/AddToTripScreen.kt
@@ -1,0 +1,167 @@
+package com.nuelto.camperexperience.ui.share
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.nuelto.camperexperience.data.model.Trip
+import com.nuelto.camperexperience.data.model.TripStatus
+import com.nuelto.camperexperience.domain.SharedPlace
+import com.nuelto.camperexperience.ui.formatTripDates
+import com.nuelto.camperexperience.ui.theme.statusColor
+
+/**
+ * Where a place shared from Google Maps lands: name it, then pick the trip it belongs
+ * to. Choosing one opens the stop editor on that trip with the place already filled in.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddToTripScreen(
+    onCancel: () -> Unit,
+    onPlanTrip: () -> Unit,
+    onAddTo: (tripId: String, place: SharedPlace) -> Unit,
+    viewModel: AddToTripViewModel = viewModel(factory = AddToTripViewModel.Factory),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Add to a trip") },
+                navigationIcon = {
+                    IconButton(onClick = onCancel) {
+                        Icon(Icons.Default.Close, contentDescription = "Cancel")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(padding),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item(key = "place") {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text(state.title, style = MaterialTheme.typography.titleLarge)
+                    Text(
+                        status(state),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    if (state.expanding) LinearProgressIndicator(Modifier.fillMaxWidth())
+                    if (state.expandFailed) {
+                        TextButton(onClick = viewModel::expand) { Text("Try again") }
+                    }
+                }
+            }
+            if (state.hasTrips) {
+                item(key = "which") {
+                    Text(
+                        "Which trip?",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+                // Not while the link is still being followed: choosing now would file the
+                // stop without the coordinate that is one redirect away.
+                val ready = !state.expanding
+                tripSection("On the road", TripStatus.ACTIVE, state.active, ready) { onAddTo(it, state.place) }
+                tripSection("Planned tours", TripStatus.PLANNED, state.planned, ready) { onAddTo(it, state.place) }
+                tripSection("Done", TripStatus.DONE, state.done, ready) { onAddTo(it, state.place) }
+            } else if (!state.loading) {
+                item(key = "empty") {
+                    Box(Modifier.fillMaxWidth().padding(top = 24.dp), Alignment.Center) {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            Text(
+                                "No trips yet.\nPlan a tour, then add this place to it.",
+                                textAlign = TextAlign.Center,
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Button(onClick = onPlanTrip) { Text("Plan a tour") }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** What we know about the place, in the order that matters to somebody about to camp. */
+private fun status(state: AddToTripUiState): String = when {
+    state.expanding -> "Opening the Google Maps link…"
+    state.expandFailed -> "Couldn't open that link. Check your connection."
+    state.place.approximate -> "Approximate spot — check the pin on the map after."
+    state.place.location != null -> "Pin from Google Maps."
+    else -> "No spot in that link — pick the place on the map after."
+}
+
+private fun LazyListScope.tripSection(
+    title: String,
+    status: TripStatus,
+    trips: List<Trip>,
+    enabled: Boolean,
+    onClick: (String) -> Unit,
+) {
+    if (trips.isEmpty()) return
+    item(key = "header-$title") {
+        Text(
+            title,
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = statusColor(status),
+        )
+    }
+    items(trips, key = { it.id }) { trip ->
+        Card(
+            onClick = { onClick(trip.id) },
+            enabled = enabled,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Column(Modifier.padding(16.dp)) {
+                Text(
+                    trip.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    formatTripDates(trip),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nuelto/camperexperience/ui/share/AddToTripViewModel.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/share/AddToTripViewModel.kt
@@ -1,0 +1,98 @@
+package com.nuelto.camperexperience.ui.share
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import com.nuelto.camperexperience.containerViewModelFactory
+import com.nuelto.camperexperience.data.TripRepository
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.data.model.Trip
+import com.nuelto.camperexperience.data.model.TripStatus
+import com.nuelto.camperexperience.domain.SharedPlace
+import com.nuelto.camperexperience.ui.nav.AddToTripRoute
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class AddToTripUiState(
+    val place: SharedPlace = SharedPlace(),
+    val active: List<Trip> = emptyList(),
+    // Sorted like the trip list: tours soonest first, finished trips as they come.
+    val planned: List<Trip> = emptyList(),
+    val done: List<Trip> = emptyList(),
+    val expanding: Boolean = false,
+    val expandFailed: Boolean = false,
+    val loading: Boolean = true,
+) {
+    val hasTrips: Boolean get() = active.isNotEmpty() || planned.isNotEmpty() || done.isNotEmpty()
+
+    /** A pin nobody named still needs a headline. */
+    val title: String get() = place.name.ifBlank { "Shared pin" }
+}
+
+/**
+ * The chooser a shared place lands on: which trip does this belong to? Everything about
+ * the place is already parsed — the only work here is following a short link, whose
+ * coordinate sits behind a redirect.
+ */
+class AddToTripViewModel(
+    place: SharedPlace,
+    tripRepository: TripRepository,
+    private val expandLink: suspend (String) -> String? = { null },
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(AddToTripUiState(place = place))
+    val uiState: StateFlow<AddToTripUiState> = _uiState
+
+    init {
+        tripRepository.trips()
+            .onEach { trips ->
+                _uiState.update { state ->
+                    state.copy(
+                        active = trips.filter { it.status == TripStatus.ACTIVE },
+                        planned = trips.filter { it.status == TripStatus.PLANNED }
+                            .sortedBy { it.startDate },
+                        done = trips.filter { it.status == TripStatus.DONE },
+                        loading = false,
+                    )
+                }
+            }
+            .launchIn(viewModelScope)
+        expand()
+    }
+
+    /** No-op unless the share was a short link; offered again when the fetch failed. */
+    fun expand() {
+        val link = _uiState.value.place.link.ifBlank { return }
+        _uiState.update { it.copy(expanding = true, expandFailed = false) }
+        viewModelScope.launch {
+            val expanded = _uiState.value.place.expandedWith(expandLink(link))
+            _uiState.update {
+                it.copy(place = expanded, expanding = false, expandFailed = expanded.link.isNotBlank())
+            }
+        }
+    }
+
+    companion object {
+        val Factory = containerViewModelFactory { container ->
+            AddToTripViewModel(
+                createSavedStateHandle().toRoute<AddToTripRoute>().sharedPlace(),
+                container.tripRepository,
+                container.expandShareLink,
+            )
+        }
+    }
+}
+
+/** Route scalars back into a place — kept out of the ViewModel so its tests need no Bundle. */
+private fun AddToTripRoute.sharedPlace() = SharedPlace(
+    name = name.orEmpty(),
+    location = if (lat != null && lon != null) LatLng(lat, lon) else null,
+    placeId = placeId.orEmpty(),
+    link = link.orEmpty(),
+    approximate = approximate,
+)

--- a/app/src/main/java/com/nuelto/camperexperience/ui/tripedit/StopEditViewModel.kt
+++ b/app/src/main/java/com/nuelto/camperexperience/ui/tripedit/StopEditViewModel.kt
@@ -111,8 +111,9 @@ class StopEditViewModel(
                     // The slot says which day this starts on; no GPS fix improves on that.
                     _uiState.update { it.copy(arrivalDate = at.date) }
                 } else if (trip == null || trip.status == TripStatus.ACTIVE) {
-                    // Logging where you are: immediately try a GPS fix.
-                    _uiState.update { it.copy(autoLocatePending = true) }
+                    // Logging where you are: immediately try a GPS fix — unless a share
+                    // already said where, in which case your own position is beside the point.
+                    if (!route.fromShare) _uiState.update { it.copy(autoLocatePending = true) }
                 } else {
                     // Planning ahead or back-filling a finished trip: no GPS fix
                     // (your couch is not the campsite), arrival chains from the last stop.
@@ -122,6 +123,7 @@ class StopEditViewModel(
                     val arrival = last?.arrivalDate?.plusDays(last.nights.toLong()) ?: trip.startDate
                     _uiState.update { it.copy(arrivalDate = arrival) }
                 }
+                applyShared()
                 return@launch
             }
 
@@ -145,6 +147,18 @@ class StopEditViewModel(
                 stop.location?.let { resolvePlaceName(it, autoFillName = false) }
             }
         }
+    }
+
+    /** A place shared into the app: what the map picker delivers, minus the Places clock. */
+    private fun applyShared() {
+        val name = route.placeName.orEmpty()
+        val at = if (route.lat != null && route.lon != null) LatLng(route.lat, route.lon) else null
+        if (at != null) {
+            return setPickedLocation(at, name, "", route.placeId.orEmpty(), fromPlaces = false)
+        }
+        // No coordinate, but a place id can still fetch one: PlaceCacheSweeper picks up a
+        // stop that has an id and nowhere to be.
+        _uiState.update { it.copy(name = name.ifBlank { it.name }, placeId = route.placeId) }
     }
 
     fun autoLocateHandled() = _uiState.update { it.copy(autoLocatePending = false) }
@@ -193,7 +207,15 @@ class StopEditViewModel(
      * It never routes through setLocation: that would drop the name and reverse geocode
      * over it. Moving the location in the same update also retires any geocode in flight.
      */
-    fun setPickedLocation(location: LatLng, name: String, label: String, placeId: String = "") {
+    fun setPickedLocation(
+        location: LatLng,
+        name: String,
+        label: String,
+        placeId: String = "",
+        // A shared link hands over a coordinate lifted from a URL, not one the Places API
+        // gave us: it carries no §14.3 clock, so PlaceCacheSweeper must leave it alone.
+        fromPlaces: Boolean = true,
+    ) {
         if (name.isBlank()) return setLocation(location)
         autoFilledName = name
         _uiState.update { state ->
@@ -203,7 +225,7 @@ class StopEditViewModel(
                 name = name,
                 // A Google place is kept by id; its coordinate is only cached (30 days).
                 placeId = placeId.ifBlank { null },
-                locationCachedAt = placeId.ifBlank { null }?.let { LocalDate.now() },
+                locationCachedAt = placeId.ifBlank { null }?.takeIf { fromPlaces }?.let { LocalDate.now() },
             )
         }
     }

--- a/app/src/test/java/com/nuelto/camperexperience/AppWiringTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/AppWiringTest.kt
@@ -8,9 +8,13 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nuelto.camperexperience.data.AuthUser
 import com.nuelto.camperexperience.data.InMemorySettingsRepository
 import com.nuelto.camperexperience.data.InMemoryTripRepository
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.domain.SharedPlace
 import com.nuelto.camperexperience.testutil.FakeAuthRepository
 import com.nuelto.camperexperience.testutil.TestCamperApp
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -37,6 +41,13 @@ class AppContainerTest {
             InMemorySettingsRepository(),
         )
         assertTrue(container.firebaseEnabled)
+    }
+
+    @Test
+    fun `the in-memory container starts with an empty intake and no link resolver`() = runTest {
+        val container = AppContainer.inMemory()
+        assertNull(container.shareIntake.pending.value)
+        assertNull(container.expandShareLink("https://maps.app.goo.gl/x1"))
     }
 
     @Test
@@ -73,6 +84,18 @@ class AppRootTest {
     fun `firebase mode with a signed-in user shows the app`() {
         compose.setContent { AppRoot(firebaseContainerWith(FakeAuthRepository(AuthUser("u1")))) }
         compose.onNodeWithText("Trips").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a share arriving while signed out waits for the sign-in`() {
+        val auth = FakeAuthRepository()
+        val container = firebaseContainerWith(auth)
+        container.shareIntake.offer(SharedPlace("Camping Grimselblick", LatLng(46.5601, 8.332)))
+        compose.setContent { AppRoot(container) }
+        compose.onNodeWithText("Sign in with Google").assertIsDisplayed()
+
+        auth.state.value = AuthUser("u1")
+        compose.onNodeWithText("Add to a trip").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/java/com/nuelto/camperexperience/ScreenshotsTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ScreenshotsTest.kt
@@ -13,11 +13,15 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nuelto.camperexperience.data.InMemorySettingsRepository
 import com.nuelto.camperexperience.data.InMemoryTripRepository
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.domain.SharedPlace
 import com.nuelto.camperexperience.testutil.TestCamperApp
 import com.nuelto.camperexperience.ui.map.LocalMapProvider
 import com.nuelto.camperexperience.ui.map.PlaceholderMapProvider
 import com.nuelto.camperexperience.ui.settings.SettingsScreen
 import com.nuelto.camperexperience.ui.settings.SettingsViewModel
+import com.nuelto.camperexperience.ui.share.AddToTripScreen
+import com.nuelto.camperexperience.ui.share.AddToTripViewModel
 import com.nuelto.camperexperience.ui.theme.CamperTheme
 import com.nuelto.camperexperience.ui.tripdetail.TripDetailScreen
 import com.nuelto.camperexperience.ui.tripdetail.TripDetailViewModel
@@ -116,6 +120,17 @@ class ScreenshotsTest {
         SettingsScreen(
             onBack = {},
             viewModel = SettingsViewModel(settingsRepository, authRepository = null),
+        )
+    }
+
+    @Test
+    fun addToTrip() = shoot("add-to-trip") {
+        AddToTripScreen(
+            onCancel = {}, onPlanTrip = {}, onAddTo = { _, _ -> },
+            viewModel = AddToTripViewModel(
+                SharedPlace("Camping Grimselblick", LatLng(46.5606, 8.3376)),
+                tripRepository,
+            ),
         )
     }
 }

--- a/app/src/test/java/com/nuelto/camperexperience/ShareIntentTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ShareIntentTest.kt
@@ -1,0 +1,104 @@
+package com.nuelto.camperexperience
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.text.SpannableString
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.camperexperience.testutil.TestCamperApp
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.annotation.Config
+
+/**
+ * The share target end to end: an Intent arrives, and the chooser is on screen. The
+ * manifest filter itself is only checked here — Robolectric cannot run the share sheet.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(application = TestCamperApp::class)
+class ShareIntentTest {
+
+    @get:Rule
+    val compose = createEmptyComposeRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val intake get() = (context as CamperApp).container.shareIntake
+
+    private val mapsLink =
+        "Camping Grimselblick\nhttps://www.google.com/maps/place/Grimselblick/data=!3d46.5601!4d8.332"
+
+    private fun shareIntent(text: CharSequence) = Intent(Intent.ACTION_SEND)
+        .setClass(context, MainActivity::class.java)
+        .setType("text/plain")
+        .putExtra(Intent.EXTRA_TEXT, text)
+
+    @Test
+    fun `a cold share opens the chooser and is not replayed`() {
+        ActivityScenario.launch<MainActivity>(shareIntent(mapsLink)).use { scenario ->
+            compose.onNodeWithText("Add to a trip").assertIsDisplayed()
+            // The URL's own place segment names the stop; the share sheet's line is a fallback.
+            compose.onNodeWithText("Grimselblick").assertIsDisplayed()
+            // Consumed the moment the chooser was pushed; a recreate offers nothing new.
+            assertNull(intake.pending.value)
+            scenario.recreate()
+            assertNull(intake.pending.value)
+        }
+    }
+
+    @Test
+    fun `a styled EXTRA_TEXT is read`() {
+        ActivityScenario.launch<MainActivity>(shareIntent(SpannableString(mapsLink))).use {
+            compose.onNodeWithText("Add to a trip").assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun `a geo link opens the chooser`() {
+        val intent = Intent(Intent.ACTION_VIEW)
+            .setClass(context, MainActivity::class.java)
+            .setData(Uri.parse("geo:0,0?q=46.5601,8.332(Grimselpass)"))
+        ActivityScenario.launch<MainActivity>(intent).use {
+            compose.onNodeWithText("Grimselpass").assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun `a share arriving while the app runs is handled too`() {
+        // Through the framework's own onNewIntent, so the listener registration is what
+        // is under test rather than the method it points at.
+        val controller = Robolectric.buildActivity(MainActivity::class.java).setup()
+        compose.onNodeWithText("Trips").assertIsDisplayed()
+        controller.newIntent(shareIntent(mapsLink))
+        compose.onNodeWithText("Add to a trip").assertIsDisplayed()
+        controller.destroy()
+    }
+
+    @Test
+    fun `a plain launch and an unreadable share open nothing`() {
+        ActivityScenario.launch<MainActivity>(shareIntent("hello")).use { scenario ->
+            compose.onNodeWithText("Trips").assertIsDisplayed()
+            scenario.onActivity {
+                assertNull(it.sharedPlace(Intent(Intent.ACTION_MAIN)))
+                // A relaunch that shares nothing leaves whatever is on screen alone.
+                it.onShared(Intent(Intent.ACTION_MAIN))
+            }
+            assertNull(intake.pending.value)
+        }
+    }
+
+    @Test
+    fun `the share filter is live in the manifest`() {
+        val filter = Intent(Intent.ACTION_SEND).setType("text/plain")
+        val activities = context.packageManager.queryIntentActivities(filter, 0)
+        assertTrue(activities.any { it.activityInfo.name == MainActivity::class.java.name })
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/domain/ShareIntakeTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/domain/ShareIntakeTest.kt
@@ -1,0 +1,40 @@
+package com.nuelto.camperexperience.domain
+
+import com.nuelto.camperexperience.data.model.LatLng
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ShareIntakeTest {
+
+    private val place = SharedPlace("Camping Grimselblick", LatLng(46.56, 8.33))
+
+    @Test
+    fun `a shared place waits in the intake until it is consumed`() {
+        val intake = ShareIntake()
+        assertNull(intake.pending.value)
+
+        intake.offer(place)
+        assertEquals(place, intake.pending.value)
+
+        intake.consume()
+        assertNull(intake.pending.value)
+    }
+
+    @Test
+    fun `the same place shared twice lands twice`() {
+        val intake = ShareIntake()
+        intake.offer(place)
+        intake.consume()
+        intake.offer(place)
+        assertEquals(place, intake.pending.value)
+    }
+
+    @Test
+    fun `an unreadable share offers nothing`() {
+        val intake = ShareIntake()
+        intake.offer(place)
+        intake.offer(null)
+        assertNull(intake.pending.value)
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/domain/SharedPlaceTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/domain/SharedPlaceTest.kt
@@ -1,0 +1,322 @@
+package com.nuelto.camperexperience.domain
+
+import com.nuelto.camperexperience.data.model.LatLng
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Real payloads: what Google Maps, WhatsApp and the geo: scheme actually send. */
+class SharedPlaceTest {
+
+    private fun parse(text: String?, subject: String = "") = SharedPlace.parse(text, subject)
+
+    private fun at(text: String): LatLng = requireNotNull(parse(text)?.location)
+
+    @Test
+    fun `the place coordinate beats the map centre`() {
+        val place = parse(
+            "https://www.google.com/maps/place/Grimselpass/@46.5,8.3,15z/" +
+                "data=!4m6!3m5!1s0x0:0x0!8m2!3d46.5601!4d8.3320",
+        )!!
+        assertEquals("Grimselpass", place.name)
+        assertEquals(LatLng(46.5601, 8.332), place.location)
+        assertFalse(place.approximate)
+    }
+
+    @Test
+    fun `the last data pair is the place`() {
+        assertEquals(
+            LatLng(48.856614, 2.3522219),
+            at("https://www.google.com/maps/place/X/data=!3d37.0625!4d-95.677!4m2!3d48.856614!4d2.3522219"),
+        )
+    }
+
+    @Test
+    fun `a map centre on its own is only approximate`() {
+        val place = parse("https://www.google.com/maps/place/Anand+Tea+Stall/@26.4989241,80.1953814,12z")!!
+        assertEquals(LatLng(26.4989241, 80.1953814), place.location)
+        assertTrue(place.approximate)
+        assertEquals("Anand Tea Stall", place.name)
+        // The camera suffix varies with what Maps was showing.
+        assertEquals(LatLng(46.5, 8.3), at("https://www.google.com/maps/@46.5,8.3,11.42z"))
+        assertEquals(LatLng(46.5, 8.3), at("https://www.google.com/maps/@46.5,8.3,247m/data=!3m1!1e3"))
+    }
+
+    @Test
+    fun `our own share link round-trips`() {
+        val url = MapsUri.share("Grimsel Pass", LatLng(46.5606, 8.3376), "ChIJCyinolJ-hUcRIQiP1AQWa4s")!!
+        val place = parse(url)!!
+        assertEquals(LatLng(46.5606, 8.3376), place.location)
+        assertEquals("ChIJCyinolJ-hUcRIQiP1AQWa4s", place.placeId)
+    }
+
+    @Test
+    fun `a dropped pin carries its coordinate in the path`() {
+        assertEquals(LatLng(5.811698, -55.118891), at("https://www.google.com/maps/search/5.811698,+-55.118891"))
+    }
+
+    @Test
+    fun `a query that is not a coordinate is a name`() {
+        val place = parse("https://www.google.com/maps/search/?api=1&query=Camping%20Delta%20Locarno")!!
+        assertEquals("Camping Delta Locarno", place.name)
+        assertNull(place.location)
+    }
+
+    @Test
+    fun `the legacy loc form keeps its label`() {
+        val place = parse("https://maps.google.com/maps?q=loc:46.8182,8.2275%20(Rütli)")!!
+        assertEquals("Rütli", place.name)
+        assertEquals(LatLng(46.8182, 8.2275), place.location)
+    }
+
+    @Test
+    fun `geo carries a coordinate, a label, or an address`() {
+        assertEquals(LatLng(46.5601, 8.332), at("geo:46.5601,8.332"))
+        assertEquals(LatLng(46.5601, 8.332), at("geo:46.5601,8.332?z=15"))
+        assertEquals(LatLng(46.5, 8.3), at("geo:46.5,8.3;u=35"))
+
+        val labelled = parse("geo:0,0?q=46.5601,8.332(Grimselpass)")!!
+        assertEquals("Grimselpass", labelled.name)
+        assertEquals(LatLng(46.5601, 8.332), labelled.location)
+
+        val address = parse("geo:0,0?q=Bahnhofplatz+3,+7000+Chur")!!
+        assertEquals("Bahnhofplatz 3, 7000 Chur", address.name)
+        assertNull(address.location)
+    }
+
+    @Test
+    fun `the geo zero sentinel is nowhere`() {
+        assertNull(parse("geo:0,0"))
+        assertNull(parse("geo:0,0?z=15"))
+    }
+
+    @Test
+    fun `only the four short-link hosts are followed`() {
+        listOf("maps.app.goo.gl/aBcD1234", "goo.gl/maps/x1", "app.goo.gl/x1", "g.co/kgs/x1").forEach { host ->
+            assertEquals("https://$host", parse("https://$host")?.link)
+            assertTrue(SharedPlace.isShortLink("https://$host"))
+        }
+        assertNull(parse("https://maps.app.goo.gl.evil.com/x"))
+        assertNull(parse("https://evil.com/maps.app.goo.gl/x"))
+        // Userinfo is not a host: this one belongs to evil.com.
+        assertNull(parse("https://maps.app.goo.gl@evil.com/x"))
+        assertFalse(SharedPlace.isShortLink("https://maps.google.com/maps?q=1,2"))
+    }
+
+    @Test
+    fun `a short link is upgraded to https`() {
+        assertEquals("https://goo.gl/maps/x1", parse("http://goo.gl/maps/x1")?.link)
+    }
+
+    @Test
+    fun `the dynamic-link form needs no network`() {
+        val place = parse(
+            "https://maps.app.goo.gl/?apn=com.google.android.apps.maps&link=" +
+                "https%3A%2F%2Fwww.google.com%2Fmaps%2Fplace%2FThun%2Fdata%3D!3d46.758!4d7.628",
+        )!!
+        assertEquals("Thun", place.name)
+        assertEquals(LatLng(46.758, 7.628), place.location)
+        assertEquals("", place.link)
+        // A dynamic link pointing at nothing usable is still worth a redirect.
+        assertEquals(
+            "https://maps.app.goo.gl/?link=https%3A%2F%2Fexample.com%2Fx",
+            parse("https://maps.app.goo.gl/?link=https%3A%2F%2Fexample.com%2Fx")?.link,
+        )
+    }
+
+    @Test
+    fun `the share sheet's own name is kept`() {
+        val place = parse("Camping Grimselblick\nGrimselstrasse\nhttps://maps.app.goo.gl/aBcD1234")!!
+        assertEquals("Camping Grimselblick", place.name)
+        assertEquals("https://maps.app.goo.gl/aBcD1234", place.link)
+        assertNull(place.location)
+    }
+
+    @Test
+    fun `the subject names an otherwise nameless share`() {
+        assertEquals(
+            "Camping Kirnbergsee",
+            parse("https://maps.app.goo.gl/x1", subject = "Camping Kirnbergsee")?.name,
+        )
+    }
+
+    @Test
+    fun `only a real place id is kept`() {
+        val kept = "https://www.google.com/maps/search/?api=1&query=46.5,8.3&query_place_id=ChIJCyinolJ-hUcR"
+        assertEquals("ChIJCyinolJ-hUcR", parse(kept)?.placeId)
+        // Too short to be one, and the hex ftid and cid forms are nobody's place id.
+        assertEquals("", parse("$kept-!".dropLast(2).replace("ChIJCyinolJ-hUcR", "ChIJ1"))?.placeId)
+        assertEquals(
+            "",
+            parse("https://www.google.com/maps/place/X/data=!1s0x47a8c:0x26bb!8m2!3d46.5!4d8.3")?.placeId,
+        )
+        assertEquals("", parse("https://maps.google.com/?q=46.5,8.3&cid=2791100708733537379")?.placeId)
+    }
+
+    @Test
+    fun `country domains are Google, lookalikes are not`() {
+        listOf("www.google.co.uk", "maps.google.de", "google.ch").forEach { host ->
+            assertEquals(LatLng(46.5, 8.3), at("https://$host/maps/place/X/data=!3d46.5!4d8.3"))
+        }
+        assertNull(parse("https://google.evil.com/maps/place/X/data=!3d46.5!4d8.3"))
+        assertNull(parse("https://notgoogle.com/maps/place/X/data=!3d46.5!4d8.3"))
+    }
+
+    @Test
+    fun `junk around the link is stripped`() {
+        assertEquals(
+            LatLng(46.5, 8.3),
+            at("Look: https://www.google.com/maps/place/X/data=!3d46.5!4d8.3%3C%2Fa%3E"),
+        )
+        assertEquals(LatLng(46.5, 8.3), at("https://www.google.com/maps/place/X/data=!3d46.5!4d8.3."))
+        // A right-to-left mark inside the payload is not part of the name.
+        assertEquals("Grimsel", parse("‭Grimsel‬\nhttps://maps.app.goo.gl/x1")?.name)
+    }
+
+    @Test
+    fun `coordinates off the globe are refused`() {
+        assertNull(parse("https://www.google.com/maps/search/?api=1&query=91.0,8.3"))
+        assertNull(parse("https://www.google.com/maps/search/?api=1&query=46.5,181.0"))
+        assertNull(parse("https://www.google.com/maps/search/?api=1&query=0,0"))
+        assertNull(parse("46.5"))
+        // A named place whose coordinate is nonsense still hands over the name.
+        val named = parse("https://www.google.com/maps/place/X/data=!3d91.0!4d8.3")!!
+        assertEquals("X", named.name)
+        assertNull(named.location)
+    }
+
+    @Test
+    fun `an address is a name, never a pin`() {
+        // "Flat 2, 14 Baker Street" is a house number and a street, not 2°N 14°E.
+        val flat = parse("geo:0,0?q=Flat 2, 14 Baker Street, London")!!
+        assertEquals("Flat 2, 14 Baker Street, London", flat.name)
+        assertNull(flat.location)
+
+        val labelled = parse("geo:0,0?q=Unit 3, 45 George St(Camping George)")!!
+        assertEquals("Camping George", labelled.name)
+        assertNull(labelled.location)
+
+        val query = parse("https://www.google.com/maps/search/?api=1&query=Apt%205%2C%20120%20Main%20St")!!
+        assertEquals("Apt 5, 120 Main St", query.name)
+        assertNull(query.location)
+
+        // Free text needs decimals before it counts as a coordinate, and text with
+        // neither a link nor a coordinate is not a place at all.
+        assertNull(parse("Camping Sussex\nFlat 2, 14 Sea Lane, Brighton"))
+    }
+
+    @Test
+    fun `the map centre in a directions link is only approximate`() {
+        // "ll" is where the map was looking; the destination is what was meant.
+        val place = parse("https://maps.google.com/maps?daddr=Camping+Delta&ll=46.9,7.4")!!
+        assertEquals("Camping Delta", place.name)
+        assertEquals(LatLng(46.9, 7.4), place.location)
+        assertTrue(place.approximate)
+    }
+
+    @Test
+    fun `a coordinate beside a link fills the link's blank`() {
+        val place = parse("Camping Grimselblick 46.5601, 8.332\nhttps://maps.app.goo.gl/x1")!!
+        assertEquals(LatLng(46.5601, 8.332), place.location)
+        // Still worth following: the redirect knows the place, not just the pin.
+        assertEquals("https://maps.app.goo.gl/x1", place.link)
+    }
+
+    @Test
+    fun `the poles and the date line are still on the globe`() {
+        assertEquals(LatLng(90.0, 180.0), at("https://www.google.com/maps/place/X/data=!3d90.0!4d180.0"))
+        assertEquals(LatLng(-90.0, -180.0), at("https://www.google.com/maps/place/X/data=!3d-90.0!4d-180.0"))
+    }
+
+    @Test
+    fun `a geo query outranks the coordinate in its path`() {
+        // RFC 5870 puts the map centre in the path; "q" is the place actually meant.
+        assertEquals(LatLng(46.5601, 8.332), at("geo:47.0,7.0?q=46.5601,8.332"))
+    }
+
+    @Test
+    fun `a place segment that is really a coordinate is no name`() {
+        val place = parse("https://www.google.com/maps/place/46.5,8.3")!!
+        assertEquals("", place.name)
+        assertEquals(LatLng(46.5, 8.3), place.location)
+    }
+
+    @Test
+    fun `a decoded name survives`() {
+        assertEquals(
+            "Poznań Old Town, Poland",
+            parse("https://www.google.com/maps/place/Pozna%C5%84+Old+Town,+Poland/@52.4,16.9,15z")?.name,
+        )
+        // A percent sign that decodes to nothing is left as it stands.
+        assertEquals("100%zoom", parse("https://www.google.com/maps/place/100%zoom/@52.4,16.9,15z")?.name)
+    }
+
+    @Test
+    fun `a list, a drawing or a live location is not a place`() {
+        assertNull(parse("https://www.google.com/maps/placelists/list/abc?entry=tts"))
+        assertNull(parse("https://www.google.com/maps/d/viewer?mid=abc"))
+        assertNull(parse("https://www.google.com/maps/@46.5,8.3,15z/data=!4m5!7m4!1m2!1sx!2e2"))
+    }
+
+    @Test
+    fun `bare coordinates in text are the last resort`() {
+        assertEquals(LatLng(46.8182, 8.2275), at("Meet me at 46.8182, 8.2275 tomorrow"))
+        // Digits inside an unusable link are not a coordinate.
+        assertNull(parse("https://example.com/x/46.8182,8.2275"))
+    }
+
+    @Test
+    fun `17 decimals survive`() {
+        assertEquals(
+            LatLng(46.5, 16.929066199999998),
+            at("https://www.google.com/maps/place/X/data=!3d46.5!4d16.929066199999998"),
+        )
+    }
+
+    @Test
+    fun `empty and oversized payloads name nowhere`() {
+        assertNull(parse(null))
+        assertNull(parse(""))
+        assertNull(parse("   "))
+        assertNull(parse("hello"))
+        assertNull(parse("x".repeat(SharedPlace.MAX_TEXT) + " 46.5,8.3"))
+    }
+
+    @Test
+    fun `expanding a link folds the redirect in and keeps the name`() {
+        val short = parse("Camping Grimselblick\nhttps://maps.app.goo.gl/aBcD1234")!!
+        val expanded = short.expandedWith(
+            "https://www.google.com/maps/place/Grimselblick/data=!3d46.5601!4d8.332" +
+                "?query_place_id=ChIJCyinolJ-hUcR",
+        )
+        assertEquals("Camping Grimselblick", expanded.name)
+        assertEquals(LatLng(46.5601, 8.332), expanded.location)
+        assertEquals("ChIJCyinolJ-hUcR", expanded.placeId)
+        assertEquals("", expanded.link)
+        assertFalse(expanded.approximate)
+    }
+
+    @Test
+    fun `a redirect that names nowhere leaves the link to retry`() {
+        val short = parse("https://maps.app.goo.gl/aBcD1234")!!
+        assertEquals(short, short.expandedWith(null))
+        assertEquals(short, short.expandedWith("https://evil.com/?q=46.5,8.3"))
+        assertEquals(short, short.expandedWith("https://goo.gl/maps/other"))
+    }
+
+    @Test
+    fun `an expanded map centre stays approximate, and a named link keeps its own name`() {
+        val short = parse("https://maps.app.goo.gl/aBcD1234")!!
+        val expanded = short.expandedWith("https://www.google.com/maps/place/Titisee/@47.8918,8.1454,15z")
+        assertEquals("Titisee", expanded.name)
+        assertTrue(expanded.approximate)
+        // A redirect with only a name keeps whatever the share already knew.
+        val named = SharedPlace(location = LatLng(46.5, 8.3), link = "https://goo.gl/maps/x")
+        val byName = named.expandedWith("https://www.google.com/maps/search/?api=1&query=Camping%20Delta")
+        assertEquals("Camping Delta", byName.name)
+        assertEquals(LatLng(46.5, 8.3), byName.location)
+        assertFalse(byName.approximate)
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/testutil/TestSupport.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/testutil/TestSupport.kt
@@ -104,3 +104,15 @@ class FakePlaceSearch : PlaceSearch {
         return result
     }
 }
+
+/** Follows a shared short link on demand; [gate] holds the answer for mid-flight assertions. */
+class FakeShareLinkResolver(var result: String? = null) {
+    val requests = mutableListOf<String>()
+    var gate: CompletableDeferred<Unit>? = null
+
+    suspend fun expand(url: String): String? {
+        requests += url
+        gate?.await()
+        return result
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/nav/AppNavHostTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/nav/AppNavHostTest.kt
@@ -10,10 +10,17 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.camperexperience.AppContainer
+import com.nuelto.camperexperience.data.InMemorySettingsRepository
+import com.nuelto.camperexperience.data.InMemoryTripRepository
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.domain.SharedPlace
 import com.nuelto.camperexperience.testutil.TestCamperApp
 import com.nuelto.camperexperience.ui.map.LocalMapProvider
 import com.nuelto.camperexperience.ui.map.PlaceholderMapProvider
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -30,13 +37,17 @@ class AppNavHostTest {
     @get:Rule
     val compose = createComposeRule()
 
-    private fun setContent() {
+    private var consumed = 0
+
+    private fun setContent(pending: SharedPlace? = null) {
         compose.setContent {
             CompositionLocalProvider(LocalMapProvider provides PlaceholderMapProvider) {
-                AppNavHost()
+                AppNavHost(pending) { consumed++ }
             }
         }
     }
+
+    private val shared = SharedPlace("Camping Grimselblick", LatLng(46.5601, 8.332))
 
     @Test
     fun `starts on the trip list with demo data`() {
@@ -181,4 +192,46 @@ class AppNavHostTest {
             .performScrollTo().assertIsDisplayed()
     }
 
+
+    @Test
+    fun `a shared place is filed on the trip that is chosen for it`() {
+        setContent(shared)
+        compose.onNodeWithText("Add to a trip").assertIsDisplayed()
+        compose.onNodeWithText("Which trip?").assertIsDisplayed()
+        // Routed once; the place rides the back stack from here on.
+        assertEquals(1, consumed)
+
+        compose.onNodeWithText("Schwarzwald").performClick()
+        compose.onNodeWithText("New stop").assertIsDisplayed()
+        compose.onAllNodesWithText("Camping Grimselblick")[0].assertIsDisplayed()
+
+        compose.onNodeWithText("Save").performScrollTo().performClick()
+        // Saving lands on that trip's timeline, with the stop on it.
+        compose.onNodeWithText("Camping Kirnbergsee").assertIsDisplayed()
+        compose.onAllNodesWithText("Camping Grimselblick")[0].assertIsDisplayed()
+    }
+
+    @Test
+    fun `the chooser can be cancelled`() {
+        setContent(shared)
+        compose.onNodeWithContentDescription("Cancel").performClick()
+        compose.onNodeWithText("Trips").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a tour planned from the chooser comes back to it`() {
+        ApplicationProvider.getApplicationContext<TestCamperApp>().container =
+            AppContainer(null, InMemoryTripRepository(seed = false), InMemorySettingsRepository())
+        setContent(shared)
+
+        compose.onNodeWithText("Plan a tour").performClick()
+        compose.onNodeWithText("Trip name").performTextInput("Ticino")
+        compose.onNodeWithText("Save").performClick()
+
+        // Back on the chooser rather than in the new tour, with the tour now listed.
+        compose.onNodeWithText("Add to a trip").assertIsDisplayed()
+        compose.onNodeWithText("Ticino").performClick()
+        compose.onNodeWithText("New stop").assertIsDisplayed()
+        compose.onAllNodesWithText("Camping Grimselblick")[0].assertIsDisplayed()
+    }
 }

--- a/app/src/test/java/com/nuelto/camperexperience/ui/share/AddToTripScreenTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/share/AddToTripScreenTest.kt
@@ -1,0 +1,129 @@
+package com.nuelto.camperexperience.ui.share
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.camperexperience.data.InMemoryTripRepository
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.data.model.Trip
+import com.nuelto.camperexperience.data.model.TripStatus
+import com.nuelto.camperexperience.domain.SharedPlace
+import com.nuelto.camperexperience.testutil.FakeShareLinkResolver
+import com.nuelto.camperexperience.testutil.TestCamperApp
+import java.time.LocalDate
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = TestCamperApp::class)
+class AddToTripScreenTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val tripRepository = InMemoryTripRepository(seed = false)
+    private val resolver = FakeShareLinkResolver()
+    private var cancelled = 0
+    private var planned = 0
+    private val added = mutableListOf<Pair<String, SharedPlace>>()
+
+    private fun setContent(place: SharedPlace) {
+        compose.setContent {
+            AddToTripScreen(
+                onCancel = { cancelled++ },
+                onPlanTrip = { planned++ },
+                onAddTo = { tripId, shared -> added += tripId to shared },
+                viewModel = AddToTripViewModel(place, tripRepository, resolver::expand),
+            )
+        }
+    }
+
+    private fun seedTrips() = runTest {
+        tripRepository.upsertTrip(
+            Trip(id = "t1", name = "Schwarzwald", startDate = LocalDate.of(2026, 5, 1), status = TripStatus.DONE),
+        )
+        tripRepository.upsertTrip(
+            Trip(id = "t2", name = "Ticino", startDate = LocalDate.of(2026, 9, 1), status = TripStatus.PLANNED),
+        )
+    }
+
+    @Test
+    fun `a shared place is filed on the trip that is tapped`() {
+        seedTrips()
+        val place = SharedPlace("Camping Grimselblick", LatLng(46.5601, 8.332))
+        setContent(place)
+
+        compose.onNodeWithText("Camping Grimselblick").assertIsDisplayed()
+        compose.onNodeWithText("Pin from Google Maps.").assertIsDisplayed()
+        compose.onNodeWithText("Which trip?").assertIsDisplayed()
+        compose.onNodeWithText("Done").assertIsDisplayed()
+        compose.onNodeWithText("Planned tours").assertIsDisplayed()
+
+        compose.onNodeWithText("Ticino").performClick()
+        assertEquals(listOf("t2" to place), added)
+    }
+
+    @Test
+    fun `an approximate pin says so`() {
+        seedTrips()
+        setContent(SharedPlace("Titisee", LatLng(47.89, 8.14), approximate = true))
+        compose.onNodeWithText("Approximate spot — check the pin on the map after.").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a share with no spot says what happens next`() {
+        seedTrips()
+        setContent(SharedPlace(name = "Camping Delta"))
+        compose.onNodeWithText("No spot in that link — pick the place on the map after.").assertIsDisplayed()
+    }
+
+    @Test
+    fun `following a link is visible, and a failure can be retried`() {
+        seedTrips()
+        resolver.gate = CompletableDeferred()
+        setContent(SharedPlace("Camping X", link = "https://maps.app.goo.gl/x1"))
+        compose.onNodeWithText("Opening the Google Maps link…").assertIsDisplayed()
+
+        // Choosing now would file the stop without the coordinate one redirect away.
+        compose.onNodeWithText("Ticino").assertIsNotEnabled()
+
+        resolver.gate?.complete(Unit)
+        compose.onNodeWithText("Couldn't open that link. Check your connection.").assertIsDisplayed()
+        compose.onNodeWithText("Ticino").performClick()
+        assertEquals(1, added.size)
+
+        resolver.result = "https://www.google.com/maps/place/X/data=!3d46.5!4d8.3"
+        compose.onNodeWithText("Try again").performClick()
+        compose.onNodeWithText("Pin from Google Maps.").assertIsDisplayed()
+        assertEquals(2, resolver.requests.size)
+    }
+
+    @Test
+    fun `with no trips at all the chooser offers to plan one`() {
+        setContent(SharedPlace("Camping X", LatLng(46.5, 8.3)))
+        compose.onNodeWithText("No trips yet.\nPlan a tour, then add this place to it.").assertIsDisplayed()
+        compose.onNodeWithText("Plan a tour").performClick()
+        assertEquals(1, planned)
+
+        compose.onNodeWithContentDescription("Cancel").performClick()
+        assertEquals(1, cancelled)
+    }
+
+    @Test
+    fun `an active trip is offered first`() = runTest {
+        tripRepository.upsertTrip(Trip(id = "t3", name = "Vierwaldstättersee", status = TripStatus.ACTIVE))
+        setContent(SharedPlace("Camping X", LatLng(46.5, 8.3)))
+        compose.onNodeWithText("On the road").assertIsDisplayed()
+        compose.onNodeWithText("Vierwaldstättersee").performClick()
+        assertEquals(listOf("t3"), added.map { it.first })
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/share/AddToTripViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/share/AddToTripViewModelTest.kt
@@ -1,0 +1,98 @@
+package com.nuelto.camperexperience.ui.share
+
+import com.nuelto.camperexperience.data.InMemoryTripRepository
+import com.nuelto.camperexperience.data.model.LatLng
+import com.nuelto.camperexperience.data.model.Trip
+import com.nuelto.camperexperience.data.model.TripStatus
+import com.nuelto.camperexperience.domain.SharedPlace
+import com.nuelto.camperexperience.testutil.FakeShareLinkResolver
+import com.nuelto.camperexperience.testutil.MainDispatcherRule
+import java.time.LocalDate
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class AddToTripViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val tripRepository = InMemoryTripRepository(seed = false)
+    private val resolver = FakeShareLinkResolver()
+
+    private fun viewModel(place: SharedPlace) = AddToTripViewModel(place, tripRepository, resolver::expand)
+
+    private suspend fun trip(name: String, status: TripStatus, start: LocalDate = LocalDate.of(2026, 6, 1)) {
+        tripRepository.upsertTrip(Trip(id = name, name = name, startDate = start, status = status))
+    }
+
+    @Test
+    fun `trips are split by status, tours soonest first`() = runTest {
+        trip("Vierwaldstättersee", TripStatus.ACTIVE)
+        trip("Ticino", TripStatus.PLANNED, LocalDate.of(2026, 9, 1))
+        trip("Jura", TripStatus.PLANNED, LocalDate.of(2026, 7, 1))
+        trip("Provence", TripStatus.DONE)
+
+        val state = viewModel(SharedPlace("Camping X", LatLng(46.5, 8.3))).uiState.value
+        assertEquals(listOf("Vierwaldstättersee"), state.active.map { it.name })
+        assertEquals(listOf("Jura", "Ticino"), state.planned.map { it.name })
+        assertEquals(listOf("Provence"), state.done.map { it.name })
+        assertTrue(state.hasTrips)
+        assertFalse(state.loading)
+    }
+
+    @Test
+    fun `a share that already has a coordinate never touches the network`() {
+        val vm = viewModel(SharedPlace("Camping X", LatLng(46.5, 8.3)))
+        assertEquals(emptyList<String>(), resolver.requests)
+        assertFalse(vm.uiState.value.expanding)
+        assertEquals("Camping X", vm.uiState.value.title)
+    }
+
+    @Test
+    fun `a short link is followed and folded in`() {
+        resolver.gate = CompletableDeferred()
+        resolver.result = "https://www.google.com/maps/place/Grimselblick/data=!3d46.5601!4d8.332"
+        val vm = viewModel(SharedPlace("Camping Grimselblick", link = "https://maps.app.goo.gl/x1"))
+
+        assertTrue(vm.uiState.value.expanding)
+        assertEquals(listOf("https://maps.app.goo.gl/x1"), resolver.requests)
+
+        resolver.gate?.complete(Unit)
+        val state = vm.uiState.value
+        assertEquals(LatLng(46.5601, 8.332), state.place.location)
+        assertEquals("Camping Grimselblick", state.place.name)
+        assertEquals("", state.place.link)
+        assertFalse(state.expanding)
+        assertFalse(state.expandFailed)
+    }
+
+    @Test
+    fun `a link that could not be followed can be tried again`() {
+        val vm = viewModel(SharedPlace("Camping Grimselblick", link = "https://maps.app.goo.gl/x1"))
+        assertTrue(vm.uiState.value.expandFailed)
+        assertEquals("https://maps.app.goo.gl/x1", vm.uiState.value.place.link)
+
+        resolver.result = "https://www.google.com/maps/place/Grimselblick/data=!3d46.5601!4d8.332"
+        vm.expand()
+        assertFalse(vm.uiState.value.expandFailed)
+        assertEquals(LatLng(46.5601, 8.332), vm.uiState.value.place.location)
+        assertEquals(2, resolver.requests.size)
+
+        // Nothing left to follow: a second try is a no-op, not another request.
+        vm.expand()
+        assertEquals(2, resolver.requests.size)
+    }
+
+    @Test
+    fun `a pin nobody named still has a headline, and no trips is no trips`() {
+        val state = viewModel(SharedPlace(location = LatLng(46.5, 8.3))).uiState.value
+        assertEquals("Shared pin", state.title)
+        assertFalse(state.hasTrips)
+        assertFalse(state.loading)
+    }
+}

--- a/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/StopEditViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/camperexperience/ui/tripedit/StopEditViewModelTest.kt
@@ -41,6 +41,27 @@ class StopEditViewModelTest {
         resolver,
     )
 
+    private fun sharedViewModel(
+        lat: Double? = 46.5601,
+        lon: Double? = 8.332,
+        placeName: String? = "Camping Grimselblick",
+        placeId: String? = "ChIJCyinolJ-hUcR",
+    ) = StopEditViewModel(
+        SavedStateHandle(
+            mapOf(
+                "tripId" to "t1",
+                "lat" to lat,
+                "lon" to lon,
+                "placeName" to placeName,
+                "placeId" to placeId,
+                "fromShare" to true,
+            ),
+        ),
+        tripRepository,
+        settingsRepository,
+        resolver,
+    )
+
     private fun editViewModel(stopId: String) = StopEditViewModel(
         SavedStateHandle(mapOf("tripId" to "t1", "stopId" to stopId)),
         tripRepository,
@@ -566,5 +587,64 @@ class StopEditViewModelTest {
         vm.setName("B")
         vm.save {}
         assertEquals(listOf("A", "B"), tripRepository.stops("t1").first().map { it.name })
+    }
+
+    @Test
+    fun `a shared place prefills the stop, and never starts the Places clock`() {
+        val state = sharedViewModel().uiState.value
+        assertEquals("Camping Grimselblick", state.name)
+        assertEquals(LatLng(46.5601, 8.332), state.location)
+        assertEquals("ChIJCyinolJ-hUcR", state.placeId)
+        // The coordinate came out of a link, not out of the Places API: it never expires.
+        assertNull(state.locationCachedAt)
+        // Somewhere to be already: no unasked-for GPS fix on top of it.
+        assertFalse(state.autoLocatePending)
+    }
+
+    @Test
+    fun `a shared pin with no name is reverse geocoded`() {
+        val state = sharedViewModel(placeName = null, placeId = null).uiState.value
+        assertEquals("Place@46.5601", state.name)
+        assertEquals(LatLng(46.5601, 8.332), state.location)
+        assertNull(state.placeId)
+    }
+
+    @Test
+    fun `a shared name with no spot is still savable`() = runTest {
+        val vm = sharedViewModel(lat = null, lon = null, placeId = null)
+        val state = vm.uiState.value
+        assertEquals("Camping Grimselblick", state.name)
+        assertNull(state.location)
+        assertTrue(state.canSave)
+        assertFalse(state.autoLocatePending)
+
+        vm.save {}
+        assertEquals("Camping Grimselblick", tripRepository.stops("t1").first().single().name)
+    }
+
+    @Test
+    fun `a place picked on the map still carries the Places clock`() {
+        val vm = newStopViewModel()
+        vm.setPickedLocation(LatLng(46.72, 8.22), "Camping Grimselblick", "Innertkirchen", "ChIJ1")
+        assertEquals(LocalDate.now(), vm.uiState.value.locationCachedAt)
+    }
+
+    @Test
+    fun `a share with nothing in it still keeps your own position out of the stop`() {
+        // The link could not be followed: no name, no coordinate — and no GPS fix either,
+        // because sharing a place says you are not standing at it.
+        val state = sharedViewModel(lat = null, lon = null, placeName = null, placeId = null)
+            .uiState.value
+        assertFalse(state.autoLocatePending)
+        assertEquals("", state.name)
+        assertNull(state.location)
+    }
+
+    @Test
+    fun `a shared place id with no coordinate is kept for the sweeper`() {
+        val state = sharedViewModel(lat = null, lon = null).uiState.value
+        assertEquals("ChIJCyinolJ-hUcR", state.placeId)
+        assertNull(state.location)
+        assertNull(state.locationCachedAt)
     }
 }


### PR DESCRIPTION
Fixes #25.

Share → CamperExperience now files the place: a chooser asks which trip, and the stop
editor opens on it with the place already in place. `geo:` links work the same way.

## What changed

- **`domain/SharedPlace`** — the parser, pure and mutation-tested. The payload is scanned
  as a haystack rather than parsed as a URL, because Maps puts the name on the line above
  the link. `!3d/!4d` is the place and beats `/@`, which is only the map camera and gets
  flagged `approximate`. A query value is a coordinate **or** a name, never both, so
  "Flat 2, 14 Baker Street" stays an address instead of becoming a pin in Gabon. Only
  `query_place_id` is kept as a place id — a wrong one would have `PlaceCacheSweeper`
  delete the pin 30 days on — and only four allowlisted hosts get their redirect followed.
- **`domain/ShareIntake`** on the container, not the Activity: in Firebase mode a share
  has to outlive the sign-in screen. `AppNavHost` routes it **once** into `AddToTripRoute`,
  after which it rides the back stack, so a rotation can neither replay nor lose it.
- **`ui/share/AddToTripScreen`** — the chooser (active / planned / done, same color
  language as the trip list). Choosing a trip pushes `TripDetailRoute` under
  `StopEditRoute`, so Save lands on the timeline.
- **`location/ShareLinkResolver`** — one `HEAD` with redirects off, for
  `maps.app.goo.gl` links. Coverage-excluded, like the rest of `location/`.
- **`StopEditViewModel`** prefills through the existing `setPickedLocation` seam, so
  ordering, date cascade and totals are untouched.

## Reviewer notes

- **A shared coordinate never gets `locationCachedAt`.** It came out of a link, not out of
  the Places API, so no SST §14.3 clock applies — and stamping one would make the pin
  vanish for a camper who is offline for a month.
- **Sharing a place says you are not standing at it**, so `StopEditRoute.fromShare`
  suppresses the new-stop GPS fix even when the share turned out to carry neither a name
  nor a coordinate.
- **The `geo:` filter makes the app compete with Google Maps** for `geo:` links, so Android
  will ask once which app to use. Dropping that one `<intent-filter>` block removes it; the
  share-sheet path is unaffected. No `https` filters: Google hosts those `assetlinks.json`,
  so a Maps-link filter can never verify.
- Deliberately not handled, each being its own rule set: Plus Codes, DMS, `/maps/dir/`
  legs (lon first), `?cid=`, ftid→place-id conversion, and Places enrichment.

## Verification

`./gradlew test` (655), `:app:coverageVerify` (100% line), `:app:pitest` (94.1%, threshold
80%). On the emulator: cold share, warm share through `onNewIntent`, `geo:` VIEW, and
saving the stop onto the trip. The real short-link redirect could not be exercised without
an actual shared link; the failure path shows "Couldn't open that link" with a retry.

An adversarial review pass caught four real defects that are fixed here: the address-as-
coordinate bug above, `ll=` being reported as an exact pin, trip cards staying tappable
while the link was still being followed, and the auto-GPS overwrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)