### PR TITLE
Come back home, and say so when home is set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,9 @@ There is no lint/format tooling configured.
 - **Routes follow roads.** `domain/GoogleRoutes` builds the Routes API `computeRoutes`
   call (pure body + field mask + parse), `location/RouteServices` makes it, and each drive
   is stored on the arriving stop as `Stop.leg` (`StopLeg`: encoded polyline, distance,
-  duration, ascent/descent). A leg records the two coordinates it was routed between, so
+  duration, ascent/descent). Two consecutive stops at the same spot are not a drive
+  (`RouteCache.drives`) — a fresh plan is home-to-home until a stop goes between. A leg
+  records the two coordinates it was routed between, so
   `domain/RouteCache` invalidates it by comparison when a stop moves or the order changes
   — plus the same 30-day clock as Places (SST §19.3), enforced by `domain/RouteRefresher`
   from TripDetailViewModel. Stay off the Pro SKU: ≤10 intermediates per call
@@ -206,11 +208,15 @@ MVVM + repository, hand-rolled DI — no Hilt, no Room. Package root:
   (offline bounding boxes, confirm-only) + `domain/VignetteTable` — **refresh the table's
   prices yearly with the `appVersionBase` bump**.
 - **Home** is a `UserSettings` pin (`homeName`/`homeLocation`) picked in Settings through
