### PR TITLE
Follow the road, and ride where it ends

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,11 @@ There is no lint/format tooling configured.
   key's API restrictions. Note Places and Routes are called as plain web services, so an
   Android *application* restriction would break both unless `X-Android-Package`/
   `X-Android-Cert` headers are added. Everything degrades to straight lines without a key.
+  A stop Google cannot drive to (Riederalp is car-free) empties the whole `computeRoutes`
+  answer, so `RouteRefresher` then asks that window drive by drive and stores a leg with
+  **no distance** for the drive that has no road (`StopLeg.hasRoad`): the map keeps its
+  straight hop, the estimate its road factor, the timeline says "No drivable route", and
+  nothing asks again for 30 days.
 - **"How far from here"**: on an ACTIVE trip the NowCard replaces the planned leg with a
   live route from the current GPS fix to the stop you are heading for (`domain/DriveFromHere`
   + `LiveDrive` rules, `MapProvider.drive`). Never stored — it is true for one fix.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,8 +79,9 @@ There is no lint/format tooling configured.
   ride boards, the vehicle is left there (`TransitRide.parked`; up to three rides back when
   no road reaches that either), the road legs run to and from that spot, and the ride sits
   on the leg either side of the drive (`StopLeg.rideAfter` up, the next leg's `rideBefore`
-  down) — dotted on the map, "122 km · 2 h + cable car 24 min" in the timeline, never in
-  the fuel. A stop no ride reaches either keeps a leg with **no distance**
+  down) — dotted on the map, an icon per vehicle with the minutes in the timeline
+  (`TravelMode`; `ui/components/TravelIcons.kt` hand-draws the cable car, which the icon
+  set lacks), never in the fuel. A stop no ride reaches either keeps a leg with **no distance**
   (`StopLeg.hasRoad` false): straight hop, road factor, "No drivable route", and nothing
   asks again for 30 days.
 - **"How far from here"**: on an ACTIVE trip the NowCard replaces the planned leg with a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ adding new ones.
 ./gradlew :app:pitest           # mutation tests over JVM-pure logic, threshold 80%
 ./gradlew :app:installDebug     # install on connected device/emulator
 ./gradlew :app:bundleRelease    # Play bundle; unsigned unless the upload key is configured
-./gradlew test --tests "com.nuelto.etappli.domain.CostCalculatorTest"  # one test class
+./gradlew :app:testDebugUnitTest --tests "com.nuelto.etappli.domain.CostCalculatorTest"  # one class
 ```
 
 CI (`.github/workflows/ci.yml`) runs tests + both gates + assembleDebug on every PR.
@@ -185,6 +185,17 @@ MVVM + repository, hand-rolled DI — no Hilt, no Room. Package root:
   In the timeline a stop's icon carries both axes at once: the **shape** is the kind
   (tent / RV hookup / forest / camera) and the **tint** is that status color. Its height
   above sea level rides to the right of the name as a small mountain badge.
+- **A tour needs no name and no form.** "Plan a tour" makes the plan on the spot
+  (`domain/NewPlan`: unnamed, dated today, home at both ends when one is set) and opens
+  the stop editor over its timeline; the chooser for a shared place does the same and
+  files the place on it. Logging a trip keeps the form, with the name optional.
+  `Trip.name` is only what the user typed; what a trip is *called* is `Trip.title`
+  (`domain/TripName`): the name, else `Trip.region`, else a name made up from the id
+  ("Rusty Edelweiss" — stable, never stored). `Trip.region` ("Ticino & Graubünden") is
+  denormalized with the totals from `Stop.region` — canton/state and country,
+  reverse-geocoded by `domain/RegionResolver` (run from TripDetailViewModel through
+  `PlaceNameResolver.region`), with an `at` that invalidates it like `StopElevation`.
+  HOME and SKIPPED stops never name a tour.
 - **Denormalized totals**: `Trip.totalCost`/`Trip.nights` are recomputed client-side by
   each repository after every stop/expense mutation (`recomputeTotals`), reading Firestore
   from `Source.CACHE` (which includes pending writes, so it works offline). Any new
@@ -262,7 +273,7 @@ swaps the Maps SDK for a stand-in (`ui/map/MapProvider.kt`). Fakes live in `test
   `InMemoryTripRepository(seed = false)` etc. and pass it into the screen composable.
 - **ViewModel tests**: plain JUnit with `MainDispatcherRule` (testutil) and Turbine
   for flow assertions. Async races (late geocode result, slow sign-in) use the gated
-  fakes: `FakeAuthRepository.gate`, `FakePlaceNameResolver.gates`.
+  fakes: `FakeAuthRepository.gate`, `FakePlaceNameResolver.gates`, `GatedSettingsRepository.gate`.
 - **Never replace the activity's intent in `MainActivity.onCreate`** (`setIntent(...)`):
   `ActivityScenario` then never sees the activity reach RESUMED, and every
   `createAndroidComposeRule` test in the run hangs — with no failure, just a stuck suite.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,10 +73,16 @@ There is no lint/format tooling configured.
   Android *application* restriction would break both unless `X-Android-Package`/
   `X-Android-Cert` headers are added. Everything degrades to straight lines without a key.
   A stop Google cannot drive to (Riederalp is car-free) empties the whole `computeRoutes`
-  answer, so `RouteRefresher` then asks that window drive by drive and stores a leg with
-  **no distance** for the drive that has no road (`StopLeg.hasRoad`): the map keeps its
-  straight hop, the estimate its road factor, the timeline says "No drivable route", and
-  nothing asks again for 30 days.
+  answer, so `RouteRefresher` then asks that window drive by drive, and a drive that still
+  has no road goes **park-and-ride** (`domain/ParkAndRide`): a TRANSIT route to the stop
+  (no `routingPreference`, no intermediates — the mode allows neither) says where its last
+  ride boards, the vehicle is left there (`TransitRide.parked`; up to three rides back when
+  no road reaches that either), the road legs run to and from that spot, and the ride sits
+  on the leg either side of the drive (`StopLeg.rideAfter` up, the next leg's `rideBefore`
+  down) — dotted on the map, "122 km · 2 h + cable car 24 min" in the timeline, never in
+  the fuel. A stop no ride reaches either keeps a leg with **no distance**
+  (`StopLeg.hasRoad` false): straight hop, road factor, "No drivable route", and nothing
+  asks again for 30 days.
 - **"How far from here"**: on an ACTIVE trip the NowCard replaces the planned leg with a
   live route from the current GPS fix to the stop you are heading for (`domain/DriveFromHere`
   + `LiveDrive` rules, `MapProvider.drive`). Never stored — it is true for one fix.

--- a/app/src/main/java/com/nuelto/etappli/data/FirestoreTripRepository.kt
+++ b/app/src/main/java/com/nuelto/etappli/data/FirestoreTripRepository.kt
@@ -14,6 +14,7 @@ import com.nuelto.etappli.data.model.Stop
 import com.nuelto.etappli.data.model.StopElevation
 import com.nuelto.etappli.data.model.StopRegion
 import com.nuelto.etappli.data.model.StopLeg
+import com.nuelto.etappli.data.model.TransitRide
 import com.nuelto.etappli.data.model.StopKind
 import com.nuelto.etappli.data.model.StopState
 import com.nuelto.etappli.data.model.Trip
@@ -114,8 +115,30 @@ class FirestoreTripRepository(
         "durationSeconds" to durationSeconds,
         "ascentMeters" to ascentMeters,
         "descentMeters" to descentMeters,
+        "rideBefore" to rideBefore?.toMap(),
+        "rideAfter" to rideAfter?.toMap(),
         "fetchedAt" to fetchedAt.toEpochDay(),
     )
+
+    private fun TransitRide.toMap() = mapOf(
+        "parked" to GeoPoint(parked.latitude, parked.longitude),
+        "polyline" to polyline,
+        "distanceMeters" to distanceMeters,
+        "durationSeconds" to durationSeconds,
+        "mode" to mode,
+    )
+
+    /** No parking spot, no ride: without it the drive cannot be told where it ends. */
+    private fun Map<*, *>.toTransitRide(): TransitRide? {
+        val parked = this["parked"] as? GeoPoint ?: return null
+        return TransitRide(
+            parked = LatLng(parked.latitude, parked.longitude),
+            polyline = this["polyline"] as? String ?: "",
+            distanceMeters = (this["distanceMeters"] as? Number)?.toInt() ?: 0,
+            durationSeconds = (this["durationSeconds"] as? Number)?.toInt() ?: 0,
+            mode = this["mode"] as? String ?: "",
+        )
+    }
 
     /** No endpoints, no leg: without them nothing can tell whether it still applies. */
     private fun Map<*, *>.toStopLeg(): StopLeg? {
@@ -129,6 +152,8 @@ class FirestoreTripRepository(
             durationSeconds = (this["durationSeconds"] as? Number)?.toInt() ?: 0,
             ascentMeters = (this["ascentMeters"] as? Number)?.toInt(),
             descentMeters = (this["descentMeters"] as? Number)?.toInt(),
+            rideBefore = (this["rideBefore"] as? Map<*, *>)?.toTransitRide(),
+            rideAfter = (this["rideAfter"] as? Map<*, *>)?.toTransitRide(),
             fetchedAt = (this["fetchedAt"] as? Number)
                 ?.let { LocalDate.ofEpochDay(it.toLong()) } ?: LocalDate.now(),
         )

--- a/app/src/main/java/com/nuelto/etappli/data/FirestoreTripRepository.kt
+++ b/app/src/main/java/com/nuelto/etappli/data/FirestoreTripRepository.kt
@@ -12,6 +12,7 @@ import com.nuelto.etappli.data.model.ExpenseType
 import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.data.model.Stop
 import com.nuelto.etappli.data.model.StopElevation
+import com.nuelto.etappli.data.model.StopRegion
 import com.nuelto.etappli.data.model.StopLeg
 import com.nuelto.etappli.data.model.StopKind
 import com.nuelto.etappli.data.model.StopState
@@ -20,6 +21,7 @@ import com.nuelto.etappli.data.model.TripStatus
 import com.nuelto.etappli.data.model.legacyTripStatus
 import com.nuelto.etappli.domain.CostCalculator
 import com.nuelto.etappli.domain.DateCascade
+import com.nuelto.etappli.domain.TripName
 import java.time.LocalDate
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
@@ -60,6 +62,7 @@ class FirestoreTripRepository(
         "status" to status.name,
         "plannedCost" to plannedCost,
         "plannedNights" to plannedNights,
+        "region" to region,
     )
 
     private fun DocumentSnapshot.toTrip(): Trip? {
@@ -77,6 +80,7 @@ class FirestoreTripRepository(
                 ?: legacyTripStatus(endDate),
             plannedCost = getDouble("plannedCost"),
             plannedNights = getLong("plannedNights")?.toInt(),
+            region = getString("region") ?: "",
         )
     }
 
@@ -96,6 +100,9 @@ class FirestoreTripRepository(
         "leg" to leg?.toMap(),
         "elevation" to elevation?.let {
             mapOf("at" to GeoPoint(it.at.latitude, it.at.longitude), "meters" to it.meters)
+        },
+        "region" to region?.let {
+            mapOf("at" to GeoPoint(it.at.latitude, it.at.longitude), "name" to it.name, "country" to it.country)
         },
     )
 
@@ -148,6 +155,14 @@ class FirestoreTripRepository(
         elevation = (get("elevation") as? Map<*, *>)?.let { stored ->
             val at = stored["at"] as? GeoPoint ?: return@let null
             StopElevation(LatLng(at.latitude, at.longitude), (stored["meters"] as? Number)?.toInt() ?: 0)
+        },
+        region = (get("region") as? Map<*, *>)?.let { stored ->
+            val at = stored["at"] as? GeoPoint ?: return@let null
+            StopRegion(
+                LatLng(at.latitude, at.longitude),
+                stored["name"] as? String ?: "",
+                stored["country"] as? String ?: "",
+            )
         },
     )
 
@@ -312,6 +327,7 @@ class FirestoreTripRepository(
             mapOf(
                 "totalCost" to CostCalculator.tripTotal(stops, expenses),
                 "nights" to CostCalculator.tripNights(stops),
+                "region" to TripName.region(stops),
             ),
         )
     }

--- a/app/src/main/java/com/nuelto/etappli/data/FirestoreTripRepository.kt
+++ b/app/src/main/java/com/nuelto/etappli/data/FirestoreTripRepository.kt
@@ -15,6 +15,7 @@ import com.nuelto.etappli.data.model.StopElevation
 import com.nuelto.etappli.data.model.StopRegion
 import com.nuelto.etappli.data.model.StopLeg
 import com.nuelto.etappli.data.model.TransitRide
+import com.nuelto.etappli.data.model.TravelMode
 import com.nuelto.etappli.data.model.StopKind
 import com.nuelto.etappli.data.model.StopState
 import com.nuelto.etappli.data.model.Trip
@@ -125,7 +126,7 @@ class FirestoreTripRepository(
         "polyline" to polyline,
         "distanceMeters" to distanceMeters,
         "durationSeconds" to durationSeconds,
-        "mode" to mode,
+        "modes" to modes.map { it.name },
     )
 
     /** No parking spot, no ride: without it the drive cannot be told where it ends. */
@@ -136,7 +137,9 @@ class FirestoreTripRepository(
             polyline = this["polyline"] as? String ?: "",
             distanceMeters = (this["distanceMeters"] as? Number)?.toInt() ?: 0,
             durationSeconds = (this["durationSeconds"] as? Number)?.toInt() ?: 0,
-            mode = this["mode"] as? String ?: "",
+            modes = (this["modes"] as? List<*>).orEmpty().mapNotNull { name ->
+                (name as? String)?.let { runCatching { TravelMode.valueOf(it) }.getOrNull() }
+            },
         )
     }
 

--- a/app/src/main/java/com/nuelto/etappli/data/InMemoryTripRepository.kt
+++ b/app/src/main/java/com/nuelto/etappli/data/InMemoryTripRepository.kt
@@ -11,6 +11,7 @@ import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
 import com.nuelto.etappli.domain.CostCalculator
 import com.nuelto.etappli.domain.DateCascade
+import com.nuelto.etappli.domain.TripName
 import java.time.LocalDate
 import java.util.UUID
 import kotlinx.coroutines.flow.Flow
