### PR TITLE
Date a tour from its first stop when it starts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,10 @@ MVVM + repository, hand-rolled DI — no Hilt, no Room. Package root:
 - **Denormalized totals**: `Trip.totalCost`/`Trip.nights` are recomputed client-side by
   each repository after every stop/expense mutation (`recomputeTotals`), reading Firestore
   from `Source.CACHE` (which includes pending writes, so it works offline). Any new
-  mutation path must call it, or the trip list shows stale totals.
+  mutation path must call it, or the trip list shows stale totals. Stop mutations also
+  call `redatePlan`: a PLANNED trip's `startDate` follows its first unskipped stop
+  (`DateCascade.start`), and `TripStarter` shifts from that stop rather than from
+  `startDate`, so a tour started on a day has its first stop on that day.
 - **Cost semantics** (`domain/CostCalculator.kt`): camping cost lives **on the Stop**
   (`campingCostTotal`); the CAMPING expense type is only for extra site fees. Breakdown
   merges both into the CAMPING category. The fuel estimator (`domain/FuelEstimator.kt`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,8 +215,9 @@ MVVM + repository, hand-rolled DI — no Hilt, no Room. Package root:
   count the drive out and the drive back without knowing what home is. Both are editable
   and deletable like any other stop. A stop added to the end of a plan goes in front of
   the drive home (`HomeStop.returning`, in StopEditViewModel), starting a tour checks the
-  start home in (`TripStarter`) so the first night is what you are heading for, and the
-  HOME kind chip appears once a home is set and puts the stop there.
+  start home in (`TripStarter`) so the first night is what you are heading for
+  (`CurrentStop` never holds a zero-night check-in, even when the tour was started ahead
+  of its date), and the HOME kind chip appears once a home is set and puts the stop there.
 - **A shared place** arrives as `ACTION_SEND` text/plain (Google Maps' share sheet) or a
   `geo:` `ACTION_VIEW`, and is parsed by pure `domain/SharedPlace`: the payload is scanned
   as a haystack, not parsed as a URL, because Maps sends the name on the line above the link.

--- a/app/src/main/java/com/nuelto/etappli/data/FirestoreTripRepository.kt
+++ b/app/src/main/java/com/nuelto/etappli/data/FirestoreTripRepository.kt
@@ -19,6 +19,7 @@ import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
 import com.nuelto.etappli.data.model.legacyTripStatus
 import com.nuelto.etappli.domain.CostCalculator
+import com.nuelto.etappli.domain.DateCascade
 import java.time.LocalDate
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
@@ -251,11 +252,13 @@ class FirestoreTripRepository(
         val doc = if (stop.id.isBlank()) col.document() else col.document(stop.id)
         doc.set(stop.toMap())
         recomputeTotals(stop.tripId)
+        redatePlan(stop.tripId)
     }
 
     override suspend fun deleteStop(tripId: String, stopId: String) {
         trips(uid).document(tripId).collection("stops").document(stopId).delete()
         recomputeTotals(tripId)
+        redatePlan(tripId)
     }
 
     override suspend fun reorderStops(tripId: String, orderedStopIds: List<String>) {
@@ -264,6 +267,7 @@ class FirestoreTripRepository(
             col.document(stopId).update("orderIndex", index)
         }
         recomputeTotals(tripId)
+        redatePlan(tripId)
     }
 
     override suspend fun upsertExpense(expense: Expense) {
@@ -276,6 +280,18 @@ class FirestoreTripRepository(
     override suspend fun deleteExpense(tripId: String, expenseId: String) {
         trips(uid).document(tripId).collection("expenses").document(expenseId).delete()
         recomputeTotals(tripId)
+    }
+
+    /** A plan starts the day its first stop does; stop edits keep the trip doc saying so. */
+    private suspend fun redatePlan(tripId: String) {
+        val tripDoc = trips(uid).document(tripId)
+        val trip = runCatching { tripDoc.get(Source.CACHE).await().toTrip() }.getOrNull() ?: return
+        if (trip.status != TripStatus.PLANNED) return
+        val stops = runCatching {
+            tripDoc.collection("stops").get(Source.CACHE).await().documents.map { it.toStop(tripId) }
+        }.getOrNull() ?: return
+        val start = DateCascade.start(stops) ?: return
+        if (start != trip.startDate) tripDoc.update("startDate", start.toEpochDay())
     }
 
     /**

--- a/app/src/main/java/com/nuelto/etappli/data/InMemoryTripRepository.kt
+++ b/app/src/main/java/com/nuelto/etappli/data/InMemoryTripRepository.kt
@@ -10,6 +10,7 @@ import com.nuelto.etappli.data.model.StopState
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
 import com.nuelto.etappli.domain.CostCalculator
+import com.nuelto.etappli.domain.DateCascade
 import java.time.LocalDate
 import java.util.UUID
 import kotlinx.coroutines.flow.Flow
@@ -65,11 +66,13 @@ class InMemoryTripRepository(seed: Boolean = true) : TripRepository {
         val withId = if (stop.id.isBlank()) stop.copy(id = UUID.randomUUID().toString()) else stop
         stopsFlow.update { list -> list.filterNot { it.id == withId.id } + withId }
         recomputeTotals(withId.tripId)
+        redatePlan(withId.tripId)
     }
 
     override suspend fun deleteStop(tripId: String, stopId: String) {
         stopsFlow.update { list -> list.filterNot { it.id == stopId } }
         recomputeTotals(tripId)
+        redatePlan(tripId)
     }
 
     override suspend fun reorderStops(tripId: String, orderedStopIds: List<String>) {
@@ -80,6 +83,7 @@ class InMemoryTripRepository(seed: Boolean = true) : TripRepository {
             }
         }
         recomputeTotals(tripId)
+        redatePlan(tripId)
     }
 
     override suspend fun upsertExpense(expense: Expense) {
@@ -91,6 +95,20 @@ class InMemoryTripRepository(seed: Boolean = true) : TripRepository {
     override suspend fun deleteExpense(tripId: String, expenseId: String) {
         expensesFlow.update { list -> list.filterNot { it.id == expenseId } }
         recomputeTotals(tripId)
+    }
+
+    /** A plan starts the day its first stop does; stop edits keep the trip saying so. */
+    private fun redatePlan(tripId: String) {
+        val start = DateCascade.start(stopsFlow.value.filter { it.tripId == tripId }) ?: return
+        tripsFlow.update { list ->
+            list.map { trip ->
+                if (trip.id == tripId && trip.status == TripStatus.PLANNED) {
+                    trip.copy(startDate = start)
+                } else {
+                    trip
+                }
+            }
+        }
     }
 
     private fun recomputeTotals(tripId: String) {

--- a/app/src/main/java/com/nuelto/etappli/domain/CurrentStop.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/CurrentStop.kt
@@ -7,15 +7,19 @@ import java.time.LocalDate
 object CurrentStop {
 
     /**
-     * Tonight's stop on an active trip. A checked-in stop stays current until its
-     * stay is over (so the ±nights stepper is at hand mid-stay); afterwards the
-     * first upcoming stop past it — a stop restored behind the check-in line only
-     * becomes current when nothing lies ahead.
+     * Tonight's stop on an active trip. A checked-in stay stays current until it is over
+     * (so the ±nights stepper is at hand mid-stay). A checked-in stop with no nights — the
+     * home a tour set out from, a visit — is behind you the moment it is done, whatever
+     * its date says: a tour started ahead of its start date must head for the first stop,
+     * not sit "checked in" at home. Otherwise the first upcoming stop past the check-in
+     * line — a stop restored behind it only becomes current when nothing lies ahead.
      */
     fun of(stops: List<Stop>, today: LocalDate): String? {
         val ordered = stops.sortedBy { it.orderIndex }.filterNot { it.state == StopState.SKIPPED }
         val lastDone = ordered.lastOrNull { it.state == StopState.DONE }
-        if (lastDone != null && today.isBefore(lastDone.arrivalDate.plusDays(lastDone.nights.toLong()))) {
+        if (lastDone != null && lastDone.nights > 0 &&
+            today.isBefore(lastDone.arrivalDate.plusDays(lastDone.nights.toLong()))
+        ) {
             return lastDone.id
         }
         val upcoming = ordered.filter { it.state == StopState.PLANNED }

--- a/app/src/main/java/com/nuelto/etappli/domain/DateCascade.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/DateCascade.kt
@@ -7,6 +7,10 @@ import java.time.temporal.ChronoUnit
 
 object DateCascade {
 
+    /** The day a schedule starts: the arrival of its first stop that is not skipped. */
+    fun start(stops: List<Stop>): LocalDate? =
+        stops.filterNot { it.state == StopState.SKIPPED }.minByOrNull { it.orderIndex }?.arrivalDate
+
     /**
      * Shifts the arrival dates of PLANNED stops ordered after [afterOrderIndex] by
      * [days] — used when a stay is extended/shortened or an arrival lands late, so

--- a/app/src/main/java/com/nuelto/etappli/domain/TripStarter.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/TripStarter.kt
@@ -16,10 +16,10 @@ import kotlinx.coroutines.flow.first
 object TripStarter {
 
     /**
-     * Starts a planned tour on [startDate] (stop dates shift by the same delta) and
-     * snapshots the estimate for planned-vs-actual. With [keepPlanAsTemplate] the plan
-     * is deep-copied and survives untouched; otherwise it converts in place.
-     * Returns the ACTIVE trip's id.
+     * Starts a planned tour on [startDate]: its first stop lands on that day and the rest
+     * keep their spacing. Snapshots the estimate for planned-vs-actual. With
+     * [keepPlanAsTemplate] the plan is deep-copied and survives untouched; otherwise it
+     * converts in place. Returns the ACTIVE trip's id.
      */
     suspend fun start(
         repository: TripRepository,
@@ -31,7 +31,7 @@ object TripStarter {
         val trip = checkNotNull(repository.trip(tripId).first())
         val stops = repository.stops(tripId).first()
         val expenses = repository.expenses(tripId).first()
-        val shift = ChronoUnit.DAYS.between(trip.startDate, startDate)
+        val shift = ChronoUnit.DAYS.between(DateCascade.start(stops) ?: trip.startDate, startDate)
         // A tour starts by leaving home, so the home it sets out from is already reached:
         // the first night's stop is what you are heading for, not your own front door.
         val departed = HomeStop.departure(stops)?.id
@@ -77,12 +77,16 @@ object TripStarter {
         return newId
     }
 
-    /** Copies a trip into a fresh plan starting [startDate]; skipped stops stay behind. */
+    /**
+     * Copies a trip into a fresh plan whose first stop is on [startDate]; skipped stops
+     * stay behind. Both copies shift from the first stop, not from [Trip.startDate]: a
+     * plan's stops are what the user dated, and the trip's own date may lag behind them.
+     */
     suspend fun planAgain(repository: TripRepository, tripId: String, startDate: LocalDate): String {
         val trip = checkNotNull(repository.trip(tripId).first())
         val stops = repository.stops(tripId).first()
         val expenses = repository.expenses(tripId).first()
-        val shift = ChronoUnit.DAYS.between(trip.startDate, startDate)
+        val shift = ChronoUnit.DAYS.between(DateCascade.start(stops) ?: trip.startDate, startDate)
 
         val newId = repository.upsertTrip(
             trip.copy(

--- a/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailViewModel.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailViewModel.kt
@@ -308,7 +308,7 @@ class TripDetailViewModel(
 
     /** Writes a rearranged timeline: the new stop order, then the dates it implies. */
     private fun applyRows(rows: List<TimelineRow>) {
-        val start = uiState.value.stops.firstOrNull { it.state != StopState.SKIPPED }?.arrivalDate ?: return
+        val start = DateCascade.start(uiState.value.stops) ?: return
         viewModelScope.launch {
             writeLock.withLock {
                 tripRepository.reorderStops(tripId, rows.filterIsInstance<StopRow>().map { it.stop.id })

--- a/app/src/test/java/com/nuelto/etappli/data/InMemoryTripRepositoryTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/data/InMemoryTripRepositoryTest.kt
@@ -226,4 +226,37 @@ class InMemoryTripRepositoryTest {
         }
         assertNotEquals(LatLng(0.0, 0.0), seeded.stops(trips[0].id).first().first().location)
     }
+
+
+    @Test
+    fun `a plan starts the day its first stop does`() = runTest {
+        val start = LocalDate.of(2026, 9, 2)
+        val id = repo.upsertTrip(Trip(id = "plan", name = "Plan", startDate = start, status = TripStatus.PLANNED))
+        repo.upsertStop(Stop(id = "s2", tripId = id, orderIndex = 1, arrivalDate = start.plusDays(2)))
+        assertEquals(start.plusDays(2), repo.trip(id).first()!!.startDate)
+
+        repo.upsertStop(Stop(id = "s1", tripId = id, orderIndex = 0, arrivalDate = start.plusDays(4)))
+        assertEquals(start.plusDays(4), repo.trip(id).first()!!.startDate)
+
+        repo.reorderStops(id, listOf("s2", "s1"))
+        assertEquals(start.plusDays(2), repo.trip(id).first()!!.startDate)
+
+        repo.upsertStop(Stop(id = "s2", tripId = id, orderIndex = 0, arrivalDate = start, state = StopState.SKIPPED))
+        assertEquals(start.plusDays(4), repo.trip(id).first()!!.startDate)
+
+        repo.deleteStop(id, "s1")
+        assertEquals(start.plusDays(4), repo.trip(id).first()!!.startDate)
+    }
+
+    @Test
+    fun `only a plan follows its stops`() = runTest {
+        val start = LocalDate.of(2026, 9, 2)
+        val active = repo.upsertTrip(Trip(id = "active", name = "Active", startDate = start, status = TripStatus.ACTIVE))
+        repo.upsertStop(Stop(id = "a1", tripId = active, orderIndex = 0, arrivalDate = start.plusDays(2)))
+        assertEquals(start, repo.trip(active).first()!!.startDate)
+
+        val plan = repo.upsertTrip(Trip(id = "plan", name = "Plan", startDate = start, status = TripStatus.PLANNED))
+        repo.upsertStop(Stop(id = "other", tripId = active, orderIndex = 1, arrivalDate = start.plusDays(3)))
+        assertEquals(start, repo.trip(plan).first()!!.startDate)
+    }
 }

--- a/app/src/test/java/com/nuelto/etappli/domain/CurrentStopTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/CurrentStopTest.kt
@@ -56,4 +56,12 @@ class CurrentStopTest {
         assertNull(CurrentStop.of(listOf(visited), today))
         assertNull(CurrentStop.of(emptyList(), today))
     }
+
+    @Test
+    fun `the home a tour set out from is behind you even before the start date`() {
+        // Started the evening before: home is checked in, dated tomorrow, with no nights.
+        val home = stop("home", 0, StopState.DONE, arrival = today.plusDays(1), nights = 0)
+        val first = stop("first", 1, arrival = today.plusDays(1))
+        assertEquals("first", CurrentStop.of(listOf(home, first), today))
+    }
 }

--- a/app/src/test/java/com/nuelto/etappli/domain/DateCascadeTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/DateCascadeTest.kt
@@ -4,6 +4,7 @@ import com.nuelto.etappli.data.model.Stop
 import com.nuelto.etappli.data.model.StopState
 import java.time.LocalDate
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -110,5 +111,23 @@ class DateCascadeTest {
     fun `an order that changes no arrival writes nothing`() {
         val stops = listOf(stop("a", 0, base), stop("b", 1, base.plusDays(1)))
         assertTrue(DateCascade.resequence(Timeline.rows(stops), base).isEmpty())
+    }
+
+
+    @Test
+    fun `start is the arrival of the first stop that is not skipped`() {
+        val stops = listOf(
+            stop("second", 1, base.plusDays(3)),
+            stop("skipped", 0, base, state = StopState.SKIPPED),
+            stop("first", 2, base.plusDays(5)),
+        )
+        assertEquals(base.plusDays(3), DateCascade.start(stops))
+        assertEquals(base.plusDays(3), DateCascade.start(stops.filterNot { it.state == StopState.SKIPPED }))
+    }
+
+    @Test
+    fun `start of no stops is nothing`() {
+        assertNull(DateCascade.start(emptyList()))
+        assertNull(DateCascade.start(listOf(stop("skipped", 0, base, state = StopState.SKIPPED))))
     }
 }

--- a/app/src/test/java/com/nuelto/etappli/domain/TripStarterTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/TripStarterTest.kt
@@ -196,4 +196,50 @@ class TripStarterTest {
         assertEquals(listOf(StopState.DONE, StopState.PLANNED, StopState.PLANNED), converted.map { it.state })
         assertEquals(listOf(planStart, planStart, planStart.plusDays(2)), converted.map { it.arrivalDate })
     }
+
+
+    @Test
+    fun `a tour is dated from its first stop, not from what the plan says`() = runTest {
+        val planId = seedPlan()
+        // The plan doc says it starts two days before anyone arrives anywhere.
+        val plan = repo.trip(planId).first()!!
+        repo.upsertTrip(plan.copy(startDate = planStart.minusDays(2)))
+
+        val templateId = TripStarter.start(repo, planId, planStart.minusDays(2), keepPlanAsTemplate = true, settings = settings)
+        assertEquals(
+            listOf(planStart.minusDays(2), planStart),
+            repo.stops(templateId).first().map { it.arrivalDate },
+        )
+
+        TripStarter.start(repo, planId, planStart.minusDays(2), keepPlanAsTemplate = false, settings = settings)
+        assertEquals(
+            listOf(planStart.minusDays(2), planStart),
+            repo.stops(planId).first().map { it.arrivalDate },
+        )
+        assertEquals(planStart.minusDays(2), repo.trip(planId).first()!!.startDate)
+    }
+
+    @Test
+    fun `plan again is dated from the first stop that comes along`() = runTest {
+        val doneId = repo.upsertTrip(
+            Trip(id = "done", name = "Drive day", startDate = LocalDate.of(2025, 9, 11), status = TripStatus.DONE),
+        )
+        repo.upsertStop(
+            Stop(
+                id = "skipped", tripId = doneId, name = "Never", arrivalDate = LocalDate.of(2025, 9, 11),
+                orderIndex = 0, state = StopState.SKIPPED,
+            ),
+        )
+        repo.upsertStop(
+            Stop(
+                id = "d1", tripId = doneId, name = "Durance", arrivalDate = LocalDate.of(2025, 9, 12),
+                nights = 3, orderIndex = 1, state = StopState.DONE,
+            ),
+        )
+
+        val newStart = LocalDate.of(2026, 9, 12)
+        val newId = TripStarter.planAgain(repo, doneId, newStart)
+        assertEquals(newStart, repo.stops(newId).first().single().arrivalDate)
+        assertEquals(newStart, repo.trip(newId).first()!!.startDate)
+    }
 }

--- a/app/src/test/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreenTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreenTest.kt
@@ -948,4 +948,30 @@ class TripDetailScreenTest {
         compose.onNodeWithText(back, useUnmergedTree = true).assertIsDisplayed()
         compose.onNodeWithText("${formatDate(start)} · start", useUnmergedTree = true).assertExists()
     }
+
+    @Test
+    fun `a tour started ahead of its date heads for the first stop, not home`() {
+        val start = LocalDate.now().plusDays(1)
+        runBlocking {
+            tripRepository.upsertTrip(Trip(id = "h3", name = "Loop", startDate = start, status = TripStatus.ACTIVE))
+            tripRepository.upsertStop(
+                Stop(
+                    id = "out", tripId = "h3", name = "Luzern", orderIndex = 0, nights = 0, state = StopState.DONE,
+                    kind = StopKind.HOME, location = LatLng(47.05, 8.31), arrivalDate = start,
+                ),
+            )
+            tripRepository.upsertStop(
+                Stop(
+                    id = "s", tripId = "h3", name = "Locarno", orderIndex = 1, nights = 2,
+                    location = LatLng(46.16, 8.79), arrivalDate = start,
+                ),
+            )
+        }
+        setContent("h3")
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Locarno"))
+        compose.onNodeWithText("TONIGHT").assertIsDisplayed()
+        compose.onNodeWithText("Navigate").assertIsDisplayed()
+        compose.onNodeWithText("Show distance from here", useUnmergedTree = true).assertIsDisplayed()
+        compose.onAllNodesWithText("Checked in", useUnmergedTree = true).assertCountEquals(0)
+    }
 }

--- a/app/src/test/java/com/nuelto/etappli/ui/tripdetail/TripDetailViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/tripdetail/TripDetailViewModelTest.kt
@@ -130,7 +130,10 @@ class TripDetailViewModelTest {
             Trip(id = "t1", name = "Plan", startDate = LocalDate.of(2027, 6, 10), status = TripStatus.PLANNED),
         )
         tripRepository.upsertStop(
-            Stop(id = "s1", tripId = "t1", name = "Luzern", nights = 2, location = LatLng(47.05, 8.31), orderIndex = 0),
+            Stop(
+                id = "s1", tripId = "t1", name = "Luzern", nights = 2, location = LatLng(47.05, 8.31),
+                orderIndex = 0, arrivalDate = LocalDate.of(2027, 6, 10),
+            ),
         )
         val vm = hotViewModel()
         val suggestion = vm.uiState.value.vignetteSuggestions.single()

--- a/play/listing/full-description.txt
+++ b/play/listing/full-description.txt
@@ -1,0 +1,19 @@
+Etappli — a little stage, one leg of the journey — is a trip book for camper travel: plan the route, log the nights, and watch what the trip actually costs, before you leave and while you are out there.
+
+PLAN A TOUR STOP BY STOP
+Start from home, add campsites, Stellplätze, free camps and places you just want to see. Give each stop its arrival date and how many nights you stay; everything after it moves along by itself. Drag a stop to reorder the tour and the dates follow. Leave a run of nights unplanned and fill them in later.
+
+KNOW WHAT IT COSTS BEFORE YOU GO
+Every trip shows a running total broken down into camping, fuel, road tax and the rest. Stops you have not priced yet are estimated from your own per-night rates, and the fuel is estimated from the distance actually driven on roads, your consumption, and the fuel price you pay. Add a vignette for the countries you cross.
+
+ROUTES THAT FOLLOW REAL ROADS
+Trips are drawn on the map along the roads you would drive, not as straight lines, with distance and driving time for every leg. On the road, the app tells you how far tonight's stop still is from where you are standing and when you will get there.
+
+FIND PLACES THE WAY YOU ACTUALLY LOOK FOR THEM
+Search a campsite by name, tap a place already on the map, or press and hold to drop a pin. Chosen places bring their rating, a short description and a photo with them. Found something in Google Maps? Share it into Etappli and pick the trip it belongs to.
+
+ALL YOUR TRIPS ON ONE MAP
+Planned trips in blue, the trip you are on in green, finished trips in grey — every tour you have ever made on a single map.
+
+BUILT TO STAY OUT OF THE WAY
+Works offline and syncs when you have signal. No ads. No analytics. No tracking. Your trips are yours.

--- a/play/listing/store-listing.md
+++ b/play/listing/store-listing.md
@@ -54,7 +54,7 @@ travel, camping, road trip, trip planner, expenses
 
 ## Contact details
 
-- Email: <CONTACT EMAIL — required, shown publicly on the listing>
+- Email: etappli@nuelto.com
 - Website: https://github.com/ampersand8/etappli (optional)
 - Privacy policy: https://github.com/ampersand8/etappli/blob/main/PRIVACY.md
 


### PR DESCRIPTION
## What

Starting a planned tour on a day now puts the tour's **first stop on that day**, with every later stop keeping its spacing. Before, the shift was computed from the trip's stored `startDate`, which only ever changes in the trip form. Moving stop dates on the timeline never touched it, so a plan whose first stop had moved to 4.9 could still claim to start on 2.9, and starting it on 2.9 moved nothing.

- `TripStarter.start` (in place and keep-as-template) and `planAgain` shift from the first unskipped stop (`DateCascade.start`), falling back to `Trip.startDate` only when there are no stops. Works on plans that already drifted in Firestore.
- Both repositories re-date a PLANNED trip to its first unskipped stop after every stop add/edit/delete/reorder (`redatePlan`), so the trip list's "from …", the edit form and the vignette expense date agree with the timeline. ACTIVE and DONE trips keep the date they actually started.
- If a plan begins with a home stop, that home is the first stop; unplanned nights between home and the first destination survive a start.

Also carried along, since they were on local main but not yet pushed:

- `88983b1` Head for the first stop, not home, when a tour starts ahead of its date (fixes #36).
- The Play listing's contact email and full description (`play/listing/`), unrelated to the fix and easy to drop if you would rather keep them separate.

## Verification

- `./gradlew test :app:coverageVerify` green (662 tests, 100% line coverage gate).
- `./gradlew :app:pitest` at 94% (gate 80%).
- One existing test seeded a stop with today's date on a 2027 plan and relied on the old drift; it now dates the stop on the plan's start.

## Reviewer notes

- `TripEditViewModel` still shifts a plan by the delta of the date field it showed, deliberately: anchoring it on the first stop would move a drifted legacy plan on a rename. Such a plan heals on its next stop edit.
- Firestore's `redatePlan` is a second cached read after `recomputeTotals`; it is device-only code and excluded from coverage like the rest of that repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