-  the same injected `LocationSection` the stop editor uses. A new *plan* opens with it as
-  its first stop (`domain/HomeStop`) — a real Stop of kind HOME, not a special case, so
-  the timeline, map, distance and fuel all count it without knowing what home is. It is
-  editable and deletable like any other stop; HOME is hidden from the kind chips so a
-  second one cannot be made by hand.
+  the same injected `LocationSection` the stop editor uses; a fix or pin with no name is
+  reverse-geocoded into `homeName`, or the section looks as if nothing happened. A new
+  *plan* opens with it as its first stop **and its last** (`domain/HomeStop.forNewPlan`)
+  — real Stops of kind HOME, not a special case, so the timeline, map, distance and fuel
+  count the drive out and the drive back without knowing what home is. Both are editable
+  and deletable like any other stop. A stop added to the end of a plan goes in front of
+  the drive home (`HomeStop.returning`, in StopEditViewModel), starting a tour checks the
+  start home in (`TripStarter`) so the first night is what you are heading for, and the
+  HOME kind chip appears once a home is set and puts the stop there.
 - **A shared place** arrives as `ACTION_SEND` text/plain (Google Maps' share sheet) or a
   `geo:` `ACTION_VIEW`, and is parsed by pure `domain/SharedPlace`: the payload is scanned
   as a haystack, not parsed as a URL, because Maps sends the name on the line above the link.

--- a/app/src/main/java/com/nuelto/etappli/domain/HomeStop.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/HomeStop.kt
@@ -2,34 +2,57 @@ package com.nuelto.etappli.domain
 
 import com.nuelto.etappli.data.model.Stop
 import com.nuelto.etappli.data.model.StopKind
+import com.nuelto.etappli.data.model.StopState
 import com.nuelto.etappli.data.model.UserSettings
 import java.time.LocalDate
 
 /**
- * Where a plan starts from. A new plan opens with the home address as its first stop, so
- * the first leg is the drive out of the door rather than a guess — the distance, the fuel
- * and the map all count it without knowing anything about "home".
+ * Where a plan starts and ends. A new plan opens with the home address as its first stop
+ * and as its last, so the first leg is the drive out of the door and the last the drive
+ * back — the distance, the fuel and the map count both without knowing anything about
+ * "home".
  *
  * It is a real [Stop] rather than a setting the rest of the app has to special-case: the
  * only thing that makes it different is its [StopKind], and being a kind means the
  * timeline, the map and the estimator already handle it. That also makes it editable and
- * removable like any other stop — a trip that starts somewhere else just says so.
+ * removable like any other stop — a trip that starts or ends somewhere else just says so.
  */
 object HomeStop {
 
     const val DEFAULT_NAME = "Home"
 
-    /** Null when no home is set, which leaves a new plan starting wherever you add first. */
-    fun forNewPlan(tripId: String, settings: UserSettings, startDate: LocalDate): Stop? {
-        val location = settings.homeLocation ?: return null
-        return Stop(
+    fun name(settings: UserSettings): String = settings.homeName.ifBlank { DEFAULT_NAME }
+
+    /**
+     * The stops a new plan opens with: home to set out from, and home to come back to.
+     * Empty when no home is set, which leaves the plan starting wherever you add first.
+     */
+    fun forNewPlan(tripId: String, settings: UserSettings, startDate: LocalDate): List<Stop> {
+        val location = settings.homeLocation ?: return emptyList()
+        val home = Stop(
             tripId = tripId,
-            name = settings.homeName.ifBlank { DEFAULT_NAME },
+            name = name(settings),
             location = location,
             arrivalDate = startDate,
             nights = 0,
             orderIndex = 0,
             kind = StopKind.HOME,
         )
+        return listOf(home, home.copy(orderIndex = 1))
+    }
+
+    /** The home a plan sets out from: its first stop, when that is a home. */
+    fun departure(stops: List<Stop>): Stop? =
+        stops.minByOrNull { it.orderIndex }?.takeIf { it.kind == StopKind.HOME }
+
+    /**
+     * The drive home a plan still ends with: its last stop, when that is a home not yet
+     * reached with something in front of it. A lone home is where a plan starts, not
+     * where it ends, so stops added to that plan follow it.
+     */
+    fun returning(stops: List<Stop>): Stop? {
+        val last = stops.maxByOrNull { it.orderIndex } ?: return null
+        val ahead = stops.any { it.orderIndex < last.orderIndex }
+        return last.takeIf { it.kind == StopKind.HOME && it.state == StopState.PLANNED && ahead }
     }
 }

--- a/app/src/main/java/com/nuelto/etappli/domain/RouteCache.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/RouteCache.kt
@@ -30,8 +30,13 @@ object RouteCache {
         .filterNot { it.state == StopState.SKIPPED }
         .filter { it.location != null }
 
-    /** Consecutive drives of the trip, each as the stop it leaves and the one it reaches. */
-    fun drives(stops: List<Stop>): List<Pair<Stop, Stop>> = routed(stops).zipWithNext()
+    /**
+     * Consecutive drives of the trip, each as the stop it leaves and the one it reaches.
+     * Two stops at the same spot — a fresh plan that leaves home and comes straight back —
+     * are not a drive: nothing to route, draw or cost.
+     */
+    fun drives(stops: List<Stop>): List<Pair<Stop, Stop>> =
+        routed(stops).zipWithNext().filter { (from, to) -> from.location != to.location }
 
     /** The stored leg for the drive [previous] → [stop], if it still describes it. */
     fun usable(previous: Stop, stop: Stop): StopLeg? =

--- a/app/src/main/java/com/nuelto/etappli/domain/RouteRefresher.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/RouteRefresher.kt
@@ -40,13 +40,16 @@ class RouteRefresher(
             return Result(fetched = 0, cleared = cleared, elevated = elevated)
         }
 
-        val routed = RouteCache.routed(stops)
-        // Safe: routed() keeps only stops that have a location.
-        val legs = fetchAll(routed.map { it.location!! })
+        val drives = RouteCache.drives(stops)
+        // One point per drive plus the last arrival: a stop at the same spot as the one
+        // before it is skipped, so consecutive points are always distinct. Safe: drives()
+        // keeps only stops that have a location.
+        val points = drives.map { (from, _) -> from.location!! } + drives.last().second.location!!
+        val legs = fetchAll(points)
             ?: return Result(fetched = 0, cleared = cleared, elevated = elevated)
 
         var fetched = 0
-        routed.zipWithNext().forEachIndexed { index, (from, to) ->
+        drives.forEachIndexed { index, (from, to) ->
             val climb = climb(legs[index].polyline)
             val leg = StopLeg(
                 // The coordinates the route was actually computed between. A stop edited

--- a/app/src/main/java/com/nuelto/etappli/domain/TripStarter.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/TripStarter.kt
@@ -32,6 +32,9 @@ object TripStarter {
         val stops = repository.stops(tripId).first()
         val expenses = repository.expenses(tripId).first()
         val shift = ChronoUnit.DAYS.between(trip.startDate, startDate)
+        // A tour starts by leaving home, so the home it sets out from is already reached:
+        // the first night's stop is what you are heading for, not your own front door.
+        val departed = HomeStop.departure(stops)?.id
         val started = trip.copy(
             status = TripStatus.ACTIVE,
             startDate = startDate,
@@ -42,10 +45,12 @@ object TripStarter {
 
         if (!keepPlanAsTemplate) {
             repository.upsertTrip(started)
-            if (shift != 0L) {
-                stops.forEach {
-                    repository.upsertStop(it.copy(arrivalDate = it.arrivalDate.plusDays(shift)))
-                }
+            stops.forEach {
+                val moved = it.copy(
+                    arrivalDate = it.arrivalDate.plusDays(shift),
+                    state = if (it.id == departed) StopState.DONE else it.state,
+                )
+                if (moved != it) repository.upsertStop(moved)
             }
             return tripId
         }
@@ -58,7 +63,7 @@ object TripStarter {
                 it.copy(
                     id = "",
                     tripId = newId,
-                    state = StopState.PLANNED,
+                    state = if (it.id == departed) StopState.DONE else StopState.PLANNED,
                     arrivalDate = it.arrivalDate.plusDays(shift),
                 ),
             )

--- a/app/src/main/java/com/nuelto/etappli/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/settings/SettingsScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewModelScope
 import com.nuelto.etappli.BuildConfig
@@ -40,17 +41,21 @@ import com.nuelto.etappli.containerViewModelFactory
 import com.nuelto.etappli.data.AuthRepository
 import com.nuelto.etappli.data.SettingsRepository
 import com.nuelto.etappli.data.model.UserSettings
+import com.nuelto.etappli.location.PlaceNameResolver
 import com.nuelto.etappli.ui.components.DecimalField
 import com.nuelto.etappli.ui.components.parseDecimal
 import com.nuelto.etappli.ui.map.LocalMapProvider
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 class SettingsViewModel(
     private val settingsRepository: SettingsRepository,
     val authRepository: AuthRepository?,
+    // Names a GPS fix or a dropped pin after the nearest village; null when nothing can.
+    private val placeName: suspend (LatLng) -> String? = { null },
 ) : ViewModel() {
 
     val settings: StateFlow<UserSettings?> =
@@ -61,16 +66,23 @@ class SettingsViewModel(
         viewModelScope.launch { settingsRepository.update(settings) }
     }
 
-    /** Sets home from the picker or a GPS fix; an unnamed pick keeps the name it had. */
+    /**
+     * Sets home from the picker or a GPS fix. An unnamed pick keeps the name it had, or
+     * takes the nearest village's: a fix or a pin has no name of its own, and a home
+     * with none looks exactly like no home at all.
+     */
     fun setHome(location: LatLng, name: String = "") {
         val current = settings.value ?: return
+        val home = current.copy(homeLocation = location, homeName = name.ifBlank { current.homeName })
         viewModelScope.launch {
-            settingsRepository.update(
-                current.copy(
-                    homeLocation = location,
-                    homeName = name.ifBlank { current.homeName },
-                ),
-            )
+            settingsRepository.update(home)
+            if (home.homeName.isNotBlank()) return@launch
+            val place = placeName(location) ?: return@launch
+            // A name typed meanwhile, or a pin moved since, beats a late answer.
+            val latest = settingsRepository.settings().first()
+            if (latest.homeLocation == location && latest.homeName.isBlank()) {
+                settingsRepository.update(latest.copy(homeName = place))
+            }
         }
     }
 
@@ -87,7 +99,8 @@ class SettingsViewModel(
 
     companion object {
         val Factory = containerViewModelFactory { container ->
-            SettingsViewModel(container.settingsRepository, container.authRepository)
+            val resolver = this[APPLICATION_KEY]?.let(::PlaceNameResolver)
+            SettingsViewModel(container.settingsRepository, container.authRepository) { resolver?.placeName(it) }
         }
     }
 }
@@ -142,8 +155,8 @@ fun SettingsScreen(
                 modifier = Modifier.fillMaxWidth(),
             )
             Text(
-                current.homeLocation?.let { "Set — new plans start here." }
-                    ?: "Not set. Pick it below and new plans will start from it.",
+                current.homeLocation?.let { "Set — new plans start and end here." }
+                    ?: "Not set. Pick it below and new plans will start and end there.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreen.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreen.kt
@@ -113,6 +113,7 @@ import com.nuelto.etappli.data.model.UserSettings
 import com.nuelto.etappli.domain.TripMapData
 import com.nuelto.etappli.domain.Elevation
 import com.nuelto.etappli.domain.GapRow
+import com.nuelto.etappli.domain.HomeStop
 import com.nuelto.etappli.domain.StopRow
 import com.nuelto.etappli.domain.TripEstimator
 import com.nuelto.etappli.ui.components.DecimalField
@@ -167,6 +168,8 @@ fun TripDetailScreen(
     val listState = rememberLazyListState()
     // Draggable set: rows hanging off a planned stop of a live trip. Done and skipped
     // rows — and the current stop, which is simply where you are — are anchors.
+    // The home the plan sets out from reads as its start; any other home is the way back.
+    val departureId = HomeStop.departure(state.stops)?.id
     val movableKeys = state.rows
         .filter {
             trip?.status != TripStatus.DONE &&
@@ -447,6 +450,7 @@ fun TripDetailScreen(
                             leg = state.drives[row.stop.id],
                             tripStatus = trip.status,
                             settings = state.settings,
+                            departure = row.stop.id == departureId,
                             movable = movable,
                             onClick = { onEditStop(trip.id, row.stop.id) },
                             onSkip = { skipWithUndo(row.stop) },
@@ -797,6 +801,7 @@ private fun TimelineStopRow(
     leg: StopLeg?,
     tripStatus: TripStatus,
     settings: UserSettings,
+    departure: Boolean,
     movable: Boolean,
     onClick: () -> Unit,
     onSkip: () -> Unit,
@@ -827,7 +832,7 @@ private fun TimelineStopRow(
                     ElevationBadge(stop)
                 }
                 Text(
-                    stopMetaText(stop, tripStatus, settings),
+                    stopMetaText(stop, departure, tripStatus, settings),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -917,11 +922,11 @@ private fun ElevationBadge(stop: Stop) {
     }
 }
 
-private fun stopMetaText(stop: Stop, tripStatus: TripStatus, settings: UserSettings): String {
+private fun stopMetaText(stop: Stop, departure: Boolean, tripStatus: TripStatus, settings: UserSettings): String {
     val date = formatDate(stop.arrivalDate)
     return when {
         stop.state == StopState.SKIPPED -> "skipped"
-        stop.kind == StopKind.HOME -> "$date · start"
+        stop.kind == StopKind.HOME -> "$date · ${if (departure) "start" else "home again"}"
         stop.kind == StopKind.VISIT -> "$date · visit"
         else -> {
             val nights = if (stop.nights == 1) "1 night" else "${stop.nights} nights"

--- a/app/src/main/java/com/nuelto/etappli/ui/tripedit/StopEditScreen.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/tripedit/StopEditScreen.kt
@@ -87,13 +87,16 @@ fun StopEditScreen(
                 modifier = Modifier.horizontalScroll(rememberScrollState()),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                StopKind.entries.filter { it != StopKind.HOME || state.kind == StopKind.HOME }.forEach { kind ->
-                    FilterChip(
-                        selected = state.kind == kind,
-                        onClick = { viewModel.setKind(kind) },
-                        label = { Text(kind.displayName) },
-                    )
-                }
+                // Home is offered once there is one to put a stop at.
+                StopKind.entries
+                    .filter { it != StopKind.HOME || state.kind == StopKind.HOME || state.settings.homeLocation != null }
+                    .forEach { kind ->
+                        FilterChip(
+                            selected = state.kind == kind,
+                            onClick = { viewModel.setKind(kind) },
+                            label = { Text(kind.displayName) },
+                        )
+                    }
             }
             if (state.isNew) {
                 // The place you pick names the stop — nothing to type. Blank until then.

--- a/app/src/main/java/com/nuelto/etappli/ui/tripedit/StopEditViewModel.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/tripedit/StopEditViewModel.kt
@@ -17,6 +17,7 @@ import com.nuelto.etappli.data.model.StopState
 import com.nuelto.etappli.data.model.TripStatus
 import com.nuelto.etappli.data.model.UserSettings
 import com.nuelto.etappli.domain.DateCascade
+import com.nuelto.etappli.domain.HomeStop
 import com.nuelto.etappli.domain.MapsUri
 import com.nuelto.etappli.domain.Timeline
 import com.nuelto.etappli.domain.nearestLocated
@@ -104,8 +105,10 @@ class StopEditViewModel(
                 // where the whole trip is "before" it.
                 val at = route.insertBefore?.let { Timeline.insertion(Timeline.rows(stops), it) }
                 insertAt = at?.orderIndex
+                // A plan ends with the drive home, so "the end" is in front of that.
+                val home = HomeStop.returning(stops)
                 _uiState.update {
-                    it.copy(nearbyLocation = nearestLocated(stops, at?.orderIndex ?: Int.MAX_VALUE))
+                    it.copy(nearbyLocation = nearestLocated(stops, at?.orderIndex ?: home?.orderIndex ?: Int.MAX_VALUE))
                 }
                 if (at != null) {
                     // The slot says which day this starts on; no GPS fix improves on that.
@@ -118,7 +121,7 @@ class StopEditViewModel(
                     // Planning ahead or back-filling a finished trip: no GPS fix
                     // (your couch is not the campsite), arrival chains from the last stop.
                     val last = stops
-                        .filterNot { it.state == StopState.SKIPPED }
+                        .filterNot { it.state == StopState.SKIPPED || it.id == home?.id }
                         .maxByOrNull { it.orderIndex }
                     val arrival = last?.arrivalDate?.plusDays(last.nights.toLong()) ?: trip.startDate
                     _uiState.update { it.copy(arrivalDate = arrival) }
@@ -169,11 +172,18 @@ class StopEditViewModel(
     fun setCampingCost(value: String) = _uiState.update { it.copy(campingCost = value) }
     fun setNotes(value: String) = _uiState.update { it.copy(notes = value) }
 
-    fun setKind(value: StopKind) = _uiState.update {
-        when {
-            !value.isStay -> it.copy(kind = value, nights = 0, campingCost = "")
-            !it.isStay -> it.copy(kind = value, nights = 1)
-            else -> it.copy(kind = value)
+    fun setKind(value: StopKind) {
+        // Home is a place you already have: choosing the kind puts the stop there.
+        if (value == StopKind.HOME) {
+            val settings = _uiState.value.settings
+            settings.homeLocation?.let { setPickedLocation(it, HomeStop.name(settings), "", fromPlaces = false) }
+        }
+        _uiState.update {
+            when {
+                !value.isStay -> it.copy(kind = value, nights = 0, campingCost = "")
+                !it.isStay -> it.copy(kind = value, nights = 1)
+                else -> it.copy(kind = value)
+            }
         }
     }
 
@@ -302,21 +312,20 @@ class StopEditViewModel(
     }
 
     /**
-     * New stops append — except when one is inserted in front of a row, and mid-trip
-     * with check-ins, where a spontaneous stop slots in right after the last done stop.
-     * Either way the stops from there on move down one.
+     * New stops append — except when one is inserted in front of a row; mid-trip with
+     * check-ins, where a spontaneous stop slots in right after the last done stop; and
+     * on a plan that ends with the drive home, which a stop added to the end goes in
+     * front of, pushing it back like any insertion. Either way the stops from there on
+     * move down one.
      */
     private suspend fun newOrderIndex(): Int {
         val stops = tripRepository.stops(route.tripId).first()
-        insertAt?.let { at ->
-            shoveDown(stops, at)
-            return at
-        }
         val lastDone = stops.filter { it.state == StopState.DONE }.maxOfOrNull { it.orderIndex }
-        if (tripStatus != TripStatus.ACTIVE || lastDone == null) {
-            return (stops.maxOfOrNull { it.orderIndex } ?: -1) + 1
-        }
-        val at = lastDone + 1
+        val at = when {
+            insertAt != null -> insertAt
+            tripStatus == TripStatus.ACTIVE && lastDone != null -> lastDone + 1
+            else -> HomeStop.returning(stops)?.orderIndex?.also { insertAt = it }
+        } ?: return (stops.maxOfOrNull { it.orderIndex } ?: -1) + 1
         shoveDown(stops, at)
         return at
     }

--- a/app/src/main/java/com/nuelto/etappli/ui/tripedit/TripEditViewModel.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/tripedit/TripEditViewModel.kt
@@ -100,11 +100,11 @@ class TripEditViewModel(
                         status = status,
                     ),
                 )
-                // A fresh plan starts at home, when there is one to start from.
+                // A fresh plan sets out from home and comes back to it, when there is one.
                 if (state.isNew && status == TripStatus.PLANNED) {
-                    val settings = settingsRepository?.settings()?.first()
-                    settings?.let { HomeStop.forNewPlan(savedId, it, state.startDate) }
-                        ?.let { tripRepository.upsertStop(it) }
+                    settingsRepository?.settings()?.first()
+                        ?.let { HomeStop.forNewPlan(savedId, it, state.startDate) }
+                        ?.forEach { tripRepository.upsertStop(it) }
                 }
                 // Moving a plan's start moves its whole itinerary along.
                 if (base.status == TripStatus.PLANNED) {

--- a/app/src/test/java/com/nuelto/etappli/domain/HomeStopTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/HomeStopTest.kt
@@ -1,59 +1,92 @@
 package com.nuelto.etappli.domain
 
 import com.nuelto.etappli.data.model.LatLng
+import com.nuelto.etappli.data.model.Stop
 import com.nuelto.etappli.data.model.StopKind
+import com.nuelto.etappli.data.model.StopState
 import com.nuelto.etappli.data.model.UserSettings
 import com.nuelto.etappli.data.model.isStay
 import java.time.LocalDate
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class HomeStopTest {
 
     private val start = LocalDate.of(2027, 6, 10)
     private val home = LatLng(47.0502, 8.3093)
+    private val settings = UserSettings(homeName = "Luzern", homeLocation = home)
 
     @Test
     fun `no home set means a plan starts wherever you add first`() {
-        assertNull(HomeStop.forNewPlan("t1", UserSettings(), start))
+        assertTrue(HomeStop.forNewPlan("t1", UserSettings(), start).isEmpty())
         // A name on its own is not somewhere to start from.
-        assertNull(HomeStop.forNewPlan("t1", UserSettings(homeName = "Luzern"), start))
+        assertTrue(HomeStop.forNewPlan("t1", UserSettings(homeName = "Luzern"), start).isEmpty())
     }
 
     @Test
-    fun `the home stop is the plan's first row, on its start date`() {
-        val stop = HomeStop.forNewPlan(
-            "t1",
-            UserSettings(homeName = "Luzern", homeLocation = home),
-            start,
-        )!!
-        assertEquals("t1", stop.tripId)
-        assertEquals("Luzern", stop.name)
-        assertEquals(home, stop.location)
-        assertEquals(start, stop.arrivalDate)
-        assertEquals(0, stop.orderIndex)
-        assertEquals(StopKind.HOME, stop.kind)
+    fun `a new plan sets out from home and comes back to it`() {
+        val stops = HomeStop.forNewPlan("t1", settings, start)
+        assertEquals(listOf(0, 1), stops.map { it.orderIndex })
+        stops.forEach { stop ->
+            assertEquals("t1", stop.tripId)
+            assertEquals("Luzern", stop.name)
+            assertEquals(home, stop.location)
+            assertEquals(start, stop.arrivalDate)
+            assertEquals(StopKind.HOME, stop.kind)
+        }
     }
 
     @Test
     fun `home is somewhere you leave, not somewhere you stay`() {
-        val stop = HomeStop.forNewPlan("t1", UserSettings(homeLocation = home), start)!!
-        assertEquals(0, stop.nights)
-        assertEquals(0.0, stop.campingCostTotal, 1e-9)
-        assertFalse(stop.kind.isStay)
+        HomeStop.forNewPlan("t1", settings, start).forEach { stop ->
+            assertEquals(0, stop.nights)
+            assertEquals(0.0, stop.campingCostTotal, 1e-9)
+            assertFalse(stop.kind.isStay)
+        }
     }
 
     @Test
     fun `an unnamed home is called Home`() {
-        val stop = HomeStop.forNewPlan("t1", UserSettings(homeLocation = home), start)!!
-        assertEquals(HomeStop.DEFAULT_NAME, stop.name)
         assertEquals("Home", HomeStop.DEFAULT_NAME)
+        assertEquals("Home", HomeStop.name(UserSettings()))
         // Blank is not a name either.
+        assertEquals("Home", HomeStop.name(UserSettings(homeName = "  ")))
+        assertEquals("Luzern", HomeStop.name(settings))
         assertEquals(
-            "Home",
-            HomeStop.forNewPlan("t1", UserSettings(homeName = "  ", homeLocation = home), start)!!.name,
+            listOf("Home", "Home"),
+            HomeStop.forNewPlan("t1", UserSettings(homeLocation = home), start).map { it.name },
         )
+    }
+
+    private val out = Stop(id = "out", kind = StopKind.HOME, orderIndex = 0)
+    private val a = Stop(id = "a", orderIndex = 1)
+    private val back = Stop(id = "back", kind = StopKind.HOME, orderIndex = 2)
+
+    @Test
+    fun `the first stop is the departure, but only when it is a home`() {
+        assertNull(HomeStop.departure(emptyList()))
+        // By order, not by list position.
+        assertEquals("out", HomeStop.departure(listOf(a, out))!!.id)
+        assertNull(HomeStop.departure(listOf(a, out.copy(orderIndex = 5))))
+        assertNull(HomeStop.departure(listOf(a)))
+    }
+
+    @Test
+    fun `the last stop is the drive home while it is a planned home with something in front`() {
+        assertNull(HomeStop.returning(emptyList()))
+        assertEquals("back", HomeStop.returning(listOf(back, out, a))!!.id)
+        // Start home deleted: the plan still ends with the drive home.
+        assertEquals("back", HomeStop.returning(listOf(a, back))!!.id)
+        // A fresh plan: nothing between leaving and coming back yet.
+        assertEquals("back", HomeStop.returning(listOf(out, back.copy(orderIndex = 1)))!!.id)
+        // A lone home is where the plan starts, so stops added to it follow it.
+        assertNull(HomeStop.returning(listOf(out)))
+        // Ends somewhere else.
+        assertNull(HomeStop.returning(listOf(out, a)))
+        // Already home.
+        assertNull(HomeStop.returning(listOf(out, a, back.copy(state = StopState.DONE))))
     }
 }

--- a/app/src/test/java/com/nuelto/etappli/domain/RouteCacheTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/RouteCacheTest.kt
@@ -51,6 +51,20 @@ class RouteCacheTest {
     }
 
     @Test
+    fun `two stops at the same spot are not a drive`() {
+        // A fresh plan: leaving home and coming straight back, with nothing between yet.
+        assertTrue(RouteCache.drives(listOf(stop("out", 0, c), stop("back", 1, c))).isEmpty())
+        // With a stop between, both drives are real; a repeat of the same spot still is
+        // not, and the next drive leaves from the later of the two.
+        assertEquals(
+            listOf("out" to "s1", "twin" to "back"),
+            RouteCache.drives(listOf(stop("out", 0, c), stop("s1", 1, a), stop("twin", 2, a), stop("back", 3, c)))
+                .map { (from, to) -> from.id to to.id },
+        )
+        assertFalse(RouteCache.needsFetch(listOf(stop("out", 0, c), stop("back", 1, c)), today))
+    }
+
+    @Test
     fun `fewer than two routable stops is no drive at all`() {
         assertTrue(RouteCache.drives(emptyList()).isEmpty())
         assertTrue(RouteCache.drives(listOf(stop("only", 0, a))).isEmpty())

--- a/app/src/test/java/com/nuelto/etappli/domain/RouteRefresherTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/RouteRefresherTest.kt
@@ -249,6 +249,29 @@ class RouteRefresherTest {
     }
 
     @Test
+    fun `a stop at the same spot as the one before is left out of the chain`() = runTest {
+        addStop("out", here, index = 0)
+        addStop("back", here, index = 1)
+        // Leaving home and coming straight back is not a drive: nothing is asked for.
+        assertFalse(refresher { listOf(RoutedLeg(geometry, 1, 1)) }.refresh("t1", today).touched)
+        assertTrue(windows.isEmpty())
+
+        addStop("twin", here, index = 1)
+        addStop("far", there, index = 2)
+        addStop("back", here, index = 3)
+        val result = refresher { window -> window.zipWithNext().map { RoutedLeg(geometry, 42_000, 3_600) } }
+            .refresh("t1", today)
+
+        // One request over the distinct points; the leg lands on the stops that are driven to.
+        assertEquals(listOf(listOf(here, there, here)), windows)
+        assertEquals(2, result.fetched)
+        assertNull(stop("twin").leg)
+        assertEquals(here, stop("far").leg!!.from)
+        assertEquals(there, stop("back").leg!!.from)
+        assertEquals(here, stop("back").leg!!.to)
+    }
+
+    @Test
     fun `a trip with nothing to drive between is never routed`() = runTest {
         addStop("lonely", here, index = 0)
 

--- a/app/src/test/java/com/nuelto/etappli/domain/TripStarterTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/TripStarterTest.kt
@@ -170,4 +170,30 @@ class TripStarterTest {
         assertNull(copied.stopId)
         assertEquals(2, repo.expenses(doneId).first().size)
     }
+
+    @Test
+    fun `starting a tour checks in at the home it sets out from`() = runTest {
+        val planId = repo.upsertTrip(Trip(id = "loop", name = "Loop", startDate = planStart, status = TripStatus.PLANNED))
+        repo.upsertStop(
+            Stop(id = "out", tripId = planId, name = "Home", kind = StopKind.HOME, nights = 0, orderIndex = 0, arrivalDate = planStart),
+        )
+        repo.upsertStop(Stop(id = "s1", tripId = planId, name = "Luzern", nights = 2, orderIndex = 1, arrivalDate = planStart))
+        repo.upsertStop(
+            Stop(
+                id = "back", tripId = planId, name = "Home", kind = StopKind.HOME, nights = 0, orderIndex = 2,
+                arrivalDate = planStart.plusDays(2),
+            ),
+        )
+
+        val newId = TripStarter.start(repo, planId, planStart, keepPlanAsTemplate = true, settings = settings)
+        val copied = repo.stops(newId).first().sortedBy { it.orderIndex }
+        assertEquals(listOf(StopState.DONE, StopState.PLANNED, StopState.PLANNED), copied.map { it.state })
+        // The template is untouched.
+        assertTrue(repo.stops(planId).first().all { it.state == StopState.PLANNED })
+
+        TripStarter.start(repo, planId, planStart, keepPlanAsTemplate = false, settings = settings)
+        val converted = repo.stops(planId).first().sortedBy { it.orderIndex }
+        assertEquals(listOf(StopState.DONE, StopState.PLANNED, StopState.PLANNED), converted.map { it.state })
+        assertEquals(listOf(planStart, planStart, planStart.plusDays(2)), converted.map { it.arrivalDate })
+    }
 }

--- a/app/src/test/java/com/nuelto/etappli/ui/nav/AppNavHostTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/nav/AppNavHostTest.kt
@@ -179,7 +179,7 @@ class AppNavHostTest {
         compose.onNodeWithText("Use this place").performClick()
 
         // Back in Settings, with somewhere for new plans to start from.
-        compose.onNodeWithText("Set — new plans start here.").performScrollTo().assertIsDisplayed()
+        compose.onNodeWithText("Set — new plans start and end here.").performScrollTo().assertIsDisplayed()
     }
 
     @Test
@@ -188,7 +188,7 @@ class AppNavHostTest {
         compose.onNodeWithContentDescription("Settings").performClick()
         compose.onNodeWithText("  Pick on map").performScrollTo().performClick()
         compose.onNodeWithContentDescription("Cancel").performClick()
-        compose.onNodeWithText("Not set. Pick it below and new plans will start from it.")
+        compose.onNodeWithText("Not set. Pick it below and new plans will start and end there.")
             .performScrollTo().assertIsDisplayed()
     }
 

--- a/app/src/test/java/com/nuelto/etappli/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/settings/SettingsScreenTest.kt
@@ -171,7 +171,7 @@ class SettingsScreenTest {
     fun `home says whether it is set, and takes a name`() {
         setContent()
         compose.onNodeWithText("Home").performScrollTo().assertIsDisplayed()
-        compose.onNodeWithText("Not set. Pick it below and new plans will start from it.")
+        compose.onNodeWithText("Not set. Pick it below and new plans will start and end there.")
             .performScrollTo().assertIsDisplayed()
         compose.onNodeWithText("Clear home").assertDoesNotExist()
 
@@ -180,7 +180,7 @@ class SettingsScreenTest {
                 settingsRepository.settings().first().copy(homeLocation = LatLng(47.05, 8.31)),
             )
         }
-        compose.onNodeWithText("Set — new plans start here.").performScrollTo().assertIsDisplayed()
+        compose.onNodeWithText("Set — new plans start and end here.").performScrollTo().assertIsDisplayed()
         compose.onNodeWithText("Clear home").performScrollTo().performClick()
         runBlocking {
             assertNull(settingsRepository.settings().first().homeLocation)

--- a/app/src/test/java/com/nuelto/etappli/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/settings/SettingsViewModelTest.kt
@@ -3,6 +3,7 @@ package com.nuelto.etappli.ui.settings
 import app.cash.turbine.test
 import com.nuelto.etappli.data.InMemorySettingsRepository
 import com.nuelto.etappli.data.model.LatLng
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.first
 import com.nuelto.etappli.data.model.UserSettings
 import com.nuelto.etappli.testutil.FakeAuthRepository
@@ -69,8 +70,9 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `a named pick renames home`() = runTest {
-        val vm = SettingsViewModel(settingsRepository, null)
+    fun `a named pick renames home, and asks nobody else`() = runTest {
+        var asked = 0
+        val vm = SettingsViewModel(settingsRepository, null) { asked++; "Bern" }
         vm.settings.test {
             awaitItem()
             vm.setHome(LatLng(47.05, 8.31), "Camping Lido")
@@ -78,6 +80,75 @@ class SettingsViewModelTest {
             assertEquals("Camping Lido", stored.homeName)
             cancelAndIgnoreRemainingEvents()
         }
+        assertEquals(0, asked)
+    }
+
+    @Test
+    fun `an unnamed home takes the name of the nearest place`() = runTest {
+        val vm = SettingsViewModel(settingsRepository, null) { "Bern" }
+        vm.settings.test {
+            awaitItem()
+            vm.setHome(LatLng(46.95, 7.45))
+            cancelAndIgnoreRemainingEvents()
+        }
+        val stored = settingsRepository.settings().first()
+        assertEquals(LatLng(46.95, 7.45), stored.homeLocation)
+        assertEquals("Bern", stored.homeName)
+    }
+
+    @Test
+    fun `without a geocoder an unnamed home stays unnamed`() = runTest {
+        val vm = SettingsViewModel(settingsRepository, null)
+        vm.settings.test {
+            awaitItem()
+            vm.setHome(LatLng(46.95, 7.45))
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals("", settingsRepository.settings().first().homeName)
+    }
+
+    @Test
+    fun `a late name never overwrites one typed meanwhile`() = runTest {
+        val gate = CompletableDeferred<String?>()
+        val vm = SettingsViewModel(settingsRepository, null) { gate.await() }
+        vm.settings.test {
+            awaitItem()
+            vm.setHome(LatLng(46.95, 7.45))
+            awaitItem()
+            vm.update(settingsRepository.settings().first().copy(homeName = "Daheim"))
+            awaitItem()
+            gate.complete("Bern")
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+        assertEquals("Daheim", settingsRepository.settings().first().homeName)
+    }
+
+    @Test
+    fun `a late name for a pin that has since moved is dropped`() = runTest {
+        val gate = CompletableDeferred<String?>()
+        var first = true
+        val vm = SettingsViewModel(settingsRepository, null) {
+            if (first) {
+                first = false
+                gate.await()
+            } else {
+                null
+            }
+        }
+        vm.settings.test {
+            awaitItem()
+            vm.setHome(LatLng(46.95, 7.45))
+            awaitItem()
+            vm.setHome(LatLng(47.05, 8.31))
+            awaitItem()
+            gate.complete("Bern")
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+        val stored = settingsRepository.settings().first()
+        assertEquals(LatLng(47.05, 8.31), stored.homeLocation)
+        assertEquals("", stored.homeName)
     }
 
     @Test

--- a/app/src/test/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreenTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreenTest.kt
@@ -922,4 +922,30 @@ class TripDetailScreenTest {
         ).assertIsDisplayed()
     }
 
+
+    @Test
+    fun `the home at the end of a plan reads as the way back`() {
+        val start = LocalDate.of(2027, 6, 10)
+        runBlocking {
+            tripRepository.upsertTrip(Trip(id = "h2", name = "Loop", startDate = start, status = TripStatus.PLANNED))
+            tripRepository.upsertStop(
+                Stop(
+                    id = "out", tripId = "h2", name = "Luzern", orderIndex = 0, nights = 0,
+                    kind = StopKind.HOME, location = LatLng(47.05, 8.31), arrivalDate = start,
+                ),
+            )
+            tripRepository.upsertStop(Stop(id = "s", tripId = "h2", name = "Locarno", orderIndex = 1, nights = 2, arrivalDate = start))
+            tripRepository.upsertStop(
+                Stop(
+                    id = "back", tripId = "h2", name = "Luzern", orderIndex = 2, nights = 0,
+                    kind = StopKind.HOME, location = LatLng(47.05, 8.31), arrivalDate = start.plusDays(2),
+                ),
+            )
+        }
+        setContent("h2")
+        val back = "${formatDate(start.plusDays(2))} · home again"
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText(back))
+        compose.onNodeWithText(back, useUnmergedTree = true).assertIsDisplayed()
+        compose.onNodeWithText("${formatDate(start)} · start", useUnmergedTree = true).assertExists()
+    }
 }

--- a/app/src/test/java/com/nuelto/etappli/ui/tripedit/StopEditScreenTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/tripedit/StopEditScreenTest.kt
@@ -3,6 +3,8 @@ package com.nuelto.etappli.ui.tripedit
 import androidx.compose.material3.Text
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -18,6 +20,7 @@ import com.nuelto.etappli.data.model.Stop
 import com.nuelto.etappli.data.model.StopKind
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
+import com.nuelto.etappli.data.model.UserSettings
 import com.nuelto.etappli.testutil.TestCamperApp
 import java.time.LocalDate
 import kotlinx.coroutines.flow.first
@@ -41,9 +44,13 @@ class StopEditScreenTest {
 
     private lateinit var viewModel: StopEditViewModel
 
-    private fun setContent(stopId: String? = null, withLocationSection: Boolean = false) {
+    private fun setContent(
+        stopId: String? = null,
+        withLocationSection: Boolean = false,
+        settingsRepository: InMemorySettingsRepository = InMemorySettingsRepository(),
+    ) {
         val args = if (stopId == null) mapOf("tripId" to "t1") else mapOf("tripId" to "t1", "stopId" to stopId)
-        viewModel = StopEditViewModel(SavedStateHandle(args), tripRepository, InMemorySettingsRepository(), null)
+        viewModel = StopEditViewModel(SavedStateHandle(args), tripRepository, settingsRepository, null)
         compose.setContent {
             if (withLocationSection) {
                 StopEditScreen(
@@ -149,5 +156,28 @@ class StopEditScreenTest {
         }
         setContent()
         compose.onNodeWithText("≈ CHF45.00/night if left blank").assertIsDisplayed()
+    }
+
+    @Test
+    fun `the home chip is offered once a home is set, and puts the stop there`() {
+        setContent()
+        compose.onNodeWithText("Home").assertDoesNotExist()
+    }
+
+    @Test
+    fun `with a home set the home chip puts the stop there`() {
+        val settings = InMemorySettingsRepository()
+        runBlocking { settings.update(UserSettings(homeName = "Luzern", homeLocation = LatLng(47.05, 8.31))) }
+        setContent(settingsRepository = settings)
+        compose.onNodeWithText("Home").performClick()
+        compose.onAllNodesWithText("Luzern").onFirst().assertIsDisplayed()
+        compose.onNodeWithText("Nights").assertDoesNotExist()
+        compose.onNodeWithText("Save").performClick()
+        runBlocking {
+            val stop = tripRepository.stops("t1").first().single()
+            assertEquals(StopKind.HOME, stop.kind)
+            assertEquals("Luzern", stop.name)
+            assertEquals(LatLng(47.05, 8.31), stop.location)
+        }
     }
 }

--- a/app/src/test/java/com/nuelto/etappli/ui/tripedit/StopEditViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/tripedit/StopEditViewModelTest.kt
@@ -11,6 +11,7 @@ import com.nuelto.etappli.data.model.StopKind
 import com.nuelto.etappli.data.model.StopState
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
+import com.nuelto.etappli.data.model.UserSettings
 import com.nuelto.etappli.testutil.FakePlaceNameResolver
 import com.nuelto.etappli.testutil.MainDispatcherRule
 import java.time.LocalDate
@@ -646,5 +647,116 @@ class StopEditViewModelTest {
         assertEquals("ChIJCyinolJ-hUcR", state.placeId)
         assertNull(state.location)
         assertNull(state.locationCachedAt)
+    }
+
+    // --- the drive home ------------------------------------------------------------------
+
+    private val homeAt = LatLng(47.05, 8.31)
+
+    /** A fresh plan: home to leave from, home to come back to, nothing between yet. */
+    private suspend fun planEndingAtHome(): LocalDate {
+        val start = LocalDate.of(2027, 6, 10)
+        tripRepository.upsertTrip(Trip(id = "t1", name = "Plan", startDate = start, status = TripStatus.PLANNED))
+        tripRepository.upsertStop(homeStop("out", 0, start))
+        tripRepository.upsertStop(homeStop("back", 1, start))
+        return start
+    }
+
+    private fun homeStop(id: String, orderIndex: Int, arrival: LocalDate, state: StopState = StopState.PLANNED) = Stop(
+        id = id, tripId = "t1", name = "Home", kind = StopKind.HOME, nights = 0,
+        orderIndex = orderIndex, arrivalDate = arrival, location = homeAt, state = state,
+    )
+
+    private suspend fun names() = tripRepository.stops("t1").first().sortedBy { it.orderIndex }.map { it.name }
+
+    @Test
+    fun `a stop added to the end of a plan goes in front of the drive home`() = runTest {
+        val start = planEndingAtHome()
+        val vm = newStopViewModel()
+        // Arrival chains from the last stop before the drive home — here, leaving home.
+        assertEquals(start, vm.uiState.value.arrivalDate)
+        vm.setName("Aire")
+        vm.setNights(2)
+        vm.save {}
+        val stops = tripRepository.stops("t1").first().sortedBy { it.orderIndex }
+        assertEquals(listOf("Home", "Aire", "Home"), stops.map { it.name })
+        assertEquals(listOf(0, 1, 2), stops.map { it.orderIndex })
+        // The stay pushes the drive home back by the nights it takes.
+        assertEquals(start, stops[1].arrivalDate)
+        assertEquals(start.plusDays(2), stops.last().arrivalDate)
+    }
+
+    @Test
+    fun `the next stop after a stay still lands before the drive home`() = runTest {
+        val start = planEndingAtHome()
+        tripRepository.upsertStop(
+            Stop(id = "a", tripId = "t1", name = "A", orderIndex = 1, nights = 2, arrivalDate = start, location = LatLng(46.32, 7.99)),
+        )
+        tripRepository.upsertStop(homeStop("back", 2, start.plusDays(2)))
+        val vm = newStopViewModel()
+        assertEquals(start.plusDays(2), vm.uiState.value.arrivalDate)
+        // The picker opens near the last stop before home, not at home.
+        assertEquals(LatLng(46.32, 7.99), vm.uiState.value.pickerStart)
+        vm.setName("B")
+        vm.save {}
+        assertEquals(listOf("Home", "A", "B", "Home"), names())
+        assertEquals(start.plusDays(3), tripRepository.stops("t1").first().single { it.id == "back" }.arrivalDate)
+    }
+
+    @Test
+    fun `a lone home is where a plan starts, so new stops follow it`() = runTest {
+        val start = LocalDate.of(2027, 6, 10)
+        tripRepository.upsertTrip(Trip(id = "t1", name = "Plan", startDate = start, status = TripStatus.PLANNED))
+        tripRepository.upsertStop(homeStop("out", 0, start))
+        val vm = newStopViewModel()
+        assertEquals(homeAt, vm.uiState.value.pickerStart)
+        vm.setName("A")
+        vm.save {}
+        assertEquals(listOf("Home", "A"), names())
+    }
+
+    @Test
+    fun `mid-trip a spontaneous stop slots in after the last check-in, not at the drive home`() = runTest {
+        val start = LocalDate.of(2026, 8, 20)
+        tripRepository.upsertTrip(Trip(id = "t1", name = "Trip", startDate = start, status = TripStatus.ACTIVE))
+        tripRepository.upsertStop(homeStop("out", 0, start, StopState.DONE))
+        tripRepository.upsertStop(Stop(id = "a", tripId = "t1", name = "A", orderIndex = 1, state = StopState.DONE))
+        tripRepository.upsertStop(Stop(id = "b", tripId = "t1", name = "B", orderIndex = 2))
+        tripRepository.upsertStop(homeStop("back", 3, start.plusDays(3)))
+        val vm = newStopViewModel()
+        vm.setName("Spontan")
+        vm.save {}
+        assertEquals(listOf("Home", "A", "Spontan", "B", "Home"), names())
+    }
+
+    @Test
+    fun `the home chip puts the stop at home`() = runTest {
+        settingsRepository.update(UserSettings(homeName = "Luzern", homeLocation = homeAt))
+        val vm = newStopViewModel()
+        vm.setKind(StopKind.HOME)
+        val state = vm.uiState.value
+        assertEquals(StopKind.HOME, state.kind)
+        assertEquals(homeAt, state.location)
+        assertEquals("Luzern", state.name)
+        assertEquals("Luzern", state.locationLabel)
+        assertEquals(0, state.nights)
+        // Home is yours, not Google's: no place id, no clock, no reverse geocode over its name.
+        assertNull(state.placeId)
+        assertNull(state.locationCachedAt)
+        assertTrue(resolver.requests.isEmpty())
+
+        settingsRepository.update(UserSettings(homeLocation = homeAt))
+        val unnamed = newStopViewModel()
+        unnamed.setKind(StopKind.HOME)
+        assertEquals("Home", unnamed.uiState.value.name)
+    }
+
+    @Test
+    fun `the home chip without a home set only changes the kind`() {
+        val vm = newStopViewModel()
+        vm.setKind(StopKind.HOME)
+        assertEquals(StopKind.HOME, vm.uiState.value.kind)
+        assertNull(vm.uiState.value.location)
+        assertEquals("", vm.uiState.value.name)
     }
 }

--- a/app/src/test/java/com/nuelto/etappli/ui/tripedit/TripEditViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/tripedit/TripEditViewModelTest.kt
@@ -193,7 +193,7 @@ class TripEditViewModelTest {
     }
 
     @Test
-    fun `a new plan starts at home`() = runTest {
+    fun `a new plan sets out from home and comes back to it`() = runTest {
         setHome()
         val vm = planViewModel()
         vm.setName("Ticino")
@@ -201,13 +201,14 @@ class TripEditViewModelTest {
         var created: String? = null
         vm.save { id, _ -> created = id }
 
-        val stops = tripRepository.stops(created!!).first()
-        val home = stops.single()
-        assertEquals("Luzern", home.name)
-        assertEquals(StopKind.HOME, home.kind)
-        assertEquals(LatLng(47.0502, 8.3093), home.location)
-        assertEquals(0, home.orderIndex)
-        assertEquals(LocalDate.of(2027, 6, 10), home.arrivalDate)
+        val stops = tripRepository.stops(created!!).first().sortedBy { it.orderIndex }
+        assertEquals(listOf(0, 1), stops.map { it.orderIndex })
+        stops.forEach { home ->
+            assertEquals("Luzern", home.name)
+            assertEquals(StopKind.HOME, home.kind)
+            assertEquals(LatLng(47.0502, 8.3093), home.location)
+            assertEquals(LocalDate.of(2027, 6, 10), home.arrivalDate)
+        }
     }
 
     @Test
@@ -238,7 +239,7 @@ class TripEditViewModelTest {
         first.setName("Ticino")
         var created: String? = null
         first.save { id, _ -> created = id }
-        assertEquals(1, tripRepository.stops(created!!).first().size)
+        assertEquals(2, tripRepository.stops(created!!).first().size)
 
         val again = TripEditViewModel(
             SavedStateHandle(mapOf("tripId" to created!!)),
@@ -248,7 +249,7 @@ class TripEditViewModelTest {
         again.setName("Ticino-Tour")
         again.save { _, _ -> }
 
-        assertEquals(1, tripRepository.stops(created!!).first().size)
+        assertEquals(2, tripRepository.stops(created!!).first().size)
     }
 
 }


### PR DESCRIPTION
Closes #33.

## What changed

- **Settings names a home set by GPS or pin.** The pin was always saved (it is in Firestore), but a fix has no name, so the Name field stayed empty and the section looked as if nothing had happened. An unnamed home is now reverse-geocoded into its name, the same way a stop's location is. A name typed meanwhile, or a pin moved before the answer lands, wins.
- **A new plan starts *and ends* at home.** `HomeStop.forNewPlan` returns two HOME stops. Both are ordinary stops, so the timeline, the map and the fuel estimate count the drive back without learning what home is. The first row reads "start", the last "home again".
- **A stop added to the end of a plan goes in front of the drive home** (`HomeStop.returning`, applied in `StopEditViewModel`), and pushes it back by the nights it takes, like any insertion. Mid-tour spontaneous stops still slot in after the last check-in.
- **Starting a tour checks the start home in** (`TripStarter`), so the NowCard points at the first night rather than at your own front door. On the way back it points home, with the live distance from wherever you are.
- **The Home kind chip** appears once a home is set and puts the stop there. That is how an existing plan (made before home was set) gets one.
- **Two consecutive stops at the same spot are not a drive** (`RouteCache.drives`): a fresh home-to-home plan is no longer routed, drawn or costed, so it does not show "0 m · 0 min" under the way home.

## Why

The issue reported "I'm here" doing nothing and new plans not starting at home. Reading the live Firestore settings doc showed the home *was* written today; the only plan predates it by a minute. So the bug was feedback, and the feature request was the return leg.

## Reviewer notes

- Settings copy changed to "Set — new plans start and end here." (tests updated).
- `TripStarter.start` now upserts per stop only when something changed, instead of skipping all stops when the date is unchanged; the start home's state change is why.
- Verified on the emulator in local-only mode: "I'm here" fills in "Bern"; a fresh plan reads Bern · start / Bern · home again; a FAB-added stop lands between them and moves the return to the next day with its own routed leg; starting the tour greys out the start and shows TONIGHT: Thun. Firebase mode could not be walked on the emulator (no Google account), only inspected via Firestore.
- Gates: full suite, 100% line coverage, pitest 94%.
- CLAUDE.md documents the new rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