@@ -120,6 +121,7 @@ class InMemoryTripRepository(seed: Boolean = true) : TripRepository {
                     trip.copy(
                         totalCost = CostCalculator.tripTotal(stops, expenses),
                         nights = CostCalculator.tripNights(stops),
+                        region = TripName.region(stops),
                     )
                 } else {
                     trip

--- a/app/src/main/java/com/nuelto/etappli/data/model/Models.kt
+++ b/app/src/main/java/com/nuelto/etappli/data/model/Models.kt
@@ -79,6 +79,8 @@ data class StopLeg(
     val to: LatLng = LatLng(0.0, 0.0),
     // Encoded polyline, decoded for drawing by domain/Polyline.
     val polyline: String = "",
+    // Zero when Google found no drivable road between the two (a car-free village) — an
+    // answer worth keeping too, so the same drive is not asked about again for 30 days.
     val distanceMeters: Int = 0,
     val durationSeconds: Int = 0,
     // Cumulative climb along the leg, from an open DEM — null until it is fetched, and
@@ -87,7 +89,10 @@ data class StopLeg(
     val ascentMeters: Int? = null,
     val descentMeters: Int? = null,
     val fetchedAt: LocalDate = LocalDate.now(),
-)
+) {
+    /** False for a drive Google could not route: the map keeps its straight hop. */
+    val hasRoad: Boolean get() = distanceMeters > 0
+}
 
 data class Stop(
     val id: String = "",

--- a/app/src/main/java/com/nuelto/etappli/data/model/Models.kt
+++ b/app/src/main/java/com/nuelto/etappli/data/model/Models.kt
@@ -66,6 +66,18 @@ data class StopElevation(val at: LatLng = LatLng(0.0, 0.0), val meters: Int = 0)
  */
 data class StopRegion(val at: LatLng = LatLng(0.0, 0.0), val name: String = "", val country: String = "")
 
+/** What you travel on — the icon beside a drive or a ride. */
+enum class TravelMode(val label: String) {
+    CAR("car"),
+    CABLE_CAR("cable car"),
+    FUNICULAR("funicular"),
+    FERRY("ferry"),
+    TRAM("tram"),
+    BUS("bus"),
+    TRAIN("train"),
+    TRANSIT("transit"),
+}
+
 /**
  * A ride on public transport between where the vehicle is left and a stop no road reaches
  * — the cable car up to a car-free village, the ferry to an island — as Google routed it
@@ -78,8 +90,8 @@ data class TransitRide(
     val polyline: String = "",
     val distanceMeters: Int = 0,
     val durationSeconds: Int = 0,
-    // What you board, in words: "cable car", "train + bus".
-    val mode: String = "",
+    // What you board, in riding order, each once: the cable car; the train, then the bus.
+    val modes: List<TravelMode> = emptyList(),
 )
 
 /**

--- a/app/src/main/java/com/nuelto/etappli/data/model/Models.kt
+++ b/app/src/main/java/com/nuelto/etappli/data/model/Models.kt
@@ -67,6 +67,22 @@ data class StopElevation(val at: LatLng = LatLng(0.0, 0.0), val meters: Int = 0)
 data class StopRegion(val at: LatLng = LatLng(0.0, 0.0), val name: String = "", val country: String = "")
 
 /**
+ * A ride on public transport between where the vehicle is left and a stop no road reaches
+ * — the cable car up to a car-free village, the ferry to an island — as Google routed it
+ * (domain/ParkAndRide). Lives on the leg either side of the drive: see [StopLeg].
+ */
+data class TransitRide(
+    // Where the vehicle waits: the valley station, the ferry port — the end of the road.
+    val parked: LatLng = LatLng(0.0, 0.0),
+    // Encoded polyline from [parked] up to the stop, rides and walks together.
+    val polyline: String = "",
+    val distanceMeters: Int = 0,
+    val durationSeconds: Int = 0,
+    // What you board, in words: "cable car", "train + bus".
+    val mode: String = "",
+)
+
+/**
  * The drive from the previous stop, as Google routed it. [from]/[to] are the stop
  * coordinates the route was computed between, so a reorder or a moved pin invalidates
  * the leg by simple comparison rather than by hoping something remembered to clear it.
@@ -79,8 +95,8 @@ data class StopLeg(
     val to: LatLng = LatLng(0.0, 0.0),
     // Encoded polyline, decoded for drawing by domain/Polyline.
     val polyline: String = "",
-    // Zero when Google found no drivable road between the two (a car-free village) — an
-    // answer worth keeping too, so the same drive is not asked about again for 30 days.
+    // Zero when no road reaches the stop and no ride does either — an answer worth
+    // keeping too, so the same drive is not asked about again for 30 days.
     val distanceMeters: Int = 0,
     val durationSeconds: Int = 0,
     // Cumulative climb along the leg, from an open DEM — null until it is fetched, and
@@ -88,9 +104,14 @@ data class StopLeg(
     // its Elevation API forbids storing results at all.
     val ascentMeters: Int? = null,
     val descentMeters: Int? = null,
+    // Rides either side of the drive where a stop has no road (domain/ParkAndRide): down
+    // from the stop before to where the vehicle was left, and up from where it is left to
+    // this one. The road then runs between the parking spots; [from]/[to] stay the stops'.
+    val rideBefore: TransitRide? = null,
+    val rideAfter: TransitRide? = null,
     val fetchedAt: LocalDate = LocalDate.now(),
 ) {
-    /** False for a drive Google could not route: the map keeps its straight hop. */
+    /** False for a drive Google could route neither by road nor by ride: a straight hop. */
     val hasRoad: Boolean get() = distanceMeters > 0
 }
 

--- a/app/src/main/java/com/nuelto/etappli/data/model/Models.kt
+++ b/app/src/main/java/com/nuelto/etappli/data/model/Models.kt
@@ -16,6 +16,7 @@ fun legacyTripStatus(endDate: LocalDate?): TripStatus =
 
 data class Trip(
     val id: String = "",
+    // What the user called it, if anything: what it is called is domain/TripName's Trip.title.
     val name: String = "",
     val startDate: LocalDate = LocalDate.now(),
     val endDate: LocalDate? = null,
@@ -29,6 +30,9 @@ data class Trip(
     // Estimate snapshot taken when the tour is started, for planned-vs-actual.
     val plannedCost: Double? = null,
     val plannedNights: Int? = null,
+    // Where it goes, denormalized from the stops' regions like the totals — the title
+    // while [name] is blank.
+    val region: String = "",
 )
 
 /**
@@ -54,6 +58,13 @@ enum class StopState { PLANNED, DONE, SKIPPED }
  * coordinate this never expires.
  */
 data class StopElevation(val at: LatLng = LatLng(0.0, 0.0), val meters: Int = 0)
+
+/**
+ * Which region a stop lies in — the canton, province or state, and the country — for
+ * naming the tour after where it goes (domain/TripName). [at] is the coordinate it was
+ * looked up for, so a moved pin invalidates it by comparison, like [StopElevation].
+ */
+data class StopRegion(val at: LatLng = LatLng(0.0, 0.0), val name: String = "", val country: String = "")
 
 /**
  * The drive from the previous stop, as Google routed it. [from]/[to] are the stop
@@ -103,6 +114,7 @@ data class Stop(
     // trip, and until the route has been fetched.
     val leg: StopLeg? = null,
     val elevation: StopElevation? = null,
+    val region: StopRegion? = null,
 )
 
 enum class ExpenseType {

--- a/app/src/main/java/com/nuelto/etappli/domain/FuelEstimator.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/FuelEstimator.kt
@@ -39,7 +39,7 @@ object FuelEstimator {
 
     // Safe: RouteCache.drives keeps only stops that have a location.
     private fun driveDistanceKm(from: Stop, to: Stop, settings: UserSettings): Double =
-        RouteCache.usable(from, to)?.let { it.distanceMeters / 1000.0 }
+        RouteCache.usable(from, to)?.takeIf { it.hasRoad }?.let { it.distanceMeters / 1000.0 }
             ?: (GeoUtils.haversineKm(from.location!!, to.location!!) * settings.roadDistanceFactor)
 
     // The gravity term of the road-load equation: lower heating value of diesel, and a

--- a/app/src/main/java/com/nuelto/etappli/domain/GoogleRoutes.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/GoogleRoutes.kt
@@ -14,6 +14,17 @@ data class RoutedLeg(
     val durationSeconds: Int,
 )
 
+/** One step of a transit route: a walk, or a ride on one vehicle from where it is boarded. */
+data class TransitStep(
+    val polyline: String,
+    val distanceMeters: Int,
+    val durationSeconds: Int,
+    // Google's vehicle type ("GONDOLA_LIFT"); null for a walk.
+    val vehicle: String? = null,
+    // Where the ride is boarded — where a vehicle could be left. Null for a walk.
+    val departure: LatLng? = null,
+)
+
 /**
  * Google Routes API (computeRoutes): the road-following geometry, distance and driving
  * time between stops. Pure request building and lenient parsing; the HTTP call is
@@ -33,6 +44,13 @@ object GoogleRoutes {
      */
     const val FIELD_MASK = "routes.legs.distanceMeters,routes.legs.duration," +
         "routes.legs.polyline.encodedPolyline"
+
+    /** Per step: the way, the numbers, where each ride boards and on what. */
+    const val TRANSIT_FIELD_MASK = "routes.legs.steps.travelMode," +
+        "routes.legs.steps.polyline.encodedPolyline,routes.legs.steps.distanceMeters," +
+        "routes.legs.steps.staticDuration," +
+        "routes.legs.steps.transitDetails.stopDetails.departureStop.location," +
+        "routes.legs.steps.transitDetails.transitLine.vehicle.type"
 
     /**
      * Origin, destination and at most 10 intermediates. Eleven intermediates is one of
@@ -80,6 +98,14 @@ object GoogleRoutes {
             "\"polylineQuality\":\"HIGH_QUALITY\"}"
     }
 
+    /**
+     * Public transport from [from] to [to]: how a stop no road reaches is still reached
+     * (ParkAndRide). No intermediates and no routing preference — the mode allows neither.
+     */
+    fun transitBody(from: LatLng, to: LatLng): String =
+        "{\"origin\":${waypoint(from)},\"destination\":${waypoint(to)}," +
+            "\"travelMode\":\"TRANSIT\",\"polylineQuality\":\"HIGH_QUALITY\"}"
+
     private fun waypoint(point: LatLng): String =
         "{\"location\":{\"latLng\":{\"latitude\":${point.latitude}," +
             "\"longitude\":${point.longitude}}}}"
@@ -90,14 +116,11 @@ object GoogleRoutes {
      * silently shifting every leg onto the wrong stop.
      */
     fun parseLegs(body: String): List<RoutedLeg> {
-        val root = runCatching { Json.parseToJsonElement(body) }.getOrNull() as? JsonObject
-        val routes = root?.get("routes") as? JsonArray ?: return emptyList()
-        val legs = (routes.firstOrNull() as? JsonObject)?.get("legs") as? JsonArray
-            ?: return emptyList()
+        val legs = firstRouteLegs(body) ?: return emptyList()
         return legs.map { element ->
             val leg = element as? JsonObject ?: return emptyList()
             RoutedLeg(
-                polyline = (leg["polyline"] as? JsonObject)?.string("encodedPolyline").orEmpty(),
+                polyline = leg.obj("polyline")?.string("encodedPolyline").orEmpty(),
                 // Proto3 JSON omits zero-valued fields, so a zero-length leg arrives
                 // with neither number present.
                 distanceMeters = leg.int("distanceMeters") ?: 0,
@@ -106,13 +129,54 @@ object GoogleRoutes {
         }
     }
 
+    /**
+     * The steps of a transit route — walks and rides, in order. Such a route has one leg,
+     * the mode allowing no intermediates. As with [parseLegs], one malformed step discards
+     * the whole response.
+     */
+    fun parseTransitSteps(body: String): List<TransitStep> {
+        val leg = firstRouteLegs(body)?.firstOrNull() as? JsonObject ?: return emptyList()
+        val steps = leg["steps"] as? JsonArray ?: return emptyList()
+        return steps.map { element ->
+            val step = element as? JsonObject ?: return emptyList()
+            val details = step.obj("transitDetails")
+            val ride = step.string("travelMode") == "TRANSIT"
+            TransitStep(
+                polyline = step.obj("polyline")?.string("encodedPolyline").orEmpty(),
+                distanceMeters = step.int("distanceMeters") ?: 0,
+                durationSeconds = step.string("staticDuration")?.let(::parseDuration) ?: 0,
+                // A ride is a ride even when Google does not say on what.
+                vehicle = if (ride) (details?.obj("transitLine")?.obj("vehicle")?.string("type") ?: "OTHER") else null,
+                departure = details?.obj("stopDetails")?.obj("departureStop")?.obj("location")?.latLng(),
+            )
+        }
+    }
+
     /** Durations are protobuf strings — seconds with optional fraction, then "s". */
     fun parseDuration(text: String): Int? =
         text.removeSuffix("s").toDoubleOrNull()?.roundToInt()
+
+    private fun firstRouteLegs(body: String): JsonArray? {
+        val root = runCatching { Json.parseToJsonElement(body) }.getOrNull() as? JsonObject
+        val routes = root?.get("routes") as? JsonArray ?: return null
+        return (routes.firstOrNull() as? JsonObject)?.get("legs") as? JsonArray
+    }
+
+    private fun JsonObject.obj(key: String): JsonObject? = this[key] as? JsonObject
 
     private fun JsonObject.string(key: String): String? =
         (this[key] as? JsonPrimitive)?.takeIf { it.isString }?.content?.takeIf { it.isNotBlank() }
 
     private fun JsonObject.int(key: String): Int? =
         (this[key] as? JsonPrimitive)?.takeIf { !it.isString }?.content?.toIntOrNull()
+
+    private fun JsonObject.double(key: String): Double? =
+        (this[key] as? JsonPrimitive)?.takeIf { !it.isString }?.content?.toDoubleOrNull()
+
+    private fun JsonObject.latLng(): LatLng? {
+        val latLng = obj("latLng") ?: return null
+        val lat = latLng.double("latitude") ?: return null
+        val lng = latLng.double("longitude") ?: return null
+        return LatLng(lat, lng)
+    }
 }

--- a/app/src/main/java/com/nuelto/etappli/domain/MapOverlay.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/MapOverlay.kt
@@ -24,6 +24,8 @@ data class MapRoute(
     val points: List<LatLng>,
     val accent: MapAccent,
     val dashed: Boolean,
+    // A ride to a stop no road reaches, drawn apart from the road: a cable car is not one.
+    val ride: Boolean = false,
 )
 
 /** How the camera should sit over a set of points. */
@@ -79,25 +81,38 @@ object MapOverlay {
             .filterNot { it.state == StopState.SKIPPED }
             .filter { it.location != null }
         if (located.size < 2) return@flatMap emptyList()
-        val leg = { stops: List<Stop>, accent: MapAccent, dashed: Boolean ->
-            MapRoute(entry.trip.id, path(stops), accent, dashed)
+        // The road through the stops, then any ride off it, in the same colour.
+        val section = { stops: List<Stop>, accent: MapAccent, dashed: Boolean ->
+            listOf(MapRoute(entry.trip.id, path(stops), accent, dashed)) +
+                rides(stops).map { MapRoute(entry.trip.id, it, accent, dashed = false, ride = true) }
         }
 
         when (entry.trip.status) {
-            TripStatus.DONE -> listOf(leg(located, MapAccent.DONE, false))
-            TripStatus.PLANNED -> listOf(leg(located, MapAccent.PLANNED, true))
+            TripStatus.DONE -> section(located, MapAccent.DONE, false)
+            TripStatus.PLANNED -> section(located, MapAccent.PLANNED, true)
             TripStatus.ACTIVE -> {
                 val done = located.filter { it.state == StopState.DONE }
                 val upcoming = located.filter { it.state == StopState.PLANNED }
                 buildList {
-                    if (done.size >= 2) add(leg(done, MapAccent.DONE, false))
+                    if (done.size >= 2) addAll(section(done, MapAccent.DONE, false))
                     if (done.isNotEmpty() && upcoming.isNotEmpty()) {
-                        add(leg(listOf(done.last(), upcoming.first()), MapAccent.CURRENT, false))
+                        addAll(section(listOf(done.last(), upcoming.first()), MapAccent.CURRENT, false))
                     }
-                    if (upcoming.size >= 2) add(leg(upcoming, MapAccent.PLANNED, true))
+                    if (upcoming.size >= 2) addAll(section(upcoming, MapAccent.PLANNED, true))
                 }
             }
         }
+    }
+
+    /**
+     * The rides either side of each drive whose stop no road reaches, as lines of their
+     * own: the road [path] ends where the vehicle is left, and the ride carries on to the pin.
+     */
+    private fun rides(stops: List<Stop>): List<List<LatLng>> = stops.zipWithNext().flatMap { (from, to) ->
+        val leg = RouteCache.usable(from, to) ?: return@flatMap emptyList()
+        listOfNotNull(leg.rideBefore, leg.rideAfter)
+            .map { Polyline.decode(it.polyline) }
+            .filter { it.size >= 2 }
     }
 
     /**

--- a/app/src/main/java/com/nuelto/etappli/domain/NewPlan.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/NewPlan.kt
@@ -1,0 +1,27 @@
+package com.nuelto.etappli.domain
+
+import com.nuelto.etappli.data.TripRepository
+import com.nuelto.etappli.data.model.Trip
+import com.nuelto.etappli.data.model.TripStatus
+import com.nuelto.etappli.data.model.UserSettings
+import java.time.LocalDate
+
+/**
+ * A plan made on the spot, with no form in the way: "Plan a tour" opens the stop editor.
+ * It has no name until its stops say where it goes (TripName), starts today until its
+ * first stop says when (the repositories re-date it), and sets out from home and comes
+ * back to it when a home is set (HomeStop). All of that can be edited afterwards.
+ */
+object NewPlan {
+
+    /** Returns the new plan's id. */
+    suspend fun create(
+        repository: TripRepository,
+        settings: UserSettings,
+        today: LocalDate = LocalDate.now(),
+    ): String {
+        val id = repository.upsertTrip(Trip(startDate = today, status = TripStatus.PLANNED))
+        HomeStop.forNewPlan(id, settings, today).forEach { repository.upsertStop(it) }
+        return id
+    }
+}

--- a/app/src/main/java/com/nuelto/etappli/domain/ParkAndRide.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/ParkAndRide.kt
@@ -1,0 +1,51 @@
+package com.nuelto.etappli.domain
+
+import com.nuelto.etappli.data.model.LatLng
+import com.nuelto.etappli.data.model.TransitRide
+
+/**
+ * Drive as far as the road goes, then ride: how a stop no road reaches — Riederalp, up its
+ * cable car — still gets a leg. Google routes by road and by public transport separately
+ * and has no park-and-ride mode, so the two are composed here: the transit route to the
+ * stop says where its last ride boards, and that is where the vehicle is left. The drives
+ * to and from that spot are then ordinary road legs (RouteRefresher).
+ */
+object ParkAndRide {
+
+    /** Rides back from the stop to try leaving the vehicle at, before giving it up as unreachable. */
+    const val MAX_ATTEMPTS = 3
+
+    /** Where the vehicle could be left, and the rest of the way from there. */
+    data class Candidate(val parked: LatLng, val steps: List<TransitStep>)
+
+    /**
+     * Nearest the stop first: the last ride's boarding point is the valley station, and
+     * each earlier one is only for when no road reaches the one after it — Zermatt's
+     * shuttle bus boards in a town no car may enter; the train before it boards in Täsch.
+     */
+    fun candidates(steps: List<TransitStep>): List<Candidate> =
+        steps.indices.reversed()
+            .filter { steps[it].departure != null }
+            .take(MAX_ATTEMPTS)
+            .map { Candidate(steps[it].departure!!, steps.subList(it, steps.size)) }
+
+    /** The rest of the way as one ride: joined geometry, summed numbers, the vehicles in words. */
+    fun ride(candidate: Candidate): TransitRide = TransitRide(
+        parked = candidate.parked,
+        polyline = Polyline.encode(candidate.steps.flatMap { Polyline.decode(it.polyline) }),
+        distanceMeters = candidate.steps.sumOf { it.distanceMeters },
+        durationSeconds = candidate.steps.sumOf { it.durationSeconds },
+        mode = candidate.steps.mapNotNull { it.vehicle }.map(::vehicleName).distinct().joinToString(" + "),
+    )
+
+    /** Google's vehicle types in plain words. */
+    fun vehicleName(type: String): String = when {
+        type == "GONDOLA_LIFT" || type == "CABLE_CAR" -> "cable car"
+        type == "FUNICULAR" -> "funicular"
+        type == "FERRY" -> "ferry"
+        type == "TRAM" -> "tram"
+        "BUS" in type || type == "SHARE_TAXI" -> "bus"
+        "RAIL" in type || "TRAIN" in type || type == "SUBWAY" -> "train"
+        else -> "transit"
+    }
+}

--- a/app/src/main/java/com/nuelto/etappli/domain/ParkAndRide.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/ParkAndRide.kt
@@ -2,6 +2,7 @@ package com.nuelto.etappli.domain
 
 import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.data.model.TransitRide
+import com.nuelto.etappli.data.model.TravelMode
 
 /**
  * Drive as far as the road goes, then ride: how a stop no road reaches — Riederalp, up its
@@ -29,23 +30,23 @@ object ParkAndRide {
             .take(MAX_ATTEMPTS)
             .map { Candidate(steps[it].departure!!, steps.subList(it, steps.size)) }
 
-    /** The rest of the way as one ride: joined geometry, summed numbers, the vehicles in words. */
+    /** The rest of the way as one ride: joined geometry, summed numbers, the vehicles boarded. */
     fun ride(candidate: Candidate): TransitRide = TransitRide(
         parked = candidate.parked,
         polyline = Polyline.encode(candidate.steps.flatMap { Polyline.decode(it.polyline) }),
         distanceMeters = candidate.steps.sumOf { it.distanceMeters },
         durationSeconds = candidate.steps.sumOf { it.durationSeconds },
-        mode = candidate.steps.mapNotNull { it.vehicle }.map(::vehicleName).distinct().joinToString(" + "),
+        modes = candidate.steps.mapNotNull { it.vehicle }.map(::mode).distinct(),
     )
 
-    /** Google's vehicle types in plain words. */
-    fun vehicleName(type: String): String = when {
-        type == "GONDOLA_LIFT" || type == "CABLE_CAR" -> "cable car"
-        type == "FUNICULAR" -> "funicular"
-        type == "FERRY" -> "ferry"
-        type == "TRAM" -> "tram"
-        "BUS" in type || type == "SHARE_TAXI" -> "bus"
-        "RAIL" in type || "TRAIN" in type || type == "SUBWAY" -> "train"
-        else -> "transit"
+    /** Google's vehicle types as what you board. */
+    fun mode(type: String): TravelMode = when {
+        type == "GONDOLA_LIFT" || type == "CABLE_CAR" -> TravelMode.CABLE_CAR
+        type == "FUNICULAR" -> TravelMode.FUNICULAR
+        type == "FERRY" -> TravelMode.FERRY
+        type == "TRAM" -> TravelMode.TRAM
+        "BUS" in type || type == "SHARE_TAXI" -> TravelMode.BUS
+        "RAIL" in type || "TRAIN" in type || type == "SUBWAY" -> TravelMode.TRAIN
+        else -> TravelMode.TRANSIT
     }
 }

--- a/app/src/main/java/com/nuelto/etappli/domain/Polyline.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/Polyline.kt
@@ -1,9 +1,10 @@
 package com.nuelto.etappli.domain
 
 import com.nuelto.etappli.data.model.LatLng
+import kotlin.math.roundToInt
 
 /**
- * Google's encoded polyline algorithm, decode half. Hand-rolled rather than pulled in
+ * Google's encoded polyline algorithm. Hand-rolled rather than pulled in
  * with `android-maps-utils`, which is not a dependency and whose `PolyUtil` would drag
  * the decode out of `domain/` — where it is covered and mutation-tested — into the
  * Android-only half of the app.
@@ -26,6 +27,30 @@ object Polyline {
             points += LatLng(lat / PRECISION, lng / PRECISION)
         }
         return points
+    }
+
+    /** The inverse of [decode], for joining several of Google's lines into one (ParkAndRide). */
+    fun encode(points: List<LatLng>): String = buildString {
+        var lat = 0
+        var lng = 0
+        points.forEach { point ->
+            val nextLat = (point.latitude * PRECISION).roundToInt()
+            val nextLng = (point.longitude * PRECISION).roundToInt()
+            chunk(nextLat - lat)
+            chunk(nextLng - lng)
+            lat = nextLat
+            lng = nextLng
+        }
+    }
+
+    /** One zig-zag-encoded delta, five bits a character, the continuation bit on all but the last. */
+    private fun StringBuilder.chunk(delta: Int) {
+        var value = if (delta < 0) (delta shl 1).inv() else delta shl 1
+        while (value >= 0x20) {
+            append(((0x20 or (value and 0x1f)) + 63).toChar())
+            value = value shr 5
+        }
+        append((value + 63).toChar())
     }
 
     /** One zig-zag-encoded delta at a time, so latitude and longitude share the reader. */

--- a/app/src/main/java/com/nuelto/etappli/domain/RegionResolver.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/RegionResolver.kt
@@ -1,0 +1,43 @@
+package com.nuelto.etappli.domain
+
+import com.nuelto.etappli.data.TripRepository
+import com.nuelto.etappli.data.model.LatLng
+import com.nuelto.etappli.data.model.Stop
+import com.nuelto.etappli.data.model.StopRegion
+import kotlinx.coroutines.flow.first
+
+/**
+ * Looks up which region each stop lies in, so the tour can be named after where it goes
+ * (TripName; the repositories denormalize the result onto Trip.region with the totals).
+ * Composed over the TripRepository interface like [RouteRefresher], and fail-soft the
+ * same way: a lookup that finds nothing — offline, no geocoder — leaves the stop alone,
+ * and the next time the trip is opened tries again.
+ */
+class RegionResolver(
+    private val tripRepository: TripRepository,
+    private val lookup: suspend (LatLng) -> StopRegion?,
+) {
+
+    /** Returns how many stops were written. */
+    suspend fun resolve(tripId: String): Int {
+        var resolved = 0
+        due(tripRepository.stops(tripId).first()).forEach { stale ->
+            val at = stale.location!! // due() keeps only located stops
+            val region = lookup(at) ?: return@forEach
+            // The lookup is a round trip, so re-read before writing: upsertStop replaces
+            // the whole document, and the stop may have been edited meanwhile — or moved,
+            // in which case this answer is for somewhere it no longer is.
+            val current = tripRepository.stops(tripId).first().find { it.id == stale.id } ?: return@forEach
+            if (current.location != at) return@forEach
+            tripRepository.upsertStop(current.copy(region = region.copy(at = at)))
+            resolved++
+        }
+        return resolved
+    }
+
+    companion object {
+        /** Located stops whose region is missing, or was looked up for another spot. */
+        fun due(stops: List<Stop>): List<Stop> =
+            stops.filter { it.location != null && it.region?.at != it.location }
+    }
+}

--- a/app/src/main/java/com/nuelto/etappli/domain/RouteRefresher.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/RouteRefresher.kt
@@ -5,6 +5,7 @@ import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.data.model.Stop
 import com.nuelto.etappli.data.model.StopElevation
 import com.nuelto.etappli.data.model.StopLeg
+import com.nuelto.etappli.data.model.TransitRide
 import java.time.LocalDate
 import kotlin.math.roundToInt
 import kotlinx.coroutines.flow.first
@@ -30,6 +31,9 @@ class RouteRefresher(
     // Null-returning by default: elevation is a second, optional service, and a leg
     // without a climb figure still draws and still costs.
     private val heights: suspend (points: List<LatLng>) -> List<Double>? = { null },
+    // Public transport to a stop no road reaches (ParkAndRide). Empty by default: without
+    // it such a stop is simply out of reach.
+    private val transit: suspend (from: LatLng, to: LatLng) -> List<TransitStep>? = { _, _ -> emptyList() },
 ) {
 
     suspend fun refresh(tripId: String, today: LocalDate = LocalDate.now()): Result {
@@ -50,20 +54,22 @@ class RouteRefresher(
 
         var fetched = 0
         drives.forEachIndexed { index, (from, to) ->
-            // Null where there is no road: written all the same, as a leg with no distance.
+            // No drive where there is no road: written all the same, as a leg with no distance.
             val routed = legs[index]
-            val climb = routed?.let { climb(it.polyline) }
+            val climb = routed.drive?.let { climb(it.polyline) }
             val leg = StopLeg(
                 // The coordinates the route was actually computed between. A stop edited
                 // while the request was in flight must invalidate this leg on the next
                 // pass, not quietly adopt it.
                 from = from.location!!,
                 to = to.location!!,
-                polyline = routed?.polyline.orEmpty(),
-                distanceMeters = routed?.distanceMeters ?: 0,
-                durationSeconds = routed?.durationSeconds ?: 0,
+                polyline = routed.drive?.polyline.orEmpty(),
+                distanceMeters = routed.drive?.distanceMeters ?: 0,
+                durationSeconds = routed.drive?.durationSeconds ?: 0,
                 ascentMeters = climb?.ascentMeters?.roundToInt(),
                 descentMeters = climb?.descentMeters?.roundToInt(),
+                rideBefore = routed.rideBefore,
+                rideAfter = routed.rideAfter,
                 fetchedAt = today,
             )
             if (write(tripId, to.id) { it.copy(leg = leg.keepingClimbOf(it.leg)) }) fetched++
@@ -126,29 +132,60 @@ class RouteRefresher(
         return true
     }
 
+    /** One drive as fetched: the road, and the rides either side of it; no road at all when [drive] is null. */
+    private class Routed(
+        val drive: RoutedLeg?,
+        val rideBefore: TransitRide? = null,
+        val rideAfter: TransitRide? = null,
+    )
+
     /**
-     * One entry per drive, null where Google found no road. A stop it cannot drive to —
-     * Riederalp is car-free — empties the whole window's answer, so such a window is then
-     * asked drive by drive to keep the roads the other drives do have. Null altogether on
-     * the first call that fails, so a half-routed trip is never written.
+     * One entry per drive. A stop Google cannot drive to — Riederalp is car-free — empties
+     * the whole window's answer, so such a window is then asked drive by drive, and the
+     * drive that has no road goes [ParkAndRide]. Null altogether on the first call that
+     * fails, so a half-routed trip is never written.
      */
-    private suspend fun fetchAll(points: List<LatLng>): List<RoutedLeg?>? {
-        val legs = mutableListOf<RoutedLeg?>()
+    private suspend fun fetchAll(points: List<LatLng>): List<Routed>? {
+        val legs = mutableListOf<Routed>()
+        // The ride up to the stop before, when no road reached it: the next drive sets out
+        // from where the vehicle was left, not from the stop.
+        var parked: TransitRide? = null
         GoogleRoutes.windows(points).forEach { window ->
-            val fetched = route(window) ?: return null
+            // Not worth asking for whole when it would set out from a stop no road reaches.
+            val fetched = if (parked == null) route(window) ?: return null else null
             when {
-                fetched.size == window.size - 1 -> legs += fetched
+                fetched != null && fetched.size == window.size - 1 -> legs += fetched.map { Routed(it) }
                 // One leg per pair, or the response cannot be lined up with the stops.
-                fetched.isNotEmpty() -> return null
+                fetched != null && fetched.isNotEmpty() -> return null
                 else -> window.zipWithNext().forEach { (from, to) ->
+                    val origin = parked?.parked ?: from
                     // A two-point window already was that one drive: no need to ask twice.
-                    val pair = if (window.size == 2) fetched else (route(listOf(from, to)) ?: return null)
-                    if (pair.size > 1) return null
-                    legs += pair.firstOrNull()
+                    val direct = fetched?.takeIf { window.size == 2 }
+                        ?: (route(listOf(origin, to)) ?: return null)
+                    if (direct.size > 1) return null
+                    val routed = direct.firstOrNull()?.let { Routed(it, rideBefore = parked) }
+                        ?: parkAndRide(origin, to, rideBefore = parked)
+                        ?: return null
+                    legs += routed
+                    parked = routed.rideAfter
                 }
             }
         }
         return legs
+    }
+
+    /**
+     * The drive to a stop no road reaches: by road to where its last ride boards, then the
+     * ride — or one ride further back when no road reaches that either. Null when a call
+     * failed; a [Routed] with no drive when there is no way at all.
+     */
+    private suspend fun parkAndRide(origin: LatLng, to: LatLng, rideBefore: TransitRide?): Routed? {
+        val steps = transit(origin, to) ?: return null
+        ParkAndRide.candidates(steps).forEach { candidate ->
+            val drive = route(listOf(origin, candidate.parked)) ?: return null
+            drive.singleOrNull()?.let { return Routed(it, rideBefore, ParkAndRide.ride(candidate)) }
+        }
+        return Routed(null, rideBefore)
     }
 
     private suspend fun climb(polyline: String): Climb? {

--- a/app/src/main/java/com/nuelto/etappli/domain/RouteRefresher.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/RouteRefresher.kt
@@ -50,16 +50,18 @@ class RouteRefresher(
 
         var fetched = 0
         drives.forEachIndexed { index, (from, to) ->
-            val climb = climb(legs[index].polyline)
+            // Null where there is no road: written all the same, as a leg with no distance.
+            val routed = legs[index]
+            val climb = routed?.let { climb(it.polyline) }
             val leg = StopLeg(
                 // The coordinates the route was actually computed between. A stop edited
                 // while the request was in flight must invalidate this leg on the next
                 // pass, not quietly adopt it.
                 from = from.location!!,
                 to = to.location!!,
-                polyline = legs[index].polyline,
-                distanceMeters = legs[index].distanceMeters,
-                durationSeconds = legs[index].durationSeconds,
+                polyline = routed?.polyline.orEmpty(),
+                distanceMeters = routed?.distanceMeters ?: 0,
+                durationSeconds = routed?.durationSeconds ?: 0,
                 ascentMeters = climb?.ascentMeters?.roundToInt(),
                 descentMeters = climb?.descentMeters?.roundToInt(),
                 fetchedAt = today,
@@ -92,9 +94,10 @@ class RouteRefresher(
      * A failed elevation call must not erase a climb already measured for the same drive.
      * [RouteCache.needsFetch] only asks whether a leg exists, so a leg written with a null
      * climb is never revisited — the figure would be gone until the stop moved again.
+     * A drive that has lost its road keeps nothing: there is no road to have climbed.
      */
     private fun StopLeg.keepingClimbOf(stored: StopLeg?): StopLeg {
-        if (ascentMeters != null) return this
+        if (ascentMeters != null || !hasRoad) return this
         val measured = stored?.takeIf { it.from == from && it.to == to } ?: return this
         return copy(ascentMeters = measured.ascentMeters, descentMeters = measured.descentMeters)
     }
@@ -123,14 +126,27 @@ class RouteRefresher(
         return true
     }
 
-    /** Null on the first window that fails, so a half-routed trip is never written. */
-    private suspend fun fetchAll(points: List<LatLng>): List<RoutedLeg>? {
-        val legs = mutableListOf<RoutedLeg>()
+    /**
+     * One entry per drive, null where Google found no road. A stop it cannot drive to —
+     * Riederalp is car-free — empties the whole window's answer, so such a window is then
+     * asked drive by drive to keep the roads the other drives do have. Null altogether on
+     * the first call that fails, so a half-routed trip is never written.
+     */
+    private suspend fun fetchAll(points: List<LatLng>): List<RoutedLeg?>? {
+        val legs = mutableListOf<RoutedLeg?>()
         GoogleRoutes.windows(points).forEach { window ->
             val fetched = route(window) ?: return null
-            // One leg per pair, or the response cannot be lined up with the stops.
-            if (fetched.size != window.size - 1) return null
-            legs += fetched
+            when {
+                fetched.size == window.size - 1 -> legs += fetched
+                // One leg per pair, or the response cannot be lined up with the stops.
+                fetched.isNotEmpty() -> return null
+                else -> window.zipWithNext().forEach { (from, to) ->
+                    // A two-point window already was that one drive: no need to ask twice.
+                    val pair = if (window.size == 2) fetched else (route(listOf(from, to)) ?: return null)
+                    if (pair.size > 1) return null
+                    legs += pair.firstOrNull()
+                }
+            }
         }
         return legs
     }

--- a/app/src/main/java/com/nuelto/etappli/domain/TripName.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/TripName.kt
@@ -1,0 +1,59 @@
+package com.nuelto.etappli.domain
+
+import com.nuelto.etappli.data.model.Stop
+import com.nuelto.etappli.data.model.StopKind
+import com.nuelto.etappli.data.model.StopState
+import com.nuelto.etappli.data.model.Trip
+
+/**
+ * A tour does not need a name: it is called after where it goes, and until it goes
+ * anywhere by a name made up from its id — the same one every time, so the list does
+ * not shuffle, and never stored, so the stops take over the moment there are any.
+ */
+object TripName {
+
+    private const val MAX_PARTS = 3
+
+    /**
+     * "Ticino", "Ticino & Graubünden", "Ticino, Graubünden & Valais": the regions the
+     * stops lie in, in the order they are visited. More than three fall back to the
+     * countries, and more than three of those end in "& more". Home is where every tour
+     * starts, so it never names one; skipped stops were not visited.
+     */
+    fun region(stops: List<Stop>): String {
+        val regions = stops
+            .filterNot { it.state == StopState.SKIPPED || it.kind == StopKind.HOME }
+            .sortedBy { it.orderIndex }
+            .mapNotNull { it.region }
+        val names = regions.map { it.name.ifBlank { it.country } }.filter { it.isNotBlank() }.distinct()
+        if (names.size <= MAX_PARTS) return join(names)
+        val coarse = regions.map { it.country }.filter { it.isNotBlank() }.distinct().ifEmpty { names }
+        return join(coarse.take(MAX_PARTS), more = coarse.size > MAX_PARTS)
+    }
+
+    private fun join(parts: List<String>, more: Boolean = false): String = when {
+        parts.isEmpty() -> ""
+        more -> parts.joinToString(", ") + " & more"
+        parts.size == 1 -> parts.single()
+        else -> parts.dropLast(1).joinToString(", ") + " & " + parts.last()
+    }
+
+    /** A name for a tour that goes nowhere yet, the same one every time for the same id. */
+    fun generated(id: String): String {
+        val hash = id.hashCode()
+        return "${ADJECTIVES[hash.mod(ADJECTIVES.size)]} ${NOUNS[(hash shr 4).mod(NOUNS.size)]}"
+    }
+
+    private val ADJECTIVES = listOf(
+        "Curious", "Quiet", "Lazy", "Sunny", "Windy", "Wandering", "Restless", "Sleepy",
+        "Golden", "Misty", "Hungry", "Brave", "Gentle", "Rusty", "Dusty", "Merry",
+    )
+    private val NOUNS = listOf(
+        "Marmot", "Ibex", "Chamois", "Edelweiss", "Glacier", "Larch", "Meadow", "Ridge",
+        "Heron", "Fox", "Otter", "Lynx", "Pine", "Comet", "Lantern", "Kettle",
+    )
+}
+
+/** What a trip is called: its own name, else where it goes, else a made-up one. */
+val Trip.title: String
+    get() = name.ifBlank { region.ifBlank { TripName.generated(id) } }

--- a/app/src/main/java/com/nuelto/etappli/location/PlaceNameResolver.kt
+++ b/app/src/main/java/com/nuelto/etappli/location/PlaceNameResolver.kt
@@ -5,6 +5,7 @@ import android.location.Address
 import android.location.Geocoder
 import android.os.Build
 import com.nuelto.etappli.data.model.LatLng
+import com.nuelto.etappli.data.model.StopRegion
 import java.util.Locale
 import kotlin.coroutines.resume
 import kotlinx.coroutines.Dispatchers
@@ -13,16 +14,30 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 
 /**
- * Reverse-geocodes a coordinate to the nearest village/city name using the platform
- * Geocoder (Play-services backed, no API key). Returns null when the geocoder is
- * unavailable, offline, or finds nothing.
+ * Reverse-geocodes a coordinate using the platform Geocoder (Play-services backed, no
+ * API key). Returns null when the geocoder is unavailable, offline, or finds nothing.
  */
 open class PlaceNameResolver(private val context: Context) {
 
+    /** The nearest village/city name, falling back to progressively coarser admin names. */
     open suspend fun placeName(location: LatLng): String? {
+        val address = address(location) ?: return null
+        return address.locality
+            ?: address.subLocality
+            ?: address.subAdminArea
+            ?: address.adminArea
+    }
+
+    /** The canton, province or state a coordinate lies in, and its country — what names a tour. */
+    open suspend fun region(location: LatLng): StopRegion? {
+        val address = address(location) ?: return null
+        return StopRegion(location, address.adminArea.orEmpty(), address.countryName.orEmpty())
+    }
+
+    private suspend fun address(location: LatLng): Address? {
         if (!Geocoder.isPresent()) return null
         val geocoder = Geocoder(context, Locale.getDefault())
-        val address = withTimeoutOrNull(10_000) {
+        return withTimeoutOrNull(10_000) {
             if (Build.VERSION.SDK_INT >= 33) {
                 suspendCancellableCoroutine<Address?> { cont ->
                     geocoder.getFromLocation(
@@ -48,11 +63,6 @@ open class PlaceNameResolver(private val context: Context) {
                     }.getOrNull()?.firstOrNull()
                 }
             }
-        } ?: return null
-        // Prefer the village/city; fall back to progressively coarser admin names.
-        return address.locality
-            ?: address.subLocality
-            ?: address.subAdminArea
-            ?: address.adminArea
+        }
     }
 }

--- a/app/src/main/java/com/nuelto/etappli/location/RouteServices.kt
+++ b/app/src/main/java/com/nuelto/etappli/location/RouteServices.kt
@@ -5,6 +5,7 @@ import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.domain.Elevation
 import com.nuelto.etappli.domain.GoogleRoutes
 import com.nuelto.etappli.domain.RoutedLeg
+import com.nuelto.etappli.domain.TransitStep
 import java.net.HttpURLConnection
 import java.net.URL
 import kotlinx.coroutines.Dispatchers
@@ -22,16 +23,17 @@ class GoogleRoutesService(private val apiKey: String = BuildConfig.MAPS_API_KEY)
 
     /** One leg per pair of consecutive points, or null if the call did not come back. */
     suspend fun legs(points: List<LatLng>): List<RoutedLeg>? = withContext(Dispatchers.IO) {
-        val body = post(
-            url = GoogleRoutes.COMPUTE_ROUTES_URL,
-            body = GoogleRoutes.computeRoutesBody(points),
-            headers = mapOf(
-                "X-Goog-Api-Key" to apiKey,
-                "X-Goog-FieldMask" to GoogleRoutes.FIELD_MASK,
-            ),
-        )
-        body?.let(GoogleRoutes::parseLegs)
+        post(GoogleRoutes.COMPUTE_ROUTES_URL, GoogleRoutes.computeRoutesBody(points), headers(GoogleRoutes.FIELD_MASK))
+            ?.let(GoogleRoutes::parseLegs)
     }
+
+    /** The steps of a public-transport route — empty when there is none, null if the call did not come back. */
+    suspend fun transit(from: LatLng, to: LatLng): List<TransitStep>? = withContext(Dispatchers.IO) {
+        post(GoogleRoutes.COMPUTE_ROUTES_URL, GoogleRoutes.transitBody(from, to), headers(GoogleRoutes.TRANSIT_FIELD_MASK))
+            ?.let(GoogleRoutes::parseTransitSteps)
+    }
+
+    private fun headers(fieldMask: String) = mapOf("X-Goog-Api-Key" to apiKey, "X-Goog-FieldMask" to fieldMask)
 }
 
 /**

--- a/app/src/main/java/com/nuelto/etappli/ui/Format.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/Format.kt
@@ -49,10 +49,12 @@ fun formatDuration(seconds: Int): String {
 /**
  * The drive that arrives at a stop: "124 km · 1 h 45 min". Deliberately not the leg's
  * climb — cumulative ascent next to a place name reads as the height of the place, which
- * is a different number and the one people actually want.
+ * is a different number and the one people actually want. Says so when there is no road:
+ * the map draws a straight hop there, and this is the only place that explains why.
  */
 fun formatDrive(leg: StopLeg): String =
-    "${formatDistance(leg.distanceMeters)} · ${formatDuration(leg.durationSeconds)}"
+    if (!leg.hasRoad) "No drivable route"
+    else "${formatDistance(leg.distanceMeters)} · ${formatDuration(leg.durationSeconds)}"
 
 private val timeFormatter: DateTimeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
 

--- a/app/src/main/java/com/nuelto/etappli/ui/Format.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/Format.kt
@@ -1,6 +1,7 @@
 package com.nuelto.etappli.ui
 
 import com.nuelto.etappli.data.model.StopLeg
+import com.nuelto.etappli.data.model.TransitRide
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
 import java.text.NumberFormat
@@ -49,12 +50,20 @@ fun formatDuration(seconds: Int): String {
 /**
  * The drive that arrives at a stop: "124 km · 1 h 45 min". Deliberately not the leg's
  * climb — cumulative ascent next to a place name reads as the height of the place, which
- * is a different number and the one people actually want. Says so when there is no road:
- * the map draws a straight hop there, and this is the only place that explains why.
+ * is a different number and the one people actually want. A ride either side of the road
+ * is spelled out ("+ cable car 24 min"), and when there is no way at all it says so: the
+ * map draws a straight hop there, and this is the only place that explains why.
  */
 fun formatDrive(leg: StopLeg): String =
     if (!leg.hasRoad) "No drivable route"
-    else "${formatDistance(leg.distanceMeters)} · ${formatDuration(leg.durationSeconds)}"
+    else listOfNotNull(
+        leg.rideBefore?.let(::formatRide),
+        "${formatDistance(leg.distanceMeters)} · ${formatDuration(leg.durationSeconds)}",
+        leg.rideAfter?.let(::formatRide),
+    ).joinToString(" + ")
+
+/** A ride to a stop no road reaches: "cable car 24 min". */
+fun formatRide(ride: TransitRide): String = "${ride.mode} ${formatDuration(ride.durationSeconds)}"
 
 private val timeFormatter: DateTimeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
 

--- a/app/src/main/java/com/nuelto/etappli/ui/Format.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/Format.kt
@@ -2,6 +2,7 @@ package com.nuelto.etappli.ui
 
 import com.nuelto.etappli.data.model.StopLeg
 import com.nuelto.etappli.data.model.TransitRide
+import com.nuelto.etappli.data.model.TravelMode
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
 import java.text.NumberFormat
@@ -47,23 +48,29 @@ fun formatDuration(seconds: Int): String {
     }
 }
 
-/**
- * The drive that arrives at a stop: "124 km · 1 h 45 min". Deliberately not the leg's
- * climb — cumulative ascent next to a place name reads as the height of the place, which
- * is a different number and the one people actually want. A ride either side of the road
- * is spelled out ("+ cable car 24 min"), and when there is no way at all it says so: the
- * map draws a straight hop there, and this is the only place that explains why.
- */
-fun formatDrive(leg: StopLeg): String =
-    if (!leg.hasRoad) "No drivable route"
-    else listOfNotNull(
-        leg.rideBefore?.let(::formatRide),
-        "${formatDistance(leg.distanceMeters)} · ${formatDuration(leg.durationSeconds)}",
-        leg.rideAfter?.let(::formatRide),
-    ).joinToString(" + ")
+/** One piece of the line under a stop: what you are on, and how far or how long. */
+data class DrivePart(val modes: List<TravelMode>, val text: String)
 
-/** A ride to a stop no road reaches: "cable car 24 min". */
-fun formatRide(ride: TransitRide): String = "${ride.mode} ${formatDuration(ride.durationSeconds)}"
+/**
+ * The drive that arrives at a stop, piece by piece: the car with "124 km · 1 h 45 min",
+ * and a ride either side of the road with its minutes. Deliberately not the leg's climb —
+ * cumulative ascent next to a place name reads as the height of the place, which is a
+ * different number and the one people actually want. When there is no way at all it says
+ * so: the map draws a straight hop there, and this is the only place that explains why.
+ */
+fun driveParts(leg: StopLeg): List<DrivePart> {
+    val car = listOf(TravelMode.CAR)
+    if (!leg.hasRoad) return listOf(DrivePart(car, "No drivable route"))
+    return listOfNotNull(
+        leg.rideBefore?.let(::ridePart),
+        DrivePart(car, "${formatDistance(leg.distanceMeters)} · ${formatDuration(leg.durationSeconds)}"),
+        leg.rideAfter?.let(::ridePart),
+    )
+}
+
+/** A ride that does not say what it is on still gets an icon: the generic one. */
+private fun ridePart(ride: TransitRide) =
+    DrivePart(ride.modes.ifEmpty { listOf(TravelMode.TRANSIT) }, formatDuration(ride.durationSeconds))
 
 private val timeFormatter: DateTimeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
 

--- a/app/src/main/java/com/nuelto/etappli/ui/components/TravelIcons.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/components/TravelIcons.kt
@@ -1,0 +1,64 @@
+package com.nuelto.etappli.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DirectionsBoat
+import androidx.compose.material.icons.filled.DirectionsBus
+import androidx.compose.material.icons.filled.DirectionsCar
+import androidx.compose.material.icons.filled.DirectionsRailway
+import androidx.compose.material.icons.filled.DirectionsTransit
+import androidx.compose.material.icons.filled.Train
+import androidx.compose.material.icons.filled.Tram
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import com.nuelto.etappli.data.model.TravelMode
+
+/** The icon for what you travel on, in the filled style the stop kinds use. */
+fun modeIcon(mode: TravelMode): ImageVector = when (mode) {
+    TravelMode.CAR -> Icons.Default.DirectionsCar
+    TravelMode.CABLE_CAR -> CableCar
+    TravelMode.FUNICULAR -> Icons.Default.DirectionsRailway
+    TravelMode.FERRY -> Icons.Default.DirectionsBoat
+    TravelMode.TRAM -> Icons.Default.Tram
+    TravelMode.BUS -> Icons.Default.DirectionsBus
+    TravelMode.TRAIN -> Icons.Default.Train
+    TravelMode.TRANSIT -> Icons.Default.DirectionsTransit
+}
+
+/**
+ * A gondola on its cable — the icon set has none. Same 24-unit canvas and filled style as
+ * the Material icons it sits beside, so it tints and scales like them.
+ */
+val CableCar: ImageVector by lazy {
+    ImageVector.Builder("CableCar", 24.dp, 24.dp, 24f, 24f).apply {
+        // The cable, rising left to right, and the hanger down to the cabin.
+        path(stroke = SolidColor(Color.Black), strokeLineWidth = 1.5f, strokeLineCap = StrokeCap.Round) {
+            moveTo(2f, 8f)
+            lineTo(22f, 4f)
+            moveTo(12f, 6f)
+            lineTo(12f, 10f)
+        }
+        // The cabin, with two windows cut out.
+        path(fill = SolidColor(Color.Black), pathFillType = PathFillType.EvenOdd) {
+            moveTo(7f, 10f)
+            lineTo(17f, 10f)
+            lineTo(18f, 20f)
+            lineTo(6f, 20f)
+            close()
+            moveTo(8.5f, 12f)
+            lineTo(11.5f, 12f)
+            lineTo(11.5f, 15.5f)
+            lineTo(8.5f, 15.5f)
+            close()
+            moveTo(12.5f, 12f)
+            lineTo(15.5f, 12f)
+            lineTo(15.5f, 15.5f)
+            lineTo(12.5f, 15.5f)
+            close()
+        }
+    }.build()
+}

--- a/app/src/main/java/com/nuelto/etappli/ui/map/AllTripsMapScreen.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/map/AllTripsMapScreen.kt
@@ -41,6 +41,7 @@ import com.nuelto.etappli.domain.TripMapData
 import com.nuelto.etappli.domain.CurrentStop
 import com.nuelto.etappli.domain.EstimateBreakdown
 import com.nuelto.etappli.domain.TripEstimator
+import com.nuelto.etappli.domain.title
 import com.nuelto.etappli.ui.formatCurrency
 import com.nuelto.etappli.ui.formatDate
 import java.time.LocalDate
@@ -121,7 +122,7 @@ fun AllTripsMapScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(if (tripId == null) "All trips" else shown.firstOrNull()?.trip?.name ?: "Trip") },
+                title = { Text(if (tripId == null) "All trips" else shown.firstOrNull()?.trip?.title ?: "Trip") },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
@@ -149,7 +150,7 @@ fun AllTripsMapScreen(
                         .padding(16.dp),
                 ) {
                     Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                        Text(entry.trip.name, style = MaterialTheme.typography.titleMedium)
+                        Text(entry.trip.title, style = MaterialTheme.typography.titleMedium)
                         Text(
                             "${stop.name} · ${formatDate(stop.arrivalDate)} · " +
                                 (if (stop.nights == 1) "1 night" else "${stop.nights} nights"),

--- a/app/src/main/java/com/nuelto/etappli/ui/map/GoogleMapProvider.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/map/GoogleMapProvider.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.dp
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.Dash
+import com.google.android.gms.maps.model.Dot
 import com.google.android.gms.maps.model.Gap
 import com.google.android.gms.maps.model.LatLngBounds
 import com.google.maps.android.compose.CameraPositionState
@@ -63,7 +64,7 @@ object GoogleMapProvider : MapProvider {
     override fun routeRefresher(tripRepository: TripRepository): RouteRefresher {
         val routes = GoogleRoutesService()
         val elevation = ElevationService()
-        return RouteRefresher(tripRepository, routes::legs, elevation::heights)
+        return RouteRefresher(tripRepository, routes::legs, elevation::heights, routes::transit)
     }
 
     override fun placeCacheSweeper(tripRepository: TripRepository): PlaceCacheSweeper {
@@ -114,9 +115,14 @@ object GoogleMapProvider : MapProvider {
                 Polyline(
                     points = route.points.map { it.gms() },
                     color = accentColor(route.accent).copy(alpha = 0.7f),
-                    width = 8f,
-                    // Google has no data-driven dash expression; a pattern list is the equivalent.
-                    pattern = if (route.dashed) listOf(Dash(20f), Gap(10f)) else null,
+                    width = if (route.ride) 5f else 8f,
+                    // Google has no data-driven dash expression; a pattern list is the
+                    // equivalent. A ride is dotted: it is not a road.
+                    pattern = when {
+                        route.ride -> listOf(Dot(), Gap(8f))
+                        route.dashed -> listOf(Dash(20f), Gap(10f))
+                        else -> null
+                    },
                 )
             }
             markers.forEach { marker ->

--- a/app/src/main/java/com/nuelto/etappli/ui/nav/AppNavHost.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/nav/AppNavHost.kt
@@ -9,7 +9,6 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.toRoute
 import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.data.model.StopKind
@@ -49,7 +48,12 @@ fun AppNavHost(pending: SharedPlace? = null, onPendingConsumed: () -> Unit = {})
         composable<TripListRoute> {
             TripListScreen(
                 onTripClick = { tripId -> navController.navigate(TripDetailRoute(tripId)) },
-                onAddTrip = { planned -> navController.navigate(TripEditRoute(planned = planned)) },
+                onLogTrip = { navController.navigate(TripEditRoute()) },
+                // A tour is planned by adding its first stop: the editor opens over its timeline.
+                onTourPlanned = { tripId ->
+                    navController.navigate(TripDetailRoute(tripId))
+                    navController.navigate(StopEditRoute(tripId))
+                },
                 onOpenMap = { navController.navigate(AllTripsMapRoute()) },
                 onOpenSettings = { navController.navigate(SettingsRoute) },
             )
@@ -71,19 +75,14 @@ fun AppNavHost(pending: SharedPlace? = null, onPendingConsumed: () -> Unit = {})
             TripEditScreen(
                 onBack = { navController.popBackStack() },
                 onSaved = { tripId, isNew ->
-                    // A tour planned to hold a shared place goes back to the chooser,
-                    // which now lists it; anything else opens the new trip.
-                    val fromChooser = navController.previousBackStackEntry
-                        ?.destination?.hasRoute<AddToTripRoute>() == true
                     navController.popBackStack()
-                    if (isNew && !fromChooser) navController.navigate(TripDetailRoute(tripId))
+                    if (isNew) navController.navigate(TripDetailRoute(tripId))
                 },
             )
         }
         composable<AddToTripRoute> {
             AddToTripScreen(
                 onCancel = { navController.popBackStack() },
-                onPlanTrip = { navController.navigate(TripEditRoute(planned = true)) },
                 onAddTo = navController::addToTrip,
             )
         }

--- a/app/src/main/java/com/nuelto/etappli/ui/nav/Routes.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/nav/Routes.kt
@@ -9,7 +9,7 @@ object TripListRoute
 data class TripDetailRoute(val tripId: String)
 
 @Serializable
-data class TripEditRoute(val tripId: String? = null, val planned: Boolean = false)
+data class TripEditRoute(val tripId: String? = null)
 
 /**
  * [insertBefore] is the timeline row key a new stop goes in front of; null appends.

--- a/app/src/main/java/com/nuelto/etappli/ui/share/AddToTripScreen.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/share/AddToTripScreen.kt
@@ -35,18 +35,19 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
 import com.nuelto.etappli.domain.SharedPlace
+import com.nuelto.etappli.domain.title
 import com.nuelto.etappli.ui.formatTripDates
 import com.nuelto.etappli.ui.theme.statusColor
 
 /**
  * Where a place shared from Google Maps lands: name it, then pick the trip it belongs
- * to. Choosing one opens the stop editor on that trip with the place already filled in.
+ * to. Choosing one opens the stop editor on that trip with the place already filled in;
+ * with no trip to choose, "Plan a tour" makes one and does the same.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddToTripScreen(
     onCancel: () -> Unit,
-    onPlanTrip: () -> Unit,
     onAddTo: (tripId: String, place: SharedPlace) -> Unit,
     viewModel: AddToTripViewModel = viewModel(factory = AddToTripViewModel.Factory),
 ) {
@@ -110,7 +111,9 @@ fun AddToTripScreen(
                                 style = MaterialTheme.typography.bodyLarge,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
-                            Button(onClick = onPlanTrip) { Text("Plan a tour") }
+                            Button(onClick = { viewModel.planTour { onAddTo(it, state.place) } }) {
+                                Text("Plan a tour")
+                            }
                         }
                     }
                 }
@@ -152,7 +155,7 @@ private fun LazyListScope.tripSection(
         ) {
             Column(Modifier.padding(16.dp)) {
                 Text(
-                    trip.name,
+                    trip.title,
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.SemiBold,
                 )

--- a/app/src/main/java/com/nuelto/etappli/ui/share/AddToTripViewModel.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/share/AddToTripViewModel.kt
@@ -5,14 +5,17 @@ import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.nuelto.etappli.containerViewModelFactory
+import com.nuelto.etappli.data.SettingsRepository
 import com.nuelto.etappli.data.TripRepository
 import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
+import com.nuelto.etappli.domain.NewPlan
 import com.nuelto.etappli.domain.SharedPlace
 import com.nuelto.etappli.ui.nav.AddToTripRoute
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
@@ -37,11 +40,12 @@ data class AddToTripUiState(
 /**
  * The chooser a shared place lands on: which trip does this belong to? Everything about
  * the place is already parsed — the only work here is following a short link, whose
- * coordinate sits behind a redirect.
+ * coordinate sits behind a redirect, and planning a tour for the place when there is none.
  */
 class AddToTripViewModel(
     place: SharedPlace,
-    tripRepository: TripRepository,
+    private val tripRepository: TripRepository,
+    private val settingsRepository: SettingsRepository,
     private val expandLink: suspend (String) -> String? = { null },
 ) : ViewModel() {
 
@@ -77,11 +81,28 @@ class AddToTripViewModel(
         }
     }
 
+    // A double-tap must not mint two tours.
+    private var planning = false
+
+    /** A tour planned on the spot for the place (domain/NewPlan); [onCreated] gets its id. */
+    fun planTour(onCreated: (String) -> Unit) {
+        if (planning) return
+        planning = true
+        viewModelScope.launch {
+            try {
+                onCreated(NewPlan.create(tripRepository, settingsRepository.settings().first()))
+            } finally {
+                planning = false
+            }
+        }
+    }
+
     companion object {
         val Factory = containerViewModelFactory { container ->
             AddToTripViewModel(
                 createSavedStateHandle().toRoute<AddToTripRoute>().sharedPlace(),
                 container.tripRepository,
+                container.settingsRepository,
                 container.expandShareLink,
             )
         }

--- a/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreen.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreen.kt
@@ -125,7 +125,8 @@ import com.nuelto.etappli.ui.components.rememberReorderState
 import com.nuelto.etappli.ui.components.reorderable
 import com.nuelto.etappli.ui.formatCurrency
 import com.nuelto.etappli.ui.formatDate
-import com.nuelto.etappli.ui.formatDrive
+import com.nuelto.etappli.ui.driveParts
+import com.nuelto.etappli.ui.components.modeIcon
 import com.nuelto.etappli.ui.tripedit.displayName
 import com.nuelto.etappli.ui.formatTripDates
 import com.nuelto.etappli.ui.map.TripMap
@@ -862,16 +863,23 @@ private fun TimelineStopRow(
 
 /**
  * How far and how long the drive to this stop is, as Google routed it — or that there is
- * none. Absent until the route has been fetched, and while a stop edit has outdated it.
+ * none — with an icon for what you are on: the car, and a ride's vehicle either side of
+ * it. Absent until the route has been fetched, and while a stop edit has outdated it.
  */
 @Composable
 private fun DriveLine(leg: StopLeg?) {
     if (leg == null) return
-    Text(
-        "\u2192 ${formatDrive(leg)}",
-        style = MaterialTheme.typography.labelSmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-    )
+    val color = MaterialTheme.colorScheme.onSurfaceVariant
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        driveParts(leg).forEach { part ->
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(3.dp)) {
+                part.modes.forEach { mode ->
+                    Icon(modeIcon(mode), contentDescription = mode.label, modifier = Modifier.size(14.dp), tint = color)
+                }
+                Text(part.text, style = MaterialTheme.typography.labelSmall, color = color)
+            }
+        }
+    }
 }
 
 /**

--- a/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreen.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreen.kt
@@ -861,8 +861,8 @@ private fun TimelineStopRow(
 }
 
 /**
- * How far and how long the drive to this stop is, as Google routed it. Absent until the
- * route has been fetched, and while a stop edit has outdated it.
+ * How far and how long the drive to this stop is, as Google routed it — or that there is
+ * none. Absent until the route has been fetched, and while a stop edit has outdated it.
  */
 @Composable
 private fun DriveLine(leg: StopLeg?) {

--- a/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreen.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreen.kt
@@ -116,6 +116,7 @@ import com.nuelto.etappli.domain.GapRow
 import com.nuelto.etappli.domain.HomeStop
 import com.nuelto.etappli.domain.StopRow
 import com.nuelto.etappli.domain.TripEstimator
+import com.nuelto.etappli.domain.title
 import com.nuelto.etappli.ui.components.DecimalField
 import com.nuelto.etappli.ui.components.DateField
 import com.nuelto.etappli.ui.components.StatusBadge
@@ -225,7 +226,7 @@ fun TripDetailScreen(
                 title = {
                     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                         Text(
-                            trip?.name ?: "",
+                            trip?.title ?: "",
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
                             modifier = Modifier.weight(1f, fill = false),
@@ -528,7 +529,7 @@ fun TripDetailScreen(
         AlertDialog(
             onDismissRequest = { showDeleteDialog = false },
             title = { Text("Delete trip?") },
-            text = { Text("\"${trip.name}\" and all its stops and expenses will be deleted.") },
+            text = { Text("\"${trip.title}\" and all its stops and expenses will be deleted.") },
             confirmButton = {
                 TextButton(onClick = {
                     showDeleteDialog = false

--- a/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailViewModel.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailViewModel.kt
@@ -2,6 +2,7 @@ package com.nuelto.etappli.ui.tripdetail
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
@@ -29,6 +30,7 @@ import com.nuelto.etappli.domain.FuelEstimator
 import com.nuelto.etappli.domain.GapRow
 import com.nuelto.etappli.domain.StopRow
 import com.nuelto.etappli.domain.PlaceCacheSweeper
+import com.nuelto.etappli.domain.RegionResolver
 import com.nuelto.etappli.domain.RouteCache
 import com.nuelto.etappli.domain.RouteRefresher
 import com.nuelto.etappli.domain.Timeline
@@ -36,6 +38,7 @@ import com.nuelto.etappli.domain.TimelineRow
 import com.nuelto.etappli.domain.TripEstimator
 import com.nuelto.etappli.domain.TripStarter
 import com.nuelto.etappli.domain.VignetteTable
+import com.nuelto.etappli.location.PlaceNameResolver
 import com.nuelto.etappli.ui.nav.TripDetailRoute
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
@@ -86,6 +89,8 @@ class TripDetailViewModel(
     // Null when the map provider has no routing of its own — the map draws straight
     // lines and the estimate falls back to the road-distance factor.
     private val routeRefresher: RouteRefresher? = null,
+    // Finds the region each stop lies in, which is what an unnamed tour is called after.
+    private val regionResolver: RegionResolver? = null,
     // One-shot GPS fix; null unless the screen has the location permission.
     private val currentLocation: suspend () -> LatLng? = { null },
     // A single route, for "how far is it from here". Never stored — see DriveFromHere.
@@ -106,6 +111,16 @@ class TripDetailViewModel(
                     .map { stops -> RouteCache.routed(stops).map { it.location } }
                     .distinctUntilChanged()
                     .collect { refresher.refresh(tripId) }
+            }
+        }
+        regionResolver?.let { resolver ->
+            viewModelScope.launch {
+                // Every located stop, whatever its state: the region is the pin's. Writing
+                // it back leaves this list alone, so this settles like the routes do.
+                tripRepository.stops(tripId)
+                    .map { stops -> stops.map { it.location } }
+                    .distinctUntilChanged()
+                    .collect { resolver.resolve(tripId) }
             }
         }
     }
@@ -379,6 +394,9 @@ class TripDetailViewModel(
                 container.settingsRepository,
                 container.mapProvider.placeCacheSweeper(container.tripRepository),
                 container.mapProvider.routeRefresher(container.tripRepository),
+                this[APPLICATION_KEY]?.let {
+                    RegionResolver(container.tripRepository, PlaceNameResolver(it)::region)
+                },
                 container.currentLocation,
                 container.mapProvider::drive,
             )

--- a/app/src/main/java/com/nuelto/etappli/ui/tripedit/TripEditScreen.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/tripedit/TripEditScreen.kt
@@ -42,7 +42,6 @@ fun TripEditScreen(
                 title = {
                     Text(
                         when {
-                            state.isNew && state.isPlan -> "Plan a tour"
                             state.isNew -> "New trip"
                             state.isPlan -> "Edit plan"
                             else -> "Edit trip"
@@ -69,6 +68,7 @@ fun TripEditScreen(
                 value = state.name,
                 onValueChange = viewModel::setName,
                 label = { Text("Trip name") },
+                supportingText = { Text(state.nameHint) },
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(),
             )
@@ -98,7 +98,6 @@ fun TripEditScreen(
             )
             Button(
                 onClick = { viewModel.save(onSaved) },
-                enabled = state.canSave,
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text("Save")

--- a/app/src/main/java/com/nuelto/etappli/ui/tripedit/TripEditViewModel.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/tripedit/TripEditViewModel.kt
@@ -7,10 +7,9 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.nuelto.etappli.containerViewModelFactory
 import com.nuelto.etappli.data.TripRepository
-import com.nuelto.etappli.domain.HomeStop
-import com.nuelto.etappli.data.SettingsRepository
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
+import com.nuelto.etappli.domain.title
 import com.nuelto.etappli.ui.nav.TripEditRoute
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
@@ -28,18 +27,20 @@ data class TripEditUiState(
     val isNew: Boolean = true,
     val isPlan: Boolean = false,
     val loaded: Boolean = false,
+    // What the trip is called while [name] is blank (domain/TripName); empty until it exists.
+    val autoName: String = "",
 ) {
-    val canSave: Boolean get() = name.isNotBlank()
+    val nameHint: String
+        get() = if (autoName.isBlank()) "Optional — named after its stops" else "Leave blank to call it \"$autoName\""
 }
 
+/** Edits a trip's own fields, and logs a past trip; tours are planned without a form (NewPlan). */
 class TripEditViewModel(
     savedStateHandle: SavedStateHandle,
     private val tripRepository: TripRepository,
-    private val settingsRepository: SettingsRepository? = null,
 ) : ViewModel() {
 
-    private val route: TripEditRoute = savedStateHandle.toRoute<TripEditRoute>()
-    private val tripId: String? = route.tripId
+    private val tripId: String? = savedStateHandle.toRoute<TripEditRoute>().tripId
     private var existing: Trip? = null
 
     private val _uiState = MutableStateFlow(TripEditUiState())
@@ -53,7 +54,7 @@ class TripEditViewModel(
             val trip = existing
             _uiState.update {
                 if (trip == null) {
-                    it.copy(isPlan = route.planned, loaded = true)
+                    it.copy(loaded = true)
                 } else {
                     TripEditUiState(
                         name = trip.name,
@@ -63,6 +64,7 @@ class TripEditViewModel(
                         isNew = false,
                         isPlan = trip.status == TripStatus.PLANNED,
                         loaded = true,
+                        autoName = trip.copy(name = "").title,
                     )
                 }
             }
@@ -77,20 +79,16 @@ class TripEditViewModel(
     private var saving = false
 
     fun save(onSaved: (tripId: String, isNew: Boolean) -> Unit) {
-        val state = _uiState.value
-        if (!state.canSave || saving) return
+        if (saving) return
         saving = true
+        val state = _uiState.value
         viewModelScope.launch {
             try {
                 val base = existing ?: Trip()
                 val endDate = state.endDate
-                val status = when {
-                    state.isNew && state.isPlan -> TripStatus.PLANNED
-                    // Logging/editing a trip that already ended finishes it right away.
-                    base.status != TripStatus.PLANNED && endDate != null && endDate.isBefore(LocalDate.now()) ->
-                        TripStatus.DONE
-                    else -> base.status
-                }
+                // Logging/editing a trip that already ended finishes it right away.
+                val ended = endDate != null && endDate.isBefore(LocalDate.now())
+                val status = if (base.status != TripStatus.PLANNED && ended) TripStatus.DONE else base.status
                 val savedId = tripRepository.upsertTrip(
                     base.copy(
                         name = state.name.trim(),
@@ -100,12 +98,6 @@ class TripEditViewModel(
                         status = status,
                     ),
                 )
-                // A fresh plan sets out from home and comes back to it, when there is one.
-                if (state.isNew && status == TripStatus.PLANNED) {
-                    settingsRepository?.settings()?.first()
-                        ?.let { HomeStop.forNewPlan(savedId, it, state.startDate) }
-                        ?.forEach { tripRepository.upsertStop(it) }
-                }
                 // Moving a plan's start moves its whole itinerary along.
                 if (base.status == TripStatus.PLANNED) {
                     val days = ChronoUnit.DAYS.between(base.startDate, state.startDate)
@@ -124,11 +116,7 @@ class TripEditViewModel(
 
     companion object {
         val Factory = containerViewModelFactory { container ->
-            TripEditViewModel(
-                createSavedStateHandle(),
-                container.tripRepository,
-                container.settingsRepository,
-            )
+            TripEditViewModel(createSavedStateHandle(), container.tripRepository)
         }
     }
 }

--- a/app/src/main/java/com/nuelto/etappli/ui/triplist/TripListScreen.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/triplist/TripListScreen.kt
@@ -45,6 +45,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
 import com.nuelto.etappli.domain.EstimateBreakdown
+import com.nuelto.etappli.domain.title
 import com.nuelto.etappli.ui.formatCurrency
 import com.nuelto.etappli.ui.formatTripDates
 import com.nuelto.etappli.ui.theme.statusColor
@@ -53,7 +54,9 @@ import com.nuelto.etappli.ui.theme.statusColor
 @Composable
 fun TripListScreen(
     onTripClick: (String) -> Unit,
-    onAddTrip: (planned: Boolean) -> Unit,
+    onLogTrip: () -> Unit,
+    // "Plan a tour" makes the tour right here; this is handed its id.
+    onTourPlanned: (tripId: String) -> Unit,
     onOpenMap: () -> Unit,
     onOpenSettings: () -> Unit,
     viewModel: TripListViewModel = viewModel(factory = TripListViewModel.Factory),
@@ -84,7 +87,7 @@ fun TripListScreen(
                         ExtendedFloatingActionButton(
                             onClick = {
                                 fabMenuExpanded = false
-                                onAddTrip(true)
+                                viewModel.planTour(onTourPlanned)
                             },
                             icon = { Icon(Icons.Default.Route, contentDescription = null) },
                             text = { Text("Plan a tour") },
@@ -93,7 +96,7 @@ fun TripListScreen(
                         ExtendedFloatingActionButton(
                             onClick = {
                                 fabMenuExpanded = false
-                                onAddTrip(false)
+                                onLogTrip()
                             },
                             icon = { Icon(Icons.Default.Luggage, contentDescription = null) },
                             text = { Text("Log a trip") },
@@ -186,7 +189,7 @@ private fun TripCard(trip: Trip, totalText: String, onClick: () -> Unit) {
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    trip.name,
+                    trip.title,
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.SemiBold,
                 )

--- a/app/src/main/java/com/nuelto/etappli/ui/triplist/TripListViewModel.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/triplist/TripListViewModel.kt
@@ -10,11 +10,14 @@ import com.nuelto.etappli.data.model.TripStatus
 import com.nuelto.etappli.data.model.UserSettings
 import com.nuelto.etappli.domain.EstimateBreakdown
 import com.nuelto.etappli.domain.FuelEstimator
+import com.nuelto.etappli.domain.NewPlan
 import com.nuelto.etappli.domain.TripEstimator
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
 data class TripListUiState(
     val active: List<Trip> = emptyList(),
@@ -32,8 +35,8 @@ data class TripListUiState(
 }
 
 class TripListViewModel(
-    tripRepository: TripRepository,
-    settingsRepository: SettingsRepository,
+    private val tripRepository: TripRepository,
+    private val settingsRepository: SettingsRepository,
 ) : ViewModel() {
 
     val uiState: StateFlow<TripListUiState> =
@@ -68,6 +71,22 @@ class TripListViewModel(
                 loading = false,
             )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), TripListUiState())
+
+    // A double-tap must not mint two tours.
+    private var planning = false
+
+    /** A tour planned on the spot (domain/NewPlan); [onCreated] gets its id. */
+    fun planTour(onCreated: (String) -> Unit) {
+        if (planning) return
+        planning = true
+        viewModelScope.launch {
+            try {
+                onCreated(NewPlan.create(tripRepository, settingsRepository.settings().first()))
+            } finally {
+                planning = false
+            }
+        }
+    }
 
     companion object {
         val Factory = containerViewModelFactory { container ->

--- a/app/src/test/java/com/nuelto/etappli/ScreenshotsTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ScreenshotsTest.kt
@@ -71,7 +71,7 @@ class ScreenshotsTest {
     @Test
     fun tripList() = shoot("trip-list") {
         TripListScreen(
-            onTripClick = {}, onAddTrip = { _ -> }, onOpenMap = {}, onOpenSettings = {},
+            onTripClick = {}, onLogTrip = {}, onTourPlanned = {}, onOpenMap = {}, onOpenSettings = {},
             viewModel = TripListViewModel(tripRepository, settingsRepository),
         )
     }
@@ -126,10 +126,11 @@ class ScreenshotsTest {
     @Test
     fun addToTrip() = shoot("add-to-trip") {
         AddToTripScreen(
-            onCancel = {}, onPlanTrip = {}, onAddTo = { _, _ -> },
+            onCancel = {}, onAddTo = { _, _ -> },
             viewModel = AddToTripViewModel(
                 SharedPlace("Camping Grimselblick", LatLng(46.5606, 8.3376)),
                 tripRepository,
+                settingsRepository,
             ),
         )
     }

--- a/app/src/test/java/com/nuelto/etappli/data/InMemoryTripRepositoryTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/data/InMemoryTripRepositoryTest.kt
@@ -5,6 +5,7 @@ import com.nuelto.etappli.data.model.ExpenseType
 import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.data.model.Stop
 import com.nuelto.etappli.data.model.StopKind
+import com.nuelto.etappli.data.model.StopRegion
 import com.nuelto.etappli.data.model.StopState
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
@@ -145,6 +146,17 @@ class InMemoryTripRepositoryTest {
         )
         assertEquals(50.0, repo.trip(id).first()!!.totalCost, 1e-9)
         assertEquals(2, repo.trip(id).first()!!.nights)
+    }
+
+    @Test
+    fun `a trip is named after its stops' regions, kept up to date like the totals`() = runTest {
+        val id = addTrip()
+        assertEquals("", repo.trip(id).first()!!.region)
+        repo.upsertStop(Stop(id = "a", tripId = id, orderIndex = 0, region = StopRegion(name = "Ticino", country = "Switzerland")))
+        repo.upsertStop(Stop(id = "b", tripId = id, orderIndex = 1, region = StopRegion(name = "Valais", country = "Switzerland")))
+        assertEquals("Ticino & Valais", repo.trip(id).first()!!.region)
+        repo.deleteStop(id, "b")
+        assertEquals("Ticino", repo.trip(id).first()!!.region)
     }
 
     @Test

--- a/app/src/test/java/com/nuelto/etappli/domain/FuelEstimatorTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/FuelEstimatorTest.kt
@@ -162,6 +162,18 @@ class FuelEstimatorTest {
     }
 
     @Test
+    fun `a drive with no road falls back to the road factor`() {
+        val a = LatLng(47.0, 8.0)
+        val b = LatLng(48.0, 8.0)
+        val stops = listOf(
+            Stop(id = "a", location = a, orderIndex = 0),
+            Stop(id = "b", location = b, orderIndex = 1, leg = routeLeg(a, b, 0)),
+        )
+        val settings = UserSettings(roadDistanceFactor = 1.25)
+        assertEquals(GeoUtils.haversineKm(a, b) * 1.25, FuelEstimator.defaultTripDistanceKm(stops, settings), 1e-9)
+    }
+
+    @Test
     fun `lifting one tonne 100 m burns about 86 millilitres`() {
         assertEquals(0.086, FuelEstimator.liftLiters(1000.0, 100.0), 5e-4)
         assertEquals(0.0, FuelEstimator.liftLiters(3500.0, 0.0), 1e-12)

--- a/app/src/test/java/com/nuelto/etappli/domain/GoogleRoutesTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/GoogleRoutesTest.kt
@@ -182,6 +182,81 @@ class GoogleRoutesTest {
         assertTrue(GoogleRoutes.parseLegs("").isEmpty())
     }
 
+    // --- transit ------------------------------------------------------------
+
+    @Test
+    fun `a transit request is origin and destination only, with no routing preference`() {
+        val body = GoogleRoutes.transitBody(LatLng(46.0, 7.0), LatLng(47.0, 8.0))
+        assertEquals(
+            """{"origin":${waypoint(46.0, 7.0)},"destination":${waypoint(47.0, 8.0)},""" +
+                """"travelMode":"TRANSIT","polylineQuality":"HIGH_QUALITY"}""",
+            body,
+        )
+        assertFalse("routingPreference" in body)
+        assertFalse("intermediates" in body)
+    }
+
+    @Test
+    fun `the transit mask asks per step for the way, the boarding point and the vehicle`() {
+        val fields = GoogleRoutes.TRANSIT_FIELD_MASK.split(",")
+        assertTrue(fields.all { it.startsWith("routes.legs.steps.") })
+        assertTrue("routes.legs.steps.transitDetails.stopDetails.departureStop.location" in fields)
+        assertTrue("routes.legs.steps.transitDetails.transitLine.vehicle.type" in fields)
+        assertTrue("routes.legs.steps.polyline.encodedPolyline" in fields)
+        assertTrue("routes.legs.steps.staticDuration" in fields)
+        assertTrue("routes.legs.steps.travelMode" in fields)
+    }
+
+    private fun transitResponse(vararg steps: String) =
+        """{"routes":[{"legs":[{"steps":[${steps.joinToString(",")}]}]}]}"""
+
+    private val walk =
+        """{"travelMode":"WALK","distanceMeters":120,"staticDuration":"90s","polyline":{"encodedPolyline":"abc"}}"""
+
+    private val gondola =
+        """{"travelMode":"TRANSIT","distanceMeters":2572,"staticDuration":"720s","polyline":{"encodedPolyline":"def"},""" +
+            """"transitDetails":{"stopDetails":{"departureStop":{"location":{"latLng":{"latitude":46.356603,"longitude":8.046011}}}},""" +
+            """"transitLine":{"vehicle":{"type":"GONDOLA_LIFT"}}}}"""
+
+    @Test
+    fun `transit steps come back in order, walks without a vehicle and rides with where they board`() {
+        val steps = GoogleRoutes.parseTransitSteps(transitResponse(walk, gondola, walk))
+        assertEquals(3, steps.size)
+        assertEquals(TransitStep("abc", 120, 90), steps[0])
+        assertEquals(TransitStep("def", 2572, 720, "GONDOLA_LIFT", LatLng(46.356603, 8.046011)), steps[1])
+        assertEquals(steps[0], steps[2])
+    }
+
+    @Test
+    fun `a ride that says neither what nor where is still a ride, just not one to park for`() {
+        val bare = TransitStep("", 0, 0, "OTHER", null)
+        assertEquals(listOf(bare), GoogleRoutes.parseTransitSteps(transitResponse("""{"travelMode":"TRANSIT"}""")))
+        listOf(
+            """{"latLng":{"latitude":"46.3","longitude":8.0}}""",
+            """{"latLng":{"latitude":46.3}}""",
+            """{"latLng":[]}""",
+        ).forEach { location ->
+            assertEquals(
+                listOf(bare),
+                GoogleRoutes.parseTransitSteps(
+                    transitResponse(
+                        """{"travelMode":"TRANSIT","transitDetails":{"stopDetails":{"departureStop":{"location":$location}}}}""",
+                    ),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `one malformed step or nothing routable is no transit route`() {
+        assertTrue(GoogleRoutes.parseTransitSteps(transitResponse(walk, "42")).isEmpty())
+        assertTrue(GoogleRoutes.parseTransitSteps("""{"routes":[{"legs":[{}]}]}""").isEmpty())
+        assertTrue(GoogleRoutes.parseTransitSteps("""{"routes":[{"legs":[{"steps":{}}]}]}""").isEmpty())
+        assertTrue(GoogleRoutes.parseTransitSteps("""{"routes":[{"legs":[]}]}""").isEmpty())
+        assertTrue(GoogleRoutes.parseTransitSteps("""{"routes":[{"legs":[42]}]}""").isEmpty())
+        assertTrue(GoogleRoutes.parseTransitSteps("{}").isEmpty())
+    }
+
     // --- durations ----------------------------------------------------------
 
     @Test

--- a/app/src/test/java/com/nuelto/etappli/domain/MapOverlayTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/MapOverlayTest.kt
@@ -5,9 +5,11 @@ import com.nuelto.etappli.data.model.Stop
 import com.nuelto.etappli.data.model.StopKind
 import com.nuelto.etappli.data.model.StopLeg
 import com.nuelto.etappli.data.model.StopState
+import com.nuelto.etappli.data.model.TransitRide
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -221,6 +223,45 @@ class MapOverlayTest {
                 MapOverlay.routes(data(TripStatus.DONE, listOf(a, b))).single().points,
             )
         }
+    }
+
+    @Test
+    fun `a ride to a stop no road reaches is a dotted line of its own, from where the vehicle is left`() {
+        val a = stop("a", 0)
+        val parked = LatLng(46.5, 7.5)
+        val pin = LatLng(47.0, 8.0)
+        val up = TransitRide(parked = parked, polyline = Polyline.encode(listOf(parked, pin)))
+        // The road runs a → parked; the ride carries on to b's pin. A ride with no line to draw is left out.
+        val b = stop("b", 1).copy(
+            leg = StopLeg(
+                from = a.location!!, to = pin, distanceMeters = 1,
+                polyline = Polyline.encode(listOf(a.location!!, parked)),
+                rideBefore = TransitRide(polyline = ""), rideAfter = up,
+            ),
+        )
+        val routes = MapOverlay.routes(data(TripStatus.PLANNED, listOf(a, b)))
+        assertEquals(listOf(false, true), routes.map { it.ride })
+        assertEquals(listOf(LatLng(46.0, 7.0), parked), routes[0].points)
+        assertEquals(listOf(parked, pin), routes[1].points)
+        assertEquals(MapAccent.PLANNED, routes[1].accent)
+        assertFalse(routes[1].dashed)
+    }
+
+    @Test
+    fun `on an active trip a ride takes the colour of its section`() {
+        val a = stop("a", 0, state = StopState.DONE)
+        val parked = LatLng(46.5, 7.5)
+        val pin = LatLng(47.0, 8.0)
+        val b = stop("b", 1).copy(
+            leg = StopLeg(
+                from = a.location!!, to = pin, distanceMeters = 1,
+                polyline = Polyline.encode(listOf(a.location!!, parked)),
+                rideAfter = TransitRide(parked = parked, polyline = Polyline.encode(listOf(parked, pin))),
+            ),
+        )
+        val routes = MapOverlay.routes(data(TripStatus.ACTIVE, listOf(a, b), currentStopId = "b"))
+        assertEquals(listOf(MapAccent.CURRENT, MapAccent.CURRENT), routes.map { it.accent })
+        assertEquals(listOf(false, true), routes.map { it.ride })
     }
 
     @Test

--- a/app/src/test/java/com/nuelto/etappli/domain/NewPlanTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/NewPlanTest.kt
@@ -1,0 +1,50 @@
+package com.nuelto.etappli.domain
+
+import com.nuelto.etappli.data.InMemoryTripRepository
+import com.nuelto.etappli.data.model.LatLng
+import com.nuelto.etappli.data.model.StopKind
+import com.nuelto.etappli.data.model.TripStatus
+import com.nuelto.etappli.data.model.UserSettings
+import java.time.LocalDate
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NewPlanTest {
+
+    private val repo = InMemoryTripRepository(seed = false)
+    private val today = LocalDate.of(2027, 6, 10)
+
+    @Test
+    fun `a new plan is unnamed, planned, dated today and empty`() = runTest {
+        val id = NewPlan.create(repo, UserSettings(), today)
+        val trip = repo.trip(id).first()!!
+        assertEquals("", trip.name)
+        assertEquals(TripStatus.PLANNED, trip.status)
+        assertEquals(today, trip.startDate)
+        assertNull(trip.endDate)
+        assertTrue(repo.stops(id).first().isEmpty())
+        assertEquals(LocalDate.now(), repo.trip(NewPlan.create(repo, UserSettings())).first()!!.startDate)
+    }
+
+    @Test
+    fun `with a home set it sets out from home and comes back`() = runTest {
+        val settings = UserSettings(homeName = "Luzern", homeLocation = LatLng(47.0502, 8.3093))
+        val id = NewPlan.create(repo, settings, today)
+        val stops = repo.stops(id).first()
+        assertEquals(listOf(0, 1), stops.map { it.orderIndex })
+        assertEquals(setOf(StopKind.HOME), stops.map { it.kind }.toSet())
+        assertEquals(setOf(today), stops.map { it.arrivalDate }.toSet())
+        assertEquals(setOf(id), stops.map { it.tripId }.toSet())
+    }
+
+    @Test
+    fun `every call is another plan`() = runTest {
+        assertNotEquals(NewPlan.create(repo, UserSettings(), today), NewPlan.create(repo, UserSettings(), today))
+        assertEquals(2, repo.trips().first().size)
+    }
+}

--- a/app/src/test/java/com/nuelto/etappli/domain/ParkAndRideTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/ParkAndRideTest.kt
@@ -1,0 +1,87 @@
+package com.nuelto.etappli.domain
+
+import com.nuelto.etappli.data.model.LatLng
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ParkAndRideTest {
+
+    private val valley = LatLng(46.3566, 8.046)
+    private val town = LatLng(46.32, 7.99)
+    private val city = LatLng(46.95, 7.44)
+
+    private fun walk(polyline: String = "", meters: Int = 100, seconds: Int = 80) =
+        TransitStep(polyline, meters, seconds)
+
+    private fun ride(vehicle: String, boards: LatLng?, polyline: String = "", meters: Int = 1_000, seconds: Int = 600) =
+        TransitStep(polyline, meters, seconds, vehicle, boards)
+
+    @Test
+    fun `the last ride's boarding point comes first, and only rides can be parked at`() {
+        val steps = listOf(
+            walk(), ride("LONG_DISTANCE_TRAIN", city), walk(), ride("HEAVY_RAIL", town), ride("GONDOLA_LIFT", valley), walk(),
+        )
+        val candidates = ParkAndRide.candidates(steps)
+        assertEquals(listOf(valley, town, city), candidates.map { it.parked })
+        assertEquals(steps.subList(4, 6), candidates[0].steps)
+        assertEquals(steps.subList(3, 6), candidates[1].steps)
+        assertEquals(steps.subList(1, 6), candidates[2].steps)
+    }
+
+    @Test
+    fun `no more than three rides back are tried, and a ride that does not say where it boards is skipped`() {
+        val steps = listOf(
+            ride("BUS", LatLng(1.0, 1.0)),
+            ride("BUS", LatLng(2.0, 2.0)),
+            ride("BUS", LatLng(3.0, 3.0)),
+            ride("BUS", null),
+            ride("BUS", LatLng(4.0, 4.0)),
+        )
+        assertEquals(
+            listOf(LatLng(4.0, 4.0), LatLng(3.0, 3.0), LatLng(2.0, 2.0)),
+            ParkAndRide.candidates(steps).map { it.parked },
+        )
+        assertTrue(ParkAndRide.candidates(listOf(walk(), walk())).isEmpty())
+    }
+
+    @Test
+    fun `a ride joins its steps into one line, one sum, and the vehicle in words`() {
+        val top = LatLng(46.378, 8.0332)
+        val hut = LatLng(46.3797, 8.0433)
+        val candidate = ParkAndRide.Candidate(
+            valley,
+            listOf(
+                ride("GONDOLA_LIFT", valley, Polyline.encode(listOf(valley, top)), 2_572, 720),
+                walk(Polyline.encode(listOf(top, hut)), 336, 246),
+            ),
+        )
+        val ride = ParkAndRide.ride(candidate)
+        assertEquals(valley, ride.parked)
+        assertEquals(listOf(valley, top, top, hut), Polyline.decode(ride.polyline))
+        assertEquals(2_908, ride.distanceMeters)
+        assertEquals(966, ride.durationSeconds)
+        assertEquals("cable car", ride.mode)
+    }
+
+    @Test
+    fun `different vehicles are named once each, in riding order`() {
+        val candidate = ParkAndRide.Candidate(
+            town,
+            listOf(ride("HEAVY_RAIL", town), walk(), ride("BUS", city), ride("INTERCITY_BUS", city)),
+        )
+        assertEquals("train + bus", ParkAndRide.ride(candidate).mode)
+    }
+
+    @Test
+    fun `google's vehicle types in plain words`() {
+        val names = mapOf(
+            "GONDOLA_LIFT" to "cable car", "CABLE_CAR" to "cable car", "FUNICULAR" to "funicular",
+            "FERRY" to "ferry", "TRAM" to "tram", "BUS" to "bus", "INTERCITY_BUS" to "bus",
+            "TROLLEYBUS" to "bus", "SHARE_TAXI" to "bus", "HEAVY_RAIL" to "train", "RAIL" to "train",
+            "COMMUTER_TRAIN" to "train", "LONG_DISTANCE_TRAIN" to "train", "HIGH_SPEED_TRAIN" to "train",
+            "METRO_RAIL" to "train", "MONORAIL" to "train", "SUBWAY" to "train", "OTHER" to "transit",
+        )
+        names.forEach { (type, name) -> assertEquals(type, name, ParkAndRide.vehicleName(type)) }
+    }
+}

--- a/app/src/test/java/com/nuelto/etappli/domain/ParkAndRideTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/ParkAndRideTest.kt
@@ -1,6 +1,7 @@
 package com.nuelto.etappli.domain
 
 import com.nuelto.etappli.data.model.LatLng
+import com.nuelto.etappli.data.model.TravelMode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -46,7 +47,7 @@ class ParkAndRideTest {
     }
 
     @Test
-    fun `a ride joins its steps into one line, one sum, and the vehicle in words`() {
+    fun `a ride joins its steps into one line, one sum, and the vehicle boarded`() {
         val top = LatLng(46.378, 8.0332)
         val hut = LatLng(46.3797, 8.0433)
         val candidate = ParkAndRide.Candidate(
@@ -61,27 +62,29 @@ class ParkAndRideTest {
         assertEquals(listOf(valley, top, top, hut), Polyline.decode(ride.polyline))
         assertEquals(2_908, ride.distanceMeters)
         assertEquals(966, ride.durationSeconds)
-        assertEquals("cable car", ride.mode)
+        assertEquals(listOf(TravelMode.CABLE_CAR), ride.modes)
     }
 
     @Test
-    fun `different vehicles are named once each, in riding order`() {
+    fun `different vehicles are listed once each, in riding order`() {
         val candidate = ParkAndRide.Candidate(
             town,
             listOf(ride("HEAVY_RAIL", town), walk(), ride("BUS", city), ride("INTERCITY_BUS", city)),
         )
-        assertEquals("train + bus", ParkAndRide.ride(candidate).mode)
+        assertEquals(listOf(TravelMode.TRAIN, TravelMode.BUS), ParkAndRide.ride(candidate).modes)
     }
 
     @Test
-    fun `google's vehicle types in plain words`() {
-        val names = mapOf(
-            "GONDOLA_LIFT" to "cable car", "CABLE_CAR" to "cable car", "FUNICULAR" to "funicular",
-            "FERRY" to "ferry", "TRAM" to "tram", "BUS" to "bus", "INTERCITY_BUS" to "bus",
-            "TROLLEYBUS" to "bus", "SHARE_TAXI" to "bus", "HEAVY_RAIL" to "train", "RAIL" to "train",
-            "COMMUTER_TRAIN" to "train", "LONG_DISTANCE_TRAIN" to "train", "HIGH_SPEED_TRAIN" to "train",
-            "METRO_RAIL" to "train", "MONORAIL" to "train", "SUBWAY" to "train", "OTHER" to "transit",
+    fun `google's vehicle types as what you board`() {
+        val modes = mapOf(
+            "GONDOLA_LIFT" to TravelMode.CABLE_CAR, "CABLE_CAR" to TravelMode.CABLE_CAR,
+            "FUNICULAR" to TravelMode.FUNICULAR, "FERRY" to TravelMode.FERRY, "TRAM" to TravelMode.TRAM,
+            "BUS" to TravelMode.BUS, "INTERCITY_BUS" to TravelMode.BUS, "TROLLEYBUS" to TravelMode.BUS,
+            "SHARE_TAXI" to TravelMode.BUS, "HEAVY_RAIL" to TravelMode.TRAIN, "RAIL" to TravelMode.TRAIN,
+            "COMMUTER_TRAIN" to TravelMode.TRAIN, "LONG_DISTANCE_TRAIN" to TravelMode.TRAIN,
+            "HIGH_SPEED_TRAIN" to TravelMode.TRAIN, "METRO_RAIL" to TravelMode.TRAIN,
+            "MONORAIL" to TravelMode.TRAIN, "SUBWAY" to TravelMode.TRAIN, "OTHER" to TravelMode.TRANSIT,
         )
-        names.forEach { (type, name) -> assertEquals(type, name, ParkAndRide.vehicleName(type)) }
+        modes.forEach { (type, mode) -> assertEquals(type, mode, ParkAndRide.mode(type)) }
     }
 }

--- a/app/src/test/java/com/nuelto/etappli/domain/PolylineTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/PolylineTest.kt
@@ -25,6 +25,20 @@ class PolylineTest {
     }
 
     @Test
+    fun `google's worked example encodes back to its string, and a line survives the round trip`() {
+        val points = listOf(LatLng(38.5, -120.2), LatLng(40.7, -120.95), LatLng(43.252, -126.453))
+        assertEquals("_p~iF~ps|U_ulLnnqC_mqNvxq`@", Polyline.encode(points))
+        assertEquals("_ibE~hbE", Polyline.encode(listOf(LatLng(1.0, -1.0))))
+        // A delta of exactly one continuation chunk's worth still needs its second character.
+        assertEquals("_@?", Polyline.encode(listOf(LatLng(0.00016, 0.0))))
+        assertPoint(0.00016, 0.0, Polyline.decode("_@?").single())
+        assertEquals("", Polyline.encode(emptyList()))
+        val back = Polyline.decode(Polyline.encode(points))
+        assertEquals(3, back.size)
+        back.forEachIndexed { index, point -> assertPoint(points[index].latitude, points[index].longitude, point) }
+    }
+
+    @Test
     fun `an empty string decodes to no points`() {
         assertEquals(emptyList<LatLng>(), Polyline.decode(""))
     }

--- a/app/src/test/java/com/nuelto/etappli/domain/RegionResolverTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/RegionResolverTest.kt
@@ -1,0 +1,86 @@
+package com.nuelto.etappli.domain
+
+import com.nuelto.etappli.data.InMemoryTripRepository
+import com.nuelto.etappli.data.model.LatLng
+import com.nuelto.etappli.data.model.Stop
+import com.nuelto.etappli.data.model.StopRegion
+import com.nuelto.etappli.data.model.Trip
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class RegionResolverTest {
+
+    private val repo = InMemoryTripRepository(seed = false)
+    private val here = LatLng(46.17, 8.79)
+    private val there = LatLng(47.0, 7.0)
+    private val ticino = StopRegion(here, "Ticino", "Switzerland")
+
+    private suspend fun seed(vararg stops: Stop) {
+        repo.upsertTrip(Trip(id = "t1"))
+        stops.forEach { repo.upsertStop(it) }
+    }
+
+    private suspend fun stop(id: String) = repo.stops("t1").first().first { it.id == id }
+
+    @Test
+    fun `due are the located stops with no region, or one looked up for another spot`() {
+        val fresh = Stop(id = "a", location = here, region = ticino)
+        val moved = Stop(id = "b", location = there, region = ticino)
+        val missing = Stop(id = "c", location = here)
+        val nowhere = Stop(id = "d")
+        assertEquals(listOf(moved, missing), RegionResolver.due(listOf(fresh, moved, missing, nowhere)))
+    }
+
+    @Test
+    fun `the region is written for the spot it was asked for, and names the trip`() = runTest {
+        seed(Stop(id = "s1", tripId = "t1", location = here, orderIndex = 0))
+        val asked = mutableListOf<LatLng>()
+        val resolver = RegionResolver(repo) { at ->
+            asked += at
+            StopRegion(name = "Ticino", country = "Switzerland")
+        }
+        assertEquals(1, resolver.resolve("t1"))
+        assertEquals(listOf(here), asked)
+        assertEquals(ticino, stop("s1").region)
+        assertEquals("Ticino", repo.trip("t1").first()!!.region)
+        // Settled: nothing is due any more.
+        assertEquals(0, resolver.resolve("t1"))
+        assertEquals(1, asked.size)
+    }
+
+    @Test
+    fun `a lookup that finds nothing leaves the stop alone`() = runTest {
+        seed(Stop(id = "s1", tripId = "t1", location = here))
+        assertEquals(0, RegionResolver(repo) { null }.resolve("t1"))
+        assertNull(stop("s1").region)
+    }
+
+    @Test
+    fun `a stop moved or deleted while the lookup ran is not written`() = runTest {
+        seed(
+            Stop(id = "s1", tripId = "t1", location = here, orderIndex = 0),
+            Stop(id = "s2", tripId = "t1", location = there, orderIndex = 1),
+        )
+        val resolver = RegionResolver(repo) { at ->
+            if (at == here) repo.upsertStop(stop("s1").copy(location = LatLng(46.0, 6.0))) else repo.deleteStop("t1", "s2")
+            StopRegion(name = "Ticino", country = "Switzerland")
+        }
+        assertEquals(0, resolver.resolve("t1"))
+        assertNull(repo.stops("t1").first().single().region)
+    }
+
+    @Test
+    fun `an edit made during the lookup survives the write`() = runTest {
+        seed(Stop(id = "s1", tripId = "t1", location = here, nights = 1))
+        val resolver = RegionResolver(repo) {
+            repo.upsertStop(stop("s1").copy(nights = 3))
+            StopRegion(name = "Ticino", country = "Switzerland")
+        }
+        assertEquals(1, resolver.resolve("t1"))
+        assertEquals(3, stop("s1").nights)
+        assertEquals(ticino, stop("s1").region)
+    }
+}

--- a/app/src/test/java/com/nuelto/etappli/domain/RouteRefresherTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/RouteRefresherTest.kt
@@ -5,6 +5,7 @@ import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.data.model.Stop
 import com.nuelto.etappli.data.model.StopElevation
 import com.nuelto.etappli.data.model.StopLeg
+import com.nuelto.etappli.data.model.TravelMode
 import java.time.LocalDate
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.first
@@ -289,7 +290,7 @@ class RouteRefresherTest {
         assertNull(up.rideBefore)
         val ride = up.rideAfter!!
         assertEquals(valley, ride.parked)
-        assertEquals("cable car", ride.mode)
+        assertEquals(listOf(TravelMode.CABLE_CAR), ride.modes)
         assertEquals(960, ride.durationSeconds)
         assertEquals(2_872, ride.distanceMeters)
         // The next drive sets out from where the vehicle was left, after the ride back down.
@@ -309,7 +310,7 @@ class RouteRefresherTest {
 
         val ride = stop("b").leg!!.rideAfter!!
         assertEquals(town, ride.parked)
-        assertEquals("train + cable car", ride.mode)
+        assertEquals(listOf(TravelMode.TRAIN, TravelMode.CABLE_CAR), ride.modes)
         assertEquals(listOf(listOf(here, there), listOf(here, valley), listOf(here, town)), windows)
     }
 

--- a/app/src/test/java/com/nuelto/etappli/domain/RouteRefresherTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/RouteRefresherTest.kt
@@ -30,14 +30,17 @@ class RouteRefresherTest {
     private val repository = InMemoryTripRepository(seed = false)
     private val windows = mutableListOf<List<LatLng>>()
     private val sampled = mutableListOf<List<LatLng>>()
+    private val transitAsks = mutableListOf<Pair<LatLng, LatLng>>()
 
     private fun refresher(
         heights: suspend (List<LatLng>) -> List<Double>? = { null },
+        transit: suspend (LatLng, LatLng) -> List<TransitStep>? = { _, _ -> emptyList() },
         route: suspend (List<LatLng>) -> List<RoutedLeg>?,
     ) = RouteRefresher(
         repository,
         { points -> windows += points; route(points) },
         { points -> sampled += points; heights(points) },
+        { from, to -> transitAsks += from to to; transit(from, to) },
     )
 
     private suspend fun addStop(
@@ -241,6 +244,134 @@ class RouteRefresherTest {
 
         assertEquals(0, result.fetched)
         assertTrue(repository.stops("t1").first().all { it.leg == null })
+    }
+
+    // --- park and ride --------------------------------------------------------
+
+    private val valley = LatLng(46.3566, 8.046)
+    private val town = LatLng(46.32, 7.99)
+
+    /** Home to Riederalp by public transport: a train from town, then the cable car from the valley. */
+    private val toRiederalp = listOf(
+        TransitStep("", 100, 80),
+        TransitStep(geometry, 100_000, 3_600, "LONG_DISTANCE_TRAIN", town),
+        TransitStep("", 50, 40),
+        TransitStep(geometry, 2_572, 720, "GONDOLA_LIFT", valley),
+        TransitStep(geometry, 300, 240),
+    )
+
+    /** Drives as Google answers them: one leg for each listed window, no road for anything else. */
+    private fun roads(vararg legs: Pair<List<LatLng>, Int>): suspend (List<LatLng>) -> List<RoutedLeg>? =
+        { window -> legs.firstOrNull { it.first == window }?.let { listOf(RoutedLeg(geometry, it.second, 600)) } ?: emptyList() }
+
+    @Test
+    fun `a stop no road reaches is driven to as far as the road goes, then ridden to`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1)
+        addStop("c", elsewhere, index = 2)
+
+        val result = refresher(
+            transit = { _, _ -> toRiederalp },
+            route = roads(listOf(here, valley) to 120_000, listOf(valley, elsewhere) to 136_000),
+        ).refresh("t1", today)
+
+        assertEquals(2, result.fetched)
+        assertEquals(listOf(here to there), transitAsks)
+        assertEquals(
+            listOf(listOf(here, there, elsewhere), listOf(here, there), listOf(here, valley), listOf(valley, elsewhere)),
+            windows,
+        )
+        val up = stop("b").leg!!
+        assertTrue(up.hasRoad)
+        assertEquals(here, up.from)
+        assertEquals(there, up.to)
+        assertEquals(120_000, up.distanceMeters)
+        assertNull(up.rideBefore)
+        val ride = up.rideAfter!!
+        assertEquals(valley, ride.parked)
+        assertEquals("cable car", ride.mode)
+        assertEquals(960, ride.durationSeconds)
+        assertEquals(2_872, ride.distanceMeters)
+        // The next drive sets out from where the vehicle was left, after the ride back down.
+        val down = stop("c").leg!!
+        assertEquals(there, down.from)
+        assertEquals(136_000, down.distanceMeters)
+        assertEquals(ride, down.rideBefore)
+        assertNull(down.rideAfter)
+    }
+
+    @Test
+    fun `when no road reaches the last ride's boarding point either, the vehicle is left one ride earlier`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1)
+
+        refresher(transit = { _, _ -> toRiederalp }, route = roads(listOf(here, town) to 100_000)).refresh("t1", today)
+
+        val ride = stop("b").leg!!.rideAfter!!
+        assertEquals(town, ride.parked)
+        assertEquals("train + cable car", ride.mode)
+        assertEquals(listOf(listOf(here, there), listOf(here, valley), listOf(here, town)), windows)
+    }
+
+    @Test
+    fun `a stop no ride reaches either is out of reach, after three tries at most`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1)
+        val rides = List(5) { TransitStep(geometry, 1_000, 600, "BUS", LatLng(47.0 + it, 9.0)) }
+
+        val result = refresher(transit = { _, _ -> rides }) { emptyList() }.refresh("t1", today)
+
+        assertEquals(1, result.fetched)
+        assertFalse(stop("b").leg!!.hasRoad)
+        assertNull(stop("b").leg!!.rideAfter)
+        // The stop itself, then the three boarding points nearest it.
+        assertEquals(listOf(there, LatLng(51.0, 9.0), LatLng(50.0, 9.0), LatLng(49.0, 9.0)), windows.map { it.last() })
+    }
+
+    @Test
+    fun `a transit lookup that fails discards the whole chain`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1)
+        addStop("c", elsewhere, index = 2)
+
+        val result = refresher(transit = { _, _ -> null }, route = roads(listOf(there, elsewhere) to 9_000))
+            .refresh("t1", today)
+
+        assertEquals(0, result.fetched)
+        assertTrue(repository.stops("t1").first().all { it.leg == null })
+    }
+
+    @Test
+    fun `a drive to a parking spot that fails discards the whole chain`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1)
+
+        val result = refresher(transit = { _, _ -> toRiederalp }) { window ->
+            if (window == listOf(here, valley)) null else emptyList()
+        }.refresh("t1", today)
+
+        assertEquals(0, result.fetched)
+        assertNull(stop("b").leg)
+    }
+
+    @Test
+    fun `a window after a stop no road reaches is not asked for whole, and sets out from the vehicle`() = runTest {
+        // Twelve stops fill the first window; the twelfth has no road, so the second would start there.
+        repeat(13) { addStop("s$it", LatLng(46.0 + it, 8.0), index = it) }
+        val offRoad = LatLng(57.0, 8.0)
+        val parked = LatLng(56.9, 8.0)
+        val steps = listOf(TransitStep(geometry, 1_000, 600, "FUNICULAR", parked))
+
+        val result = refresher(transit = { _, _ -> steps }) { window ->
+            if (offRoad in window) emptyList() else window.zipWithNext().map { RoutedLeg(geometry, 1, 1) }
+        }.refresh("t1", today)
+
+        assertEquals(12, result.fetched)
+        assertEquals(listOf(LatLng(56.0, 8.0) to offRoad), transitAsks)
+        assertFalse(listOf(offRoad, LatLng(58.0, 8.0)) in windows)
+        assertTrue(listOf(parked, LatLng(58.0, 8.0)) in windows)
+        assertEquals(parked, stop("s11").leg!!.rideAfter!!.parked)
+        assertEquals(stop("s11").leg!!.rideAfter, stop("s12").leg!!.rideBefore)
     }
 
     @Test

--- a/app/src/test/java/com/nuelto/etappli/domain/RouteRefresherTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/RouteRefresherTest.kt
@@ -153,17 +153,109 @@ class RouteRefresherTest {
     }
 
     @Test
-    fun `a response with the wrong number of legs writes nothing`() = runTest {
+    fun `a response with the wrong number of legs writes nothing, and is not retried drive by drive`() = runTest {
         addStop("a", here, index = 0)
         addStop("b", there, index = 1)
+        addStop("c", elsewhere, index = 2)
 
-        val result = refresher {
-            listOf(RoutedLeg(geometry, 1, 1), RoutedLeg(geometry, 2, 2))
-        }.refresh("t1", today)
+        val result = refresher { listOf(RoutedLeg(geometry, 1, 1)) }.refresh("t1", today)
 
         assertEquals(0, result.fetched)
         assertFalse(result.touched)
-        assertNull(stop("b").leg)
+        assertEquals(listOf(listOf(here, there, elsewhere)), windows)
+        assertTrue(repository.stops("t1").first().all { it.leg == null })
+    }
+
+    @Test
+    fun `a stop with no road to it gets a leg saying so, and the rest is routed drive by drive`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1)
+        addStop("c", elsewhere, index = 2)
+
+        val result = refresher { window ->
+            // Nothing drives through `there`, so only the drive that avoids it has a road.
+            if (window == listOf(there, elsewhere)) listOf(RoutedLeg(geometry, 9_000, 600)) else emptyList()
+        }.refresh("t1", today)
+
+        assertEquals(2, result.fetched)
+        assertEquals(
+            listOf(listOf(here, there, elsewhere), listOf(here, there), listOf(there, elsewhere)),
+            windows,
+        )
+        val none = stop("b").leg!!
+        assertFalse(none.hasRoad)
+        assertEquals(here, none.from)
+        assertEquals(there, none.to)
+        assertEquals(today, none.fetchedAt)
+        assertEquals(9_000, stop("c").leg!!.distanceMeters)
+    }
+
+    @Test
+    fun `a drive with no road is not asked about again`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1, leg = StopLeg(from = here, to = there, fetchedAt = today))
+
+        val result = refresher { error("asked again") }.refresh("t1", today)
+
+        assertFalse(result.touched)
+        assertTrue(windows.isEmpty())
+        assertFalse(stop("b").leg!!.hasRoad)
+    }
+
+    @Test
+    fun `a two-stop trip with no road is asked only once`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1)
+
+        val result = refresher { emptyList() }.refresh("t1", today)
+
+        assertEquals(1, result.fetched)
+        assertEquals(listOf(listOf(here, there)), windows)
+        assertFalse(stop("b").leg!!.hasRoad)
+    }
+
+    @Test
+    fun `a drive that fails while asked on its own discards the whole chain`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1)
+        addStop("c", elsewhere, index = 2)
+
+        val result = refresher { window ->
+            if (window == listOf(here, there)) null else emptyList()
+        }.refresh("t1", today)
+
+        assertEquals(0, result.fetched)
+        assertEquals(listOf(listOf(here, there, elsewhere), listOf(here, there)), windows)
+        assertTrue(repository.stops("t1").first().all { it.leg == null })
+    }
+
+    @Test
+    fun `a drive answered with more than one leg on its own writes nothing`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1)
+        addStop("c", elsewhere, index = 2)
+
+        val result = refresher { window ->
+            if (window.size == 3) emptyList() else listOf(RoutedLeg(geometry, 1, 1), RoutedLeg(geometry, 2, 2))
+        }.refresh("t1", today)
+
+        assertEquals(0, result.fetched)
+        assertTrue(repository.stops("t1").first().all { it.leg == null })
+    }
+
+    @Test
+    fun `a drive that has lost its road does not keep the climb it had`() = runTest {
+        addStop("a", here, index = 0)
+        addStop("b", there, index = 1, leg = leg(here, there, today).copy(ascentMeters = 300, descentMeters = 100))
+        // The new stop is what triggers the re-route; the answer says the old drive has no road now.
+        addStop("c", elsewhere, index = 2)
+
+        refresher { emptyList() }.refresh("t1", today)
+
+        val none = stop("b").leg!!
+        assertFalse(none.hasRoad)
+        assertNull(none.ascentMeters)
+        assertNull(none.descentMeters)
     }
 
     @Test

--- a/app/src/test/java/com/nuelto/etappli/domain/TripNameTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/TripNameTest.kt
@@ -1,0 +1,86 @@
+package com.nuelto.etappli.domain
+
+import com.nuelto.etappli.data.model.LatLng
+import com.nuelto.etappli.data.model.Stop
+import com.nuelto.etappli.data.model.StopKind
+import com.nuelto.etappli.data.model.StopRegion
+import com.nuelto.etappli.data.model.StopState
+import com.nuelto.etappli.data.model.Trip
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TripNameTest {
+
+    private fun region(name: String, country: String = "Switzerland") =
+        StopRegion(LatLng(46.0, 8.0), name, country)
+
+    private fun stop(
+        order: Int,
+        region: StopRegion?,
+        kind: StopKind = StopKind.CAMPSITE,
+        state: StopState = StopState.PLANNED,
+    ) = Stop(id = "s$order", orderIndex = order, kind = kind, state = state, region = region)
+
+    @Test
+    fun `nothing to go on is no name`() {
+        assertEquals("", TripName.region(emptyList()))
+        assertEquals("", TripName.region(listOf(stop(0, null), stop(1, region("", "")))))
+    }
+
+    @Test
+    fun `regions are listed in visiting order, without repeats`() {
+        assertEquals("Ticino", TripName.region(listOf(stop(0, region("Ticino")))))
+        val stops = listOf(
+            stop(2, region("Valais")),
+            stop(0, region("Ticino")),
+            stop(1, region("Graubünden")),
+            stop(3, region("Ticino")),
+        )
+        assertEquals("Ticino, Graubünden & Valais", TripName.region(stops))
+        assertEquals("Ticino & Graubünden", TripName.region(stops.drop(0).filter { it.orderIndex != 2 }))
+    }
+
+    @Test
+    fun `more than three regions fall back to the countries`() {
+        val swiss = listOf("Ticino", "Graubünden", "Valais", "Bern").mapIndexed { i, r -> stop(i, region(r)) }
+        assertEquals("Switzerland", TripName.region(swiss))
+        assertEquals("Switzerland & Italy", TripName.region(swiss + stop(4, region("Lombardia", "Italy"))))
+        val three = swiss + stop(4, region("Lombardia", "Italy")) + stop(5, region("Savoie", "France"))
+        assertEquals("Switzerland, Italy & France", TripName.region(three))
+        val grand = swiss + listOf("Italy", "France", "Spain").mapIndexed { i, c -> stop(4 + i, region("R$i", c)) }
+        assertEquals("Switzerland, Italy, France & more", TripName.region(grand))
+        // Nowhere to fall back to: the regions themselves, cut short.
+        val stateless = listOf("A", "B", "C", "D").mapIndexed { i, r -> stop(i, region(r, "")) }
+        assertEquals("A, B, C & more", TripName.region(stateless))
+    }
+
+    @Test
+    fun `home and skipped stops never name a tour, and a nameless region is its country`() {
+        val stops = listOf(
+            stop(0, region("Luzern"), kind = StopKind.HOME),
+            stop(1, region("Ticino")),
+            stop(2, region("", "Italy")),
+            stop(3, region("Valais"), state = StopState.SKIPPED),
+            stop(4, region("Luzern"), kind = StopKind.HOME),
+        )
+        assertEquals("Ticino & Italy", TripName.region(stops))
+    }
+
+    @Test
+    fun `a made-up name follows from the id alone`() {
+        assertEquals("Curious Marmot", TripName.generated(""))
+        assertEquals("Rusty Edelweiss", TripName.generated("t1"))
+        assertEquals("Dusty Edelweiss", TripName.generated("t2"))
+        assertEquals("Windy Meadow", TripName.generated("demo-jura"))
+        // A negative hash still lands in the lists.
+        assertEquals("Sunny Fox", TripName.generated("plan-7"))
+        assertEquals("Gentle Lynx", TripName.generated("Ticino"))
+    }
+
+    @Test
+    fun `the title is the name, else where it goes, else made up`() {
+        assertEquals("Jura", Trip(id = "t1", name = "Jura", region = "Ticino").title)
+        assertEquals("Ticino", Trip(id = "t1", name = " ", region = "Ticino").title)
+        assertEquals("Rusty Edelweiss", Trip(id = "t1").title)
+    }
+}

--- a/app/src/test/java/com/nuelto/etappli/testutil/TestSupport.kt
+++ b/app/src/test/java/com/nuelto/etappli/testutil/TestSupport.kt
@@ -3,8 +3,10 @@ package com.nuelto.etappli.testutil
 import android.content.Context
 import com.nuelto.etappli.data.AuthRepository
 import com.nuelto.etappli.data.AuthUser
+import com.nuelto.etappli.data.SettingsRepository
 import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.data.model.StopKind
+import com.nuelto.etappli.data.model.UserSettings
 import com.nuelto.etappli.domain.PlaceSearch
 import com.nuelto.etappli.domain.PlaceSuggestion
 import com.nuelto.etappli.location.PlaceNameResolver
@@ -13,6 +15,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -115,4 +118,14 @@ class FakeShareLinkResolver(var result: String? = null) {
         gate?.await()
         return result
     }
+}
+
+/** Settings that arrive only once [gate] completes — for what a second tap does mid-write. */
+class GatedSettingsRepository : SettingsRepository {
+    val gate = CompletableDeferred<Unit>()
+    override fun settings(): Flow<UserSettings> = flow {
+        gate.await()
+        emit(UserSettings())
+    }
+    override suspend fun update(settings: UserSettings) = Unit
 }

--- a/app/src/test/java/com/nuelto/etappli/ui/FormatTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/FormatTest.kt
@@ -1,6 +1,7 @@
 package com.nuelto.etappli.ui
 
 import com.nuelto.etappli.data.model.StopLeg
+import com.nuelto.etappli.data.model.TransitRide
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
 import java.time.LocalDate
@@ -136,6 +137,13 @@ class FormatTest {
     fun `a drive joins distance and duration`() {
         assertEquals("124 km · 1 h 45 min", formatDrive(leg(124_400, 6300)))
         assertEquals("800 m · 12 min", formatDrive(leg(800, 700)))
+    }
+
+    @Test
+    fun `a drive to a stop no road reaches ends with the ride, and the one back starts with it`() {
+        val ride = TransitRide(mode = "cable car", durationSeconds = 1_440)
+        assertEquals("124 km · 1 h 45 min + cable car 24 min", formatDrive(leg(124_400, 6300).copy(rideAfter = ride)))
+        assertEquals("cable car 24 min + 136 km · 2 h", formatDrive(leg(136_000, 7200).copy(rideBefore = ride)))
     }
 
     @Test

--- a/app/src/test/java/com/nuelto/etappli/ui/FormatTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/FormatTest.kt
@@ -2,6 +2,7 @@ package com.nuelto.etappli.ui
 
 import com.nuelto.etappli.data.model.StopLeg
 import com.nuelto.etappli.data.model.TransitRide
+import com.nuelto.etappli.data.model.TravelMode
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
 import java.time.LocalDate
@@ -133,29 +134,39 @@ class FormatTest {
     private fun leg(meters: Int, seconds: Int, ascent: Int? = null) =
         StopLeg(distanceMeters = meters, durationSeconds = seconds, ascentMeters = ascent)
 
+    private val car = listOf(TravelMode.CAR)
+
     @Test
-    fun `a drive joins distance and duration`() {
-        assertEquals("124 km · 1 h 45 min", formatDrive(leg(124_400, 6300)))
-        assertEquals("800 m · 12 min", formatDrive(leg(800, 700)))
+    fun `a drive is the car with distance and duration`() {
+        assertEquals(listOf(DrivePart(car, "124 km · 1 h 45 min")), driveParts(leg(124_400, 6300)))
+        assertEquals("800 m · 12 min", driveParts(leg(800, 700)).single().text)
     }
 
     @Test
     fun `a drive to a stop no road reaches ends with the ride, and the one back starts with it`() {
-        val ride = TransitRide(mode = "cable car", durationSeconds = 1_440)
-        assertEquals("124 km · 1 h 45 min + cable car 24 min", formatDrive(leg(124_400, 6300).copy(rideAfter = ride)))
-        assertEquals("cable car 24 min + 136 km · 2 h", formatDrive(leg(136_000, 7200).copy(rideBefore = ride)))
+        val ride = TransitRide(modes = listOf(TravelMode.CABLE_CAR), durationSeconds = 1_440)
+        val drive = DrivePart(car, "124 km · 1 h 45 min")
+        val up = DrivePart(listOf(TravelMode.CABLE_CAR), "24 min")
+        assertEquals(listOf(drive, up), driveParts(leg(124_400, 6300).copy(rideAfter = ride)))
+        assertEquals(listOf(up, drive), driveParts(leg(124_400, 6300).copy(rideBefore = ride)))
+    }
+
+    @Test
+    fun `a ride that does not say what it is on gets the generic icon`() {
+        val parts = driveParts(leg(1_000, 60).copy(rideAfter = TransitRide(durationSeconds = 600)))
+        assertEquals(DrivePart(listOf(TravelMode.TRANSIT), "10 min"), parts.last())
     }
 
     @Test
     fun `a drive with no road says so rather than showing zero`() {
-        assertEquals("No drivable route", formatDrive(leg(0, 0)))
+        assertEquals(listOf(DrivePart(car, "No drivable route")), driveParts(leg(0, 0)))
     }
 
     @Test
     fun `the drive is distance and time only, never the climb`() {
         // Cumulative ascent beside a place name reads as the height of the place.
-        assertEquals("10 km · 12 min", formatDrive(leg(10_000, 700, 1450)))
-        assertEquals("10 km · 12 min", formatDrive(leg(10_000, 700, null)))
+        assertEquals("10 km · 12 min", driveParts(leg(10_000, 700, 1450)).single().text)
+        assertEquals("10 km · 12 min", driveParts(leg(10_000, 700, null)).single().text)
     }
     private val midday = LocalDateTime.of(2026, 9, 1, 15, 47)
     private val evening = LocalDateTime.of(2026, 9, 1, 22, 30)

--- a/app/src/test/java/com/nuelto/etappli/ui/FormatTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/FormatTest.kt
@@ -139,6 +139,11 @@ class FormatTest {
     }
 
     @Test
+    fun `a drive with no road says so rather than showing zero`() {
+        assertEquals("No drivable route", formatDrive(leg(0, 0)))
+    }
+
+    @Test
     fun `the drive is distance and time only, never the climb`() {
         // Cumulative ascent beside a place name reads as the height of the place.
         assertEquals("10 km · 12 min", formatDrive(leg(10_000, 700, 1450)))

--- a/app/src/test/java/com/nuelto/etappli/ui/components/TravelIconsTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/components/TravelIconsTest.kt
@@ -1,0 +1,31 @@
+package com.nuelto.etappli.ui.components
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.etappli.data.model.TravelMode
+import com.nuelto.etappli.testutil.TestCamperApp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = TestCamperApp::class)
+class TravelIconsTest {
+
+    @Test
+    fun `every way of travelling has an icon of its own`() {
+        val icons = TravelMode.entries.associateWith { modeIcon(it) }
+        assertEquals(TravelMode.entries.size, icons.values.distinct().size)
+        assertEquals(CableCar, icons[TravelMode.CABLE_CAR])
+        assertNotEquals(icons[TravelMode.CAR], icons[TravelMode.CABLE_CAR])
+    }
+
+    @Test
+    fun `the hand-drawn cable car sits on the same canvas as the set's icons`() {
+        assertEquals("CableCar", CableCar.name)
+        assertEquals(24f, CableCar.viewportWidth)
+        assertEquals(24f, CableCar.viewportHeight)
+        assertEquals(modeIcon(TravelMode.CAR).viewportWidth, CableCar.viewportWidth)
+    }
+}

--- a/app/src/test/java/com/nuelto/etappli/ui/nav/AppNavHostTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/nav/AppNavHostTest.kt
@@ -88,14 +88,16 @@ class AppNavHostTest {
     }
 
     @Test
-    fun `a tour is planned from the fab menu`() {
+    fun `a tour is planned from the fab menu by adding its first stop`() {
         setContent()
         compose.onNodeWithContentDescription("New trip").performClick()
         compose.onNodeWithText("Plan a tour", useUnmergedTree = true).performClick()
-        compose.onNodeWithText("Planned start").assertIsDisplayed()
-        compose.onNodeWithText("Trip name").performTextInput("Ticino-Tour")
-        compose.onNodeWithText("Save").performClick()
-        compose.onNodeWithText("Ticino-Tour").assertIsDisplayed()
+        // No form: straight into the stop editor, over the new tour's timeline.
+        compose.onNodeWithText("New stop").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Cancel").performClick()
+        compose.onNodeWithText("No stops yet — add where you want to go.").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Back").performClick()
+        compose.onNodeWithText("Trips").assertIsDisplayed()
     }
 
     @Test
@@ -219,19 +221,20 @@ class AppNavHostTest {
     }
 
     @Test
-    fun `a tour planned from the chooser comes back to it`() {
+    fun `a tour planned from the chooser takes the place as its first stop`() {
         ApplicationProvider.getApplicationContext<TestCamperApp>().container =
             AppContainer(null, InMemoryTripRepository(seed = false), InMemorySettingsRepository())
         setContent(shared)
 
         compose.onNodeWithText("Plan a tour").performClick()
-        compose.onNodeWithText("Trip name").performTextInput("Ticino")
-        compose.onNodeWithText("Save").performClick()
-
-        // Back on the chooser rather than in the new tour, with the tour now listed.
-        compose.onNodeWithText("Add to a trip").assertIsDisplayed()
-        compose.onNodeWithText("Ticino").performClick()
+        // Straight into the new tour's stop editor, with the place filled in.
         compose.onNodeWithText("New stop").assertIsDisplayed()
         compose.onAllNodesWithText("Camping Grimselblick")[0].assertIsDisplayed()
+        compose.onNodeWithText("Save").performScrollTo().performClick()
+
+        // Saved onto the tour's timeline; the chooser is gone from the back stack.
+        compose.onAllNodesWithText("Camping Grimselblick")[0].assertIsDisplayed()
+        compose.onNodeWithContentDescription("Back").performClick()
+        compose.onNodeWithText("Trips").assertIsDisplayed()
     }
 }

--- a/app/src/test/java/com/nuelto/etappli/ui/share/AddToTripScreenTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/share/AddToTripScreenTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.etappli.data.InMemorySettingsRepository
 import com.nuelto.etappli.data.InMemoryTripRepository
 import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.data.model.Trip
@@ -16,6 +17,7 @@ import com.nuelto.etappli.testutil.FakeShareLinkResolver
 import com.nuelto.etappli.testutil.TestCamperApp
 import java.time.LocalDate
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -33,16 +35,14 @@ class AddToTripScreenTest {
     private val tripRepository = InMemoryTripRepository(seed = false)
     private val resolver = FakeShareLinkResolver()
     private var cancelled = 0
-    private var planned = 0
     private val added = mutableListOf<Pair<String, SharedPlace>>()
 
     private fun setContent(place: SharedPlace) {
         compose.setContent {
             AddToTripScreen(
                 onCancel = { cancelled++ },
-                onPlanTrip = { planned++ },
                 onAddTo = { tripId, shared -> added += tripId to shared },
-                viewModel = AddToTripViewModel(place, tripRepository, resolver::expand),
+                viewModel = AddToTripViewModel(place, tripRepository, InMemorySettingsRepository(), resolver::expand),
             )
         }
     }
@@ -108,11 +108,14 @@ class AddToTripScreenTest {
     }
 
     @Test
-    fun `with no trips at all the chooser offers to plan one`() {
-        setContent(SharedPlace("Camping X", LatLng(46.5, 8.3)))
+    fun `with no trips at all the chooser plans one and files the place on it`() = runTest {
+        val place = SharedPlace("Camping X", LatLng(46.5, 8.3))
+        setContent(place)
         compose.onNodeWithText("No trips yet.\nPlan a tour, then add this place to it.").assertIsDisplayed()
         compose.onNodeWithText("Plan a tour").performClick()
-        assertEquals(1, planned)
+        val planned = tripRepository.trips().first().single()
+        assertEquals(TripStatus.PLANNED, planned.status)
+        assertEquals(listOf(planned.id to place), added)
 
         compose.onNodeWithContentDescription("Cancel").performClick()
         assertEquals(1, cancelled)

--- a/app/src/test/java/com/nuelto/etappli/ui/share/AddToTripViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/share/AddToTripViewModelTest.kt
@@ -1,14 +1,18 @@
 package com.nuelto.etappli.ui.share
 
+import com.nuelto.etappli.data.InMemorySettingsRepository
 import com.nuelto.etappli.data.InMemoryTripRepository
 import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
+import com.nuelto.etappli.data.model.UserSettings
 import com.nuelto.etappli.domain.SharedPlace
 import com.nuelto.etappli.testutil.FakeShareLinkResolver
+import com.nuelto.etappli.testutil.GatedSettingsRepository
 import com.nuelto.etappli.testutil.MainDispatcherRule
 import java.time.LocalDate
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -22,9 +26,11 @@ class AddToTripViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     private val tripRepository = InMemoryTripRepository(seed = false)
+    private val settingsRepository = InMemorySettingsRepository()
     private val resolver = FakeShareLinkResolver()
 
-    private fun viewModel(place: SharedPlace) = AddToTripViewModel(place, tripRepository, resolver::expand)
+    private fun viewModel(place: SharedPlace) =
+        AddToTripViewModel(place, tripRepository, settingsRepository, resolver::expand)
 
     private suspend fun trip(name: String, status: TripStatus, start: LocalDate = LocalDate.of(2026, 6, 1)) {
         tripRepository.upsertTrip(Trip(id = name, name = name, startDate = start, status = status))
@@ -86,6 +92,30 @@ class AddToTripViewModelTest {
         // Nothing left to follow: a second try is a no-op, not another request.
         vm.expand()
         assertEquals(2, resolver.requests.size)
+    }
+
+    @Test
+    fun `planning a tour for the place makes an unnamed plan from home and hands back its id`() = runTest {
+        settingsRepository.update(UserSettings(homeName = "Luzern", homeLocation = LatLng(47.05, 8.31)))
+        val created = mutableListOf<String>()
+        viewModel(SharedPlace("Camping X", LatLng(46.5, 8.3))).planTour { created += it }
+        val trip = tripRepository.trip(created.single()).first()!!
+        assertEquals(TripStatus.PLANNED, trip.status)
+        assertEquals("", trip.name)
+        assertEquals(2, tripRepository.stops(trip.id).first().size)
+    }
+
+    @Test
+    fun `a second tap while the plan is being made mints no second plan`() = runTest {
+        val gated = GatedSettingsRepository()
+        val vm = AddToTripViewModel(SharedPlace("Camping X", LatLng(46.5, 8.3)), tripRepository, gated)
+        val created = mutableListOf<String>()
+        vm.planTour { created += it }
+        vm.planTour { created += it }
+        gated.gate.complete(Unit)
+        assertEquals(1, created.size)
+        vm.planTour { created += it }
+        assertEquals(2, tripRepository.trips().first().size)
     }
 
     @Test

--- a/app/src/test/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreenTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreenTest.kt
@@ -40,6 +40,8 @@ import com.nuelto.etappli.data.model.Stop
 import com.nuelto.etappli.data.model.StopKind
 import com.nuelto.etappli.data.model.StopElevation
 import com.nuelto.etappli.data.model.StopLeg
+import com.nuelto.etappli.data.model.TransitRide
+import com.nuelto.etappli.data.model.TravelMode
 import com.nuelto.etappli.data.model.StopState
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
@@ -689,8 +691,30 @@ class TripDetailScreenTest {
             )
         }
         setContent("p1")
-        compose.onNodeWithTag("timeline").performScrollToNode(hasText("\u2192 124 km \u00b7 1 h 45 min"))
-        compose.onNodeWithText("\u2192 124 km \u00b7 1 h 45 min", useUnmergedTree = true).assertIsDisplayed()
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("124 km \u00b7 1 h 45 min"))
+        compose.onNodeWithText("124 km \u00b7 1 h 45 min", useUnmergedTree = true).assertIsDisplayed()
+        compose.onNodeWithContentDescription("car", useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a stop reached by cable car shows the ride with its icon`() {
+        seedPlan()
+        runBlocking {
+            val s2 = tripRepository.stops("p1").first().first { it.id == "s2" }
+            tripRepository.upsertStop(
+                s2.copy(
+                    leg = StopLeg(
+                        from = LatLng(47.05, 8.31), to = LatLng(46.16, 8.79),
+                        distanceMeters = 124_000, durationSeconds = 6_300,
+                        rideAfter = TransitRide(modes = listOf(TravelMode.CABLE_CAR), durationSeconds = 1_440),
+                    ),
+                ),
+            )
+        }
+        setContent("p1")
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("24 min"))
+        compose.onNodeWithText("24 min", useUnmergedTree = true).assertIsDisplayed()
+        compose.onNodeWithContentDescription("cable car", useUnmergedTree = true).assertIsDisplayed()
     }
 
     @Test
@@ -698,7 +722,7 @@ class TripDetailScreenTest {
         seedPlan()
         setContent("p1")
         compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camping Delta"))
-        compose.onAllNodes(hasText("\u2192", substring = true)).assertCountEquals(0)
+        compose.onAllNodesWithContentDescription("car", useUnmergedTree = true).assertCountEquals(0)
     }
     @Test
     fun `a stop shows how high it sits`() {

--- a/app/src/test/java/com/nuelto/etappli/ui/tripdetail/TripDetailViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/tripdetail/TripDetailViewModelTest.kt
@@ -10,11 +10,13 @@ import com.nuelto.etappli.data.model.ExpenseType
 import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.data.model.Stop
 import com.nuelto.etappli.data.model.StopLeg
+import com.nuelto.etappli.data.model.StopRegion
 import com.nuelto.etappli.data.model.StopState
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
 import com.nuelto.etappli.domain.VignetteTable
 import com.nuelto.etappli.domain.PlaceCacheSweeper
+import com.nuelto.etappli.domain.RegionResolver
 import com.nuelto.etappli.domain.RoutedLeg
 import com.nuelto.etappli.domain.RouteRefresher
 import com.nuelto.etappli.testutil.MainDispatcherRule
@@ -650,4 +652,38 @@ class TripDetailViewModelTest {
         assertNull(vm.uiState.value.driveFromHere)
     }
 
+}
+
+@RunWith(AndroidJUnit4::class)
+class TripDetailRegionTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val tripRepository = InMemoryTripRepository(seed = false)
+
+    @Test
+    fun `opening a trip finds the region of every located stop, and again when a pin moves`() = runTest {
+        tripRepository.upsertTrip(Trip(id = "t1", status = TripStatus.PLANNED))
+        tripRepository.upsertStop(Stop(id = "s1", tripId = "t1", location = LatLng(46.17, 8.79), orderIndex = 0))
+        tripRepository.upsertStop(Stop(id = "s2", tripId = "t1", orderIndex = 1))
+        val asked = mutableListOf<LatLng>()
+        TripDetailViewModel(
+            SavedStateHandle(mapOf("tripId" to "t1")),
+            tripRepository,
+            InMemorySettingsRepository(),
+            regionResolver = RegionResolver(tripRepository) { at ->
+                asked += at
+                StopRegion(name = "Ticino", country = "Switzerland")
+            },
+        )
+        assertEquals(listOf(LatLng(46.17, 8.79)), asked)
+        assertEquals("Ticino", tripRepository.trip("t1").first()!!.region)
+
+        // A stop that gets a pin is looked up; one whose pin moves is looked up again.
+        val s2 = tripRepository.stops("t1").first().first { it.id == "s2" }
+        tripRepository.upsertStop(s2.copy(location = LatLng(47.0, 7.0)))
+        tripRepository.upsertStop(s2.copy(location = LatLng(47.5, 7.5)))
+        assertEquals(listOf(LatLng(46.17, 8.79), LatLng(47.0, 7.0), LatLng(47.5, 7.5)), asked)
+    }
 }

--- a/app/src/test/java/com/nuelto/etappli/ui/tripedit/TripEditScreenTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/tripedit/TripEditScreenTest.kt
@@ -1,8 +1,6 @@
 package com.nuelto.etappli.ui.tripedit
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsEnabled
-import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -33,12 +31,8 @@ class TripEditScreenTest {
     private val tripRepository = InMemoryTripRepository(seed = false)
     private val events = mutableListOf<String>()
 
-    private fun setContent(tripId: String? = null, planned: Boolean = false) {
-        val handle = when {
-            tripId != null -> SavedStateHandle(mapOf("tripId" to tripId))
-            planned -> SavedStateHandle(mapOf("planned" to true))
-            else -> SavedStateHandle()
-        }
+    private fun setContent(tripId: String? = null) {
+        val handle = if (tripId != null) SavedStateHandle(mapOf("tripId" to tripId)) else SavedStateHandle()
         val viewModel = TripEditViewModel(handle, tripRepository)
         compose.setContent {
             TripEditScreen(
@@ -50,12 +44,11 @@ class TripEditScreenTest {
     }
 
     @Test
-    fun `new trip cannot be saved until it has a name`() {
+    fun `a new trip saves with the name typed`() {
         setContent()
         compose.onNodeWithText("New trip").assertIsDisplayed()
-        compose.onNodeWithText("Save").assertIsNotEnabled()
+        compose.onNodeWithText("Optional — named after its stops").assertIsDisplayed()
         compose.onNodeWithText("Trip name").performTextInput("Jura")
-        compose.onNodeWithText("Save").assertIsEnabled()
         compose.onNodeWithText("Save").performClick()
         runBlocking {
             val trip = tripRepository.trips().first().single()
@@ -65,15 +58,10 @@ class TripEditScreenTest {
     }
 
     @Test
-    fun `plan mode titles the form and saves a planned tour`() {
-        setContent(planned = true)
-        compose.onNodeWithText("Plan a tour").assertIsDisplayed()
-        compose.onNodeWithText("Planned start").assertIsDisplayed()
-        compose.onNodeWithText("Trip name").performTextInput("Ticino")
+    fun `a new trip saves without a name`() {
+        setContent()
         compose.onNodeWithText("Save").performClick()
-        runBlocking {
-            assertEquals(TripStatus.PLANNED, tripRepository.trips().first().single().status)
-        }
+        runBlocking { assertEquals("", tripRepository.trips().first().single().name) }
     }
 
     @Test
@@ -97,6 +85,7 @@ class TripEditScreenTest {
         setContent("t1")
         compose.onNodeWithText("Edit trip").assertIsDisplayed()
         compose.onNodeWithText("Old").assertIsDisplayed()
+        compose.onNodeWithText("Leave blank to call it \"Rusty Edelweiss\"").assertIsDisplayed()
         compose.onNodeWithText("Clear").performClick()
         compose.onNodeWithText("Clear").assertDoesNotExist()
         compose.onNodeWithText("Save").performClick()
@@ -104,5 +93,15 @@ class TripEditScreenTest {
             assertEquals(null, tripRepository.trip("t1").first()!!.endDate)
         }
         assertEquals(listOf("saved:t1:false"), events)
+    }
+
+    @Test
+    fun `a plan is edited under its own title, with a planned start`() {
+        runBlocking {
+            tripRepository.upsertTrip(Trip(id = "p1", startDate = LocalDate.of(2027, 6, 10), status = TripStatus.PLANNED))
+        }
+        setContent("p1")
+        compose.onNodeWithText("Edit plan").assertIsDisplayed()
+        compose.onNodeWithText("Planned start").assertIsDisplayed()
     }
 }

--- a/app/src/test/java/com/nuelto/etappli/ui/tripedit/TripEditViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/tripedit/TripEditViewModelTest.kt
@@ -2,9 +2,6 @@ package com.nuelto.etappli.ui.tripedit
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.nuelto.etappli.data.InMemorySettingsRepository
-import com.nuelto.etappli.data.model.LatLng
-import com.nuelto.etappli.data.model.StopKind
 import com.nuelto.etappli.data.InMemoryTripRepository
 import com.nuelto.etappli.data.model.Stop
 import com.nuelto.etappli.data.model.Trip
@@ -36,13 +33,13 @@ class TripEditViewModelTest {
         TripEditViewModel(SavedStateHandle(mapOf("tripId" to tripId)), tripRepository)
 
     @Test
-    fun `new trip starts blank and savable only with a name`() {
+    fun `new trip starts blank, with its name optional`() {
         val state = newTripViewModel().uiState.value
         assertTrue(state.isNew)
         assertTrue(state.loaded)
         assertEquals("", state.name)
         assertNull(state.endDate)
-        assertFalse(state.canSave)
+        assertEquals("Optional — named after its stops", state.nameHint)
     }
 
     @Test
@@ -57,7 +54,6 @@ class TripEditViewModelTest {
         assertEquals(LocalDate.of(2026, 7, 1), state.startDate)
         assertEquals(LocalDate.of(2026, 7, 5), state.endDate)
         assertEquals("wet", state.notes)
-        assertTrue(state.canSave)
         vm.setEndDate(null)
         assertNull(vm.uiState.value.endDate)
     }
@@ -76,11 +72,10 @@ class TripEditViewModelTest {
     }
 
     @Test
-    fun `save without a name is refused`() = runTest {
-        var called = false
-        newTripViewModel().save { _, _ -> called = true }
-        assertFalse(called)
-        assertTrue(tripRepository.trips().first().isEmpty())
+    fun `a trip saves without a name`() = runTest {
+        var saved: String? = null
+        newTripViewModel().save { id, _ -> saved = id }
+        assertEquals("", tripRepository.trip(saved!!).first()!!.name)
     }
 
     @Test
@@ -107,19 +102,18 @@ class TripEditViewModelTest {
     }
 
     @Test
+    fun `the hint says what an unnamed trip is called`() = runTest {
+        tripRepository.upsertTrip(Trip(id = "t1", name = "Old"))
+        assertEquals("Leave blank to call it \"Rusty Edelweiss\"", editViewModel("t1").uiState.value.nameHint)
+        tripRepository.upsertStop(Stop(id = "s1", tripId = "t1", region = com.nuelto.etappli.data.model.StopRegion(name = "Ticino")))
+        assertEquals("Leave blank to call it \"Ticino\"", editViewModel("t1").uiState.value.nameHint)
+    }
+
+    @Test
     fun `editing an id that vanished behaves like a new trip`() {
         val state = editViewModel("gone").uiState.value
         assertTrue(state.isNew)
         assertTrue(state.loaded)
-    }
-
-    @Test
-    fun `a plan route creates a planned tour`() = runTest {
-        val vm = TripEditViewModel(SavedStateHandle(mapOf("planned" to true)), tripRepository)
-        assertTrue(vm.uiState.value.isPlan)
-        vm.setName("Ticino")
-        vm.save { _, _ -> }
-        assertEquals(TripStatus.PLANNED, tripRepository.trips().first().single().status)
     }
 
     @Test
@@ -175,81 +169,4 @@ class TripEditViewModelTest {
         vm.save { _, _ -> }
         assertEquals(TripStatus.PLANNED, tripRepository.trip("p1").first()!!.status)
     }
-    // --- home as the plan's starting point ----------------------------------------------
-
-    private val settingsRepository = InMemorySettingsRepository()
-
-    private fun planViewModel() = TripEditViewModel(
-        SavedStateHandle(mapOf("planned" to true)),
-        tripRepository,
-        settingsRepository,
-    )
-
-    private suspend fun setHome(name: String = "Luzern") {
-        settingsRepository.update(
-            settingsRepository.settings().first()
-                .copy(homeName = name, homeLocation = LatLng(47.0502, 8.3093)),
-        )
-    }
-
-    @Test
-    fun `a new plan sets out from home and comes back to it`() = runTest {
-        setHome()
-        val vm = planViewModel()
-        vm.setName("Ticino")
-        vm.setStartDate(LocalDate.of(2027, 6, 10))
-        var created: String? = null
-        vm.save { id, _ -> created = id }
-
-        val stops = tripRepository.stops(created!!).first().sortedBy { it.orderIndex }
-        assertEquals(listOf(0, 1), stops.map { it.orderIndex })
-        stops.forEach { home ->
-            assertEquals("Luzern", home.name)
-            assertEquals(StopKind.HOME, home.kind)
-            assertEquals(LatLng(47.0502, 8.3093), home.location)
-            assertEquals(LocalDate.of(2027, 6, 10), home.arrivalDate)
-        }
-    }
-
-    @Test
-    fun `with no home set a new plan starts empty`() = runTest {
-        val vm = planViewModel()
-        vm.setName("Ticino")
-        var created: String? = null
-        vm.save { id, _ -> created = id }
-
-        assertTrue(tripRepository.stops(created!!).first().isEmpty())
-    }
-
-    @Test
-    fun `a logged trip does not get a home stop`() = runTest {
-        setHome()
-        val vm = TripEditViewModel(SavedStateHandle(), tripRepository, settingsRepository)
-        vm.setName("Last weekend")
-        var created: String? = null
-        vm.save { id, _ -> created = id }
-
-        assertTrue(tripRepository.stops(created!!).first().isEmpty())
-    }
-
-    @Test
-    fun `editing an existing plan does not add a second home`() = runTest {
-        setHome()
-        val first = planViewModel()
-        first.setName("Ticino")
-        var created: String? = null
-        first.save { id, _ -> created = id }
-        assertEquals(2, tripRepository.stops(created!!).first().size)
-
-        val again = TripEditViewModel(
-            SavedStateHandle(mapOf("tripId" to created!!)),
-            tripRepository,
-            settingsRepository,
-        )
-        again.setName("Ticino-Tour")
-        again.save { _, _ -> }
-
-        assertEquals(2, tripRepository.stops(created!!).first().size)
-    }
-
 }

--- a/app/src/test/java/com/nuelto/etappli/ui/triplist/TripListScreenTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/triplist/TripListScreenTest.kt
@@ -16,6 +16,7 @@ import com.nuelto.etappli.data.model.Stop
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
 import java.time.LocalDate
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -41,7 +42,8 @@ class TripListScreenTest {
         compose.setContent {
             TripListScreen(
                 onTripClick = { clicks += "trip:$it" },
-                onAddTrip = { planned -> clicks += if (planned) "plan" else "log" },
+                onLogTrip = { clicks += "log" },
+                onTourPlanned = { clicks += "planned:$it" },
                 onOpenMap = { clicks += "map" },
                 onOpenSettings = { clicks += "settings" },
                 viewModel = viewModel,
@@ -121,7 +123,10 @@ class TripListScreenTest {
         compose.onNodeWithText("Log a trip", useUnmergedTree = true).performClick()
         compose.onNodeWithContentDescription("New trip").performClick()
         compose.onNodeWithText("Plan a tour", useUnmergedTree = true).performClick()
-        assertEquals(listOf("map", "settings", "log", "plan"), clicks)
+        // Planning a tour makes it on the spot and hands over its id.
+        val planned = runBlocking { tripRepository.trips().first().single() }
+        assertEquals(TripStatus.PLANNED, planned.status)
+        assertEquals(listOf("map", "settings", "log", "planned:${planned.id}"), clicks)
     }
 
     @Test

--- a/app/src/test/java/com/nuelto/etappli/ui/triplist/TripListViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/triplist/TripListViewModelTest.kt
@@ -10,8 +10,10 @@ import com.nuelto.etappli.data.model.Stop
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
 import com.nuelto.etappli.data.model.UserSettings
+import com.nuelto.etappli.testutil.GatedSettingsRepository
 import com.nuelto.etappli.testutil.MainDispatcherRule
 import java.time.LocalDate
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -122,6 +124,32 @@ class TripListViewModelTest {
         viewModel().uiState.test {
             assertEquals(setOf("t1"), awaitItem().fuelEstimates.keys)
         }
+    }
+
+    @Test
+    fun `planning a tour makes an unnamed plan from home and hands back its id`() = runTest {
+        settingsRepository.update(UserSettings(homeName = "Luzern", homeLocation = LatLng(47.05, 8.31)))
+        val created = mutableListOf<String>()
+        viewModel().planTour { created += it }
+        val trip = tripRepository.trip(created.single()).first()!!
+        assertEquals(TripStatus.PLANNED, trip.status)
+        assertEquals("", trip.name)
+        assertEquals(2, tripRepository.stops(trip.id).first().size)
+    }
+
+    @Test
+    fun `a second tap while the plan is being made mints no second plan`() = runTest {
+        val gated = GatedSettingsRepository()
+        val vm = TripListViewModel(tripRepository, gated)
+        val created = mutableListOf<String>()
+        vm.planTour { created += it }
+        vm.planTour { created += it }
+        gated.gate.complete(Unit)
+        assertEquals(1, created.size)
+        assertEquals(1, tripRepository.trips().first().size)
+        // And once made, the next tap plans another.
+        vm.planTour { created += it }
+        assertEquals(2, created.size)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Four commits on top of `main`:

- **Plan a tour by adding its first stop, and name it after where it goes** (1567c4e) — "Plan a tour" opens the stop editor straight away; the tour is dated from its first stop and named after the regions it visits.
- **Follow the road past a stop that has none** (e1a35ce) — one stop Google cannot drive to (Riederalp is car-free) emptied the whole `computeRoutes` answer, so every leg fell back to a straight line. A window that comes back empty is now asked drive by drive, and a drive with no road is stored as a leg with no distance so it is not re-asked for 30 days.
- **Ride where the road ends: park and ride to a stop no road reaches** (15c42a8) — a drive with no road goes park-and-ride: the TRANSIT route to the stop says where its last ride boards, the vehicle is left there (up to three rides back if no road reaches that either), the road legs run to and from that spot, and the ride is stored on the leg either side of the drive. Dotted on the map, never in the fuel. `Polyline` gains the encode half.
- **Show what you ride on as an icon, not a word** (d0d3a2a) — the line under a stop leads each piece with an icon: the car before the numbers, the vehicle before a ride's minutes. Rides store `TravelMode` values instead of words; the cable car icon is hand-drawn because the icon set has none.

## Notes

- Transit requests only go out after a drive has failed, and the mode takes no `routingPreference` and no intermediates. Google may bill transit routing on a higher SKU than plain driving.
- The live "how far from here" distance still targets the stop's pin, so it shows nothing for a car-free stop. Pointing it at the parking spot is a follow-up.
- Stops that stored a "no road" leg with the second commit installed keep it for 30 days; a re-route happens once any other leg of the trip is missing.

## Test plan

- [x] `./gradlew test :app:coverageVerify :app:pitest` — all green, mutation score 94%
- [x] Emulator (local-only build): added the Naturfreunde Riederalp hut to a Locarno tour; the timeline shows car "91 km · 2 h 7 min" and gondola "28 min", the map runs the road to the Betten cable-car station and draws the ride dotted up to the hut
- [ ] On the phone: open the Riederalp tours and check the legs come back with the ride

🤖 Generated with [Claude Code](https://claude.com/claude-code)
