### PR TITLE
Keep every stop behind the one before it

### DIFF
--- a/.claude/skills/app-review/SKILL.md
+++ b/.claude/skills/app-review/SKILL.md
@@ -9,6 +9,7 @@ Review the current diff (`git diff` / `git diff HEAD`) against these invariants.
 ## Data invariants
 
 - **Every stop/expense mutation path recomputes trip totals.** Any new call site that writes stops or expenses must trigger `recomputeTotals(tripId)` (both `FirestoreTripRepository` and `InMemoryTripRepository`), or `Trip.totalCost`/`nights` go stale in the trip list.
+- **A stop edit and the shift it causes are one write.** Multi-stop changes go through `upsertStops` (one batch), never `upsertStop` in a loop: both repos settle the plan (`DateCascade.settle`) after every stop write, so a half-written change would be re-dated twice.
 - **Firestore writes are fire-and-forget.** Never `await()` a `set`/`update`/`delete` — with offline persistence the Task only completes on server ack, so awaiting hangs the UI offline. Reads that must work offline use `Source.CACHE` (which includes pending writes).
 - **Repository parity.** `InMemoryTripRepository` and `FirestoreTripRepository` implement the same interface and must stay behaviorally equivalent (ordering, id generation on blank id, cascade delete of stops/expenses with the trip). A change to one usually needs the mirror change.
 - **Camping cost lives on the Stop** (`campingCostTotal`). The CAMPING expense type is only for extra fees not tied to a stay; `CostCalculator.breakdown` merges both. Don't introduce double-counting.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,9 +189,14 @@ MVVM + repository, hand-rolled DI — no Hilt, no Room. Package root:
   front of what has already happened. `Timeline.insertion` turns the row key (carried to
   the editor as `StopEditRoute.insertBefore`) into the order index and the start date the
   new row takes over, and `DateCascade.shift` moves the rest of the plan back by the
-  nights it takes. Every such edit writes `reorderStops` + `DateCascade.resequence`,
+  nights it takes. Every such edit writes the new order + `DateCascade.resequence`,
   which re-dates the plan from the row order (a pure reorder keeps the trip's start and
   length); nights/arrival changes instead shift downstream dates (`DateCascade.shift`).
+  **A stop and the shift it causes are one `upsertStops` write** (a Firestore batch),
+  never `upsertStop` in a loop: both repositories run `DateCascade.settle` after every
+  stop write — no PLANNED stop may arrive before the one in front of it leaves — so a
+  half-written change would be re-dated twice, and a lost cascade can never leave a
+  plan overlapping itself (a DONE stop's departure binds nothing: tours leave early).
   Color language everywhere (lists, timeline, maps):
   **blue = planned, green = active/current, grey = done** (`ui/theme/StatusColors.kt`).
   In the timeline a stop's icon carries both axes at once: the **shape** is the kind
@@ -212,9 +217,10 @@ MVVM + repository, hand-rolled DI — no Hilt, no Room. Package root:
   each repository after every stop/expense mutation (`recomputeTotals`), reading Firestore
   from `Source.CACHE` (which includes pending writes, so it works offline). Any new
   mutation path must call it, or the trip list shows stale totals. Stop mutations also
-  call `redatePlan`: a PLANNED trip's `startDate` follows its first unskipped stop
-  (`DateCascade.start`), and `TripStarter` shifts from that stop rather than from
-  `startDate`, so a tour started on a day has its first stop on that day.
+  call `redatePlan`: it settles the plan (above), and a PLANNED trip's `startDate`
+  follows its first unskipped stop (`DateCascade.start`) — `TripStarter` shifts from
+  that stop rather than from `startDate`, so a tour started on a day has its first stop
+  on that day.
 - **Cost semantics** (`domain/CostCalculator.kt`): camping cost lives **on the Stop**
   (`campingCostTotal`); the CAMPING expense type is only for extra site fees. Breakdown
   merges both into the CAMPING category. The fuel estimator (`domain/FuelEstimator.kt`)

--- a/app/src/main/java/com/nuelto/etappli/data/FirestoreTripRepository.kt
+++ b/app/src/main/java/com/nuelto/etappli/data/FirestoreTripRepository.kt
@@ -290,25 +290,25 @@ class FirestoreTripRepository(
         tripDoc.delete()
     }
 
-    override suspend fun upsertStop(stop: Stop) {
-        val col = trips(uid).document(stop.tripId).collection("stops")
-        val doc = if (stop.id.isBlank()) col.document() else col.document(stop.id)
-        doc.set(stop.toMap())
-        recomputeTotals(stop.tripId)
-        redatePlan(stop.tripId)
+    override suspend fun upsertStop(stop: Stop) = upsertStops(listOf(stop))
+
+    /** One batch: it reaches the local view as a whole, so no listener sees it half done. */
+    override suspend fun upsertStops(stops: List<Stop>) {
+        if (stops.isEmpty()) return
+        val batch = db.batch()
+        stops.forEach { stop ->
+            val col = trips(uid).document(stop.tripId).collection("stops")
+            batch.set(if (stop.id.isBlank()) col.document() else col.document(stop.id), stop.toMap())
+        }
+        batch.commit()
+        stops.map { it.tripId }.distinct().forEach {
+            recomputeTotals(it)
+            redatePlan(it)
+        }
     }
 
     override suspend fun deleteStop(tripId: String, stopId: String) {
         trips(uid).document(tripId).collection("stops").document(stopId).delete()
-        recomputeTotals(tripId)
-        redatePlan(tripId)
-    }
-
-    override suspend fun reorderStops(tripId: String, orderedStopIds: List<String>) {
-        val col = trips(uid).document(tripId).collection("stops")
-        orderedStopIds.forEachIndexed { index, stopId ->
-            col.document(stopId).update("orderIndex", index)
-        }
         recomputeTotals(tripId)
         redatePlan(tripId)
     }
@@ -325,14 +325,22 @@ class FirestoreTripRepository(
         recomputeTotals(tripId)
     }
 
-    /** A plan starts the day its first stop does; stop edits keep the trip doc saying so. */
+    /**
+     * No stop starts before the one in front of it leaves (DateCascade.settle), and a
+     * plan starts the day its first stop does. Both are kept true after every stop write,
+     * from the cache so it holds offline too. A finished trip is a record.
+     */
     private suspend fun redatePlan(tripId: String) {
         val tripDoc = trips(uid).document(tripId)
         val trip = runCatching { tripDoc.get(Source.CACHE).await().toTrip() }.getOrNull() ?: return
-        if (trip.status != TripStatus.PLANNED) return
+        if (trip.status == TripStatus.DONE) return
         val stops = runCatching {
             tripDoc.collection("stops").get(Source.CACHE).await().documents.map { it.toStop(tripId) }
         }.getOrNull() ?: return
+        DateCascade.settle(stops).forEach {
+            tripDoc.collection("stops").document(it.id).update("arrivalDate", it.arrivalDate.toEpochDay())
+        }
+        if (trip.status != TripStatus.PLANNED) return
         val start = DateCascade.start(stops) ?: return
         if (start != trip.startDate) tripDoc.update("startDate", start.toEpochDay())
     }

--- a/app/src/main/java/com/nuelto/etappli/data/InMemoryTripRepository.kt
+++ b/app/src/main/java/com/nuelto/etappli/data/InMemoryTripRepository.kt
@@ -63,26 +63,21 @@ class InMemoryTripRepository(seed: Boolean = true) : TripRepository {
         expensesFlow.update { list -> list.filterNot { it.tripId == tripId } }
     }
 
-    override suspend fun upsertStop(stop: Stop) {
-        val withId = if (stop.id.isBlank()) stop.copy(id = UUID.randomUUID().toString()) else stop
-        stopsFlow.update { list -> list.filterNot { it.id == withId.id } + withId }
-        recomputeTotals(withId.tripId)
-        redatePlan(withId.tripId)
+    override suspend fun upsertStop(stop: Stop) = upsertStops(listOf(stop))
+
+    override suspend fun upsertStops(stops: List<Stop>) {
+        if (stops.isEmpty()) return
+        val withIds = stops.map { if (it.id.isBlank()) it.copy(id = UUID.randomUUID().toString()) else it }
+        val ids = withIds.map { it.id }.toSet()
+        stopsFlow.update { list -> list.filterNot { it.id in ids } + withIds }
+        withIds.map { it.tripId }.distinct().forEach {
+            recomputeTotals(it)
+            redatePlan(it)
+        }
     }
 
     override suspend fun deleteStop(tripId: String, stopId: String) {
         stopsFlow.update { list -> list.filterNot { it.id == stopId } }
-        recomputeTotals(tripId)
-        redatePlan(tripId)
-    }
-
-    override suspend fun reorderStops(tripId: String, orderedStopIds: List<String>) {
-        stopsFlow.update { list ->
-            list.map { stop ->
-                val index = orderedStopIds.indexOf(stop.id)
-                if (stop.tripId == tripId && index >= 0) stop.copy(orderIndex = index) else stop
-            }
-        }
         recomputeTotals(tripId)
         redatePlan(tripId)
     }
@@ -98,18 +93,19 @@ class InMemoryTripRepository(seed: Boolean = true) : TripRepository {
         recomputeTotals(tripId)
     }
 
-    /** A plan starts the day its first stop does; stop edits keep the trip saying so. */
+    /**
+     * No stop starts before the one in front of it leaves (DateCascade.settle), and a
+     * plan starts the day its first stop does. Both are kept true after every stop write,
+     * so no path can leave a plan overlapping itself. A finished trip is a record.
+     */
     private fun redatePlan(tripId: String) {
+        val trip = tripsFlow.value.find { it.id == tripId } ?: return
+        if (trip.status == TripStatus.DONE) return
+        val settled = DateCascade.settle(stopsFlow.value.filter { it.tripId == tripId }).associateBy { it.id }
+        stopsFlow.update { list -> list.map { settled[it.id] ?: it } }
+        if (trip.status != TripStatus.PLANNED) return
         val start = DateCascade.start(stopsFlow.value.filter { it.tripId == tripId }) ?: return
-        tripsFlow.update { list ->
-            list.map { trip ->
-                if (trip.id == tripId && trip.status == TripStatus.PLANNED) {
-                    trip.copy(startDate = start)
-                } else {
-                    trip
-                }
-            }
-        }
+        tripsFlow.update { list -> list.map { if (it.id == tripId) it.copy(startDate = start) else it } }
     }
 
     private fun recomputeTotals(tripId: String) {

--- a/app/src/main/java/com/nuelto/etappli/data/TripRepository.kt
+++ b/app/src/main/java/com/nuelto/etappli/data/TripRepository.kt
@@ -22,8 +22,11 @@ interface TripRepository {
     suspend fun deleteTrip(tripId: String)
     suspend fun upsertStop(stop: Stop)
 
-    /** Rewrites orderIndex to match [orderedStopIds] in one pass (one totals recompute). */
-    suspend fun reorderStops(tripId: String, orderedStopIds: List<String>)
+    /**
+     * Writes several stops as one change (one totals recompute), so nothing ever sees
+     * the plan half-moved: an edit and the shift it causes behind it land together.
+     */
+    suspend fun upsertStops(stops: List<Stop>)
     suspend fun deleteStop(tripId: String, stopId: String)
     suspend fun upsertExpense(expense: Expense)
     suspend fun deleteExpense(tripId: String, expenseId: String)

--- a/app/src/main/java/com/nuelto/etappli/domain/DateCascade.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/DateCascade.kt
@@ -62,5 +62,39 @@ object DateCascade {
         return changed
     }
 
+    /**
+     * Pushes back every PLANNED stop that arrives before the stop in front of it leaves —
+     * nobody sleeps in two places on one night — and the rest of the plan with it, so the
+     * spacing behind it survives the way [shift] would have kept it. The repositories run
+     * this after every stop write, so no path can leave a plan overlapping itself. DONE
+     * stops are never rewritten and their planned departure binds nothing: a tour can
+     * leave a place early. SKIPPED stops sit outside the chain. Returns only the changed stops.
+     */
+    fun settle(stops: List<Stop>): List<Stop> {
+        val changed = mutableListOf<Stop>()
+        var leaves: LocalDate? = null
+        var carry = 0L
+        for (stop in stops.sortedBy { it.orderIndex }) {
+            when (stop.state) {
+                StopState.SKIPPED -> continue
+                StopState.DONE -> {
+                    leaves = null
+                    carry = 0
+                }
+                StopState.PLANNED -> {
+                    var arrival = stop.arrivalDate.plusDays(carry)
+                    val earliest = leaves
+                    if (earliest != null && arrival.isBefore(earliest)) {
+                        carry += ChronoUnit.DAYS.between(arrival, earliest)
+                        arrival = earliest
+                    }
+                    if (arrival != stop.arrivalDate) changed += stop.copy(arrivalDate = arrival)
+                    leaves = arrival.plusDays(stop.nights.toLong())
+                }
+            }
+        }
+        return changed
+    }
+
     private fun departure(stop: Stop): LocalDate = stop.arrivalDate.plusDays(stop.nights.toLong())
 }

--- a/app/src/main/java/com/nuelto/etappli/domain/NewPlan.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/NewPlan.kt
@@ -21,7 +21,7 @@ object NewPlan {
         today: LocalDate = LocalDate.now(),
     ): String {
         val id = repository.upsertTrip(Trip(startDate = today, status = TripStatus.PLANNED))
-        HomeStop.forNewPlan(id, settings, today).forEach { repository.upsertStop(it) }
+        repository.upsertStops(HomeStop.forNewPlan(id, settings, today))
         return id
     }
 }

--- a/app/src/main/java/com/nuelto/etappli/domain/TripStarter.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/TripStarter.kt
@@ -45,29 +45,30 @@ object TripStarter {
 
         if (!keepPlanAsTemplate) {
             repository.upsertTrip(started)
-            stops.forEach {
-                val moved = it.copy(
-                    arrivalDate = it.arrivalDate.plusDays(shift),
-                    state = if (it.id == departed) StopState.DONE else it.state,
-                )
-                if (moved != it) repository.upsertStop(moved)
-            }
+            repository.upsertStops(
+                stops.mapNotNull { stop ->
+                    stop.copy(
+                        arrivalDate = stop.arrivalDate.plusDays(shift),
+                        state = if (stop.id == departed) StopState.DONE else stop.state,
+                    ).takeIf { it != stop }
+                },
+            )
             return tripId
         }
 
         // Fresh copies start with clean denormalized totals; the stop/expense upserts
         // below rebuild them (Firestore only recomputes on those mutation paths).
         val newId = repository.upsertTrip(started.copy(id = "", totalCost = 0.0, nights = 0))
-        stops.forEach {
-            repository.upsertStop(
+        repository.upsertStops(
+            stops.map {
                 it.copy(
                     id = "",
                     tripId = newId,
                     state = if (it.id == departed) StopState.DONE else StopState.PLANNED,
                     arrivalDate = it.arrivalDate.plusDays(shift),
-                ),
-            )
-        }
+                )
+            },
+        )
         // Only planned costs travel to the new trip; stop links would dangle, drop them.
         expenses.filter { it.isEstimate }.forEach {
             repository.upsertExpense(
@@ -100,16 +101,16 @@ object TripStarter {
                 nights = 0,
             ),
         )
-        stops.filterNot { it.state == StopState.SKIPPED }.forEach {
-            repository.upsertStop(
+        repository.upsertStops(
+            stops.filterNot { it.state == StopState.SKIPPED }.map {
                 it.copy(
                     id = "",
                     tripId = newId,
                     state = StopState.PLANNED,
                     arrivalDate = it.arrivalDate.plusDays(shift),
-                ),
-            )
-        }
+                )
+            },
+        )
         expenses.filter { it.isEstimate }.forEach {
             repository.upsertExpense(
                 it.copy(id = "", tripId = newId, stopId = null, date = it.date.plusDays(shift)),

--- a/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailViewModel.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailViewModel.kt
@@ -231,15 +231,18 @@ class TripDetailViewModel(
         }
     }
 
-    /** ±1 night on a stop; the downstream planned schedule shifts along. */
+    /** ±1 night on a stop; the downstream planned schedule shifts along, in the same write. */
     fun changeNights(stopId: String, delta: Int) {
         viewModelScope.launch {
             writeLock.withLock {
-                val stop = freshStop(stopId) ?: return@withLock
+                val stops = tripRepository.stops(tripId).first()
+                val stop = stops.find { it.id == stopId } ?: return@withLock
                 val nights = (stop.nights + delta).coerceIn(0, 365)
                 if (nights == stop.nights) return@withLock
-                tripRepository.upsertStop(stop.copy(nights = nights))
-                shiftAfter(stop.orderIndex, (nights - stop.nights).toLong())
+                tripRepository.upsertStops(
+                    listOf(stop.copy(nights = nights)) +
+                        DateCascade.shift(stops, stop.orderIndex, (nights - stop.nights).toLong()),
+                )
             }
         }
     }
@@ -248,10 +251,13 @@ class TripDetailViewModel(
     fun arrived(stopId: String) {
         viewModelScope.launch {
             writeLock.withLock {
-                val stop = freshStop(stopId) ?: return@withLock
+                val stops = tripRepository.stops(tripId).first()
+                val stop = stops.find { it.id == stopId } ?: return@withLock
                 val today = LocalDate.now()
-                tripRepository.upsertStop(stop.copy(state = StopState.DONE, arrivalDate = today))
-                shiftAfter(stop.orderIndex, ChronoUnit.DAYS.between(stop.arrivalDate, today))
+                tripRepository.upsertStops(
+                    listOf(stop.copy(state = StopState.DONE, arrivalDate = today)) +
+                        DateCascade.shift(stops, stop.orderIndex, ChronoUnit.DAYS.between(stop.arrivalDate, today)),
+                )
             }
         }
     }
@@ -283,11 +289,6 @@ class TripDetailViewModel(
         }
     }
 
-    private suspend fun shiftAfter(orderIndex: Int, days: Long) {
-        val stops = tripRepository.stops(tripId).first()
-        DateCascade.shift(stops, orderIndex, days).forEach { tripRepository.upsertStop(it) }
-    }
-
     /**
      * Drops the dragged row at [toIndex] and returns the key it carries afterwards —
      * a moved gap is renamed after the stop it now sits in front of. The rows the user
@@ -304,7 +305,9 @@ class TripDetailViewModel(
     fun insertGap(key: String) {
         val at = Timeline.insertion(uiState.value.rows, key) ?: return
         viewModelScope.launch {
-            writeLock.withLock { shiftAfter(at.orderIndex - 1, 1) }
+            writeLock.withLock {
+                tripRepository.upsertStops(DateCascade.shift(tripRepository.stops(tripId).first(), at.orderIndex - 1, 1))
+            }
         }
     }
 
@@ -321,13 +324,21 @@ class TripDetailViewModel(
         )
     }
 
-    /** Writes a rearranged timeline: the new stop order, then the dates it implies. */
+    /** Writes a rearranged timeline in one go: the new stop order and the dates it implies. */
     private fun applyRows(rows: List<TimelineRow>) {
         val start = DateCascade.start(uiState.value.stops) ?: return
         viewModelScope.launch {
             writeLock.withLock {
-                tripRepository.reorderStops(tripId, rows.filterIsInstance<StopRow>().map { it.stop.id })
-                DateCascade.resequence(rows, start).forEach { tripRepository.upsertStop(it) }
+                val dated = DateCascade.resequence(rows, start).associateBy { it.id }
+                // Onto the stops as they are now, so a leg written meanwhile is not lost.
+                val current = tripRepository.stops(tripId).first().associateBy { it.id }
+                tripRepository.upsertStops(
+                    rows.filterIsInstance<StopRow>().mapIndexedNotNull { index, row ->
+                        val stop = current[row.stop.id] ?: return@mapIndexedNotNull null
+                        stop.copy(orderIndex = index, arrivalDate = dated[stop.id]?.arrivalDate ?: stop.arrivalDate)
+                            .takeIf { it != stop }
+                    },
+                )
             }
         }
     }

--- a/app/src/main/java/com/nuelto/etappli/ui/tripedit/StopEditViewModel.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/tripedit/StopEditViewModel.kt
@@ -260,14 +260,27 @@ class StopEditViewModel(
 
     private var saving = false
 
+    /**
+     * Saves the stop and moves the plan behind it in the same write: a new stop takes its
+     * slot and pushes the rest back by the nights it takes, a moved departure shifts the
+     * planned schedule along. One `upsertStops` for all of it, so nothing — not the
+     * timeline, not a route being written back — ever sees the plan half-moved.
+     */
     fun save(onSaved: () -> Unit) {
         val state = _uiState.value
         if (!state.canSave || saving) return
         saving = true
         viewModelScope.launch {
             try {
-                val old = existing
-                val base = old ?: Stop(tripId = route.tripId, orderIndex = newOrderIndex())
+                val stops = tripRepository.stops(route.tripId).first()
+                // The stop as it is now, not as it was when the editor opened: a route or a
+                // height written to it meanwhile must survive the save.
+                val old = existing?.let { known -> stops.find { it.id == known.id } ?: known }
+                val at = if (old == null) slot(stops) else null
+                val base = old ?: Stop(
+                    tripId = route.tripId,
+                    orderIndex = at ?: (stops.maxOfOrNull { it.orderIndex } ?: -1) + 1,
+                )
                 val parsed = parseDecimal(state.campingCost)
                 val nights = if (state.isStay) state.nights else 0
                 // No parseable price means "estimate at the kind's default rate" —
@@ -275,30 +288,35 @@ class StopEditViewModel(
                 val costKnown = parsed != null ||
                     state.kind == StopKind.FREE_CAMP || !state.isStay ||
                     (old != null && old.costKnown && old.campingCostTotal == 0.0 && old.kind == state.kind)
-                tripRepository.upsertStop(
-                    base.copy(
-                        name = state.savedName(),
-                        arrivalDate = state.arrivalDate,
-                        nights = nights,
-                        campingCostTotal = if (state.isStay) parsed ?: 0.0 else 0.0,
-                        location = state.location,
-                        notes = state.notes.trim(),
-                        kind = state.kind,
-                        costKnown = costKnown,
-                        placeId = state.placeId,
-                        locationCachedAt = state.locationCachedAt,
-                    ),
+                val saved = base.copy(
+                    name = state.savedName(),
+                    arrivalDate = state.arrivalDate,
+                    nights = nights,
+                    campingCostTotal = if (state.isStay) parsed ?: 0.0 else 0.0,
+                    location = state.location,
+                    notes = state.notes.trim(),
+                    kind = state.kind,
+                    costKnown = costKnown,
+                    placeId = state.placeId,
+                    locationCachedAt = state.locationCachedAt,
                 )
-                // An inserted stay pushes the rest of the plan back by the nights it takes.
-                insertAt?.let { at -> shiftAfter(at, nights.toLong()) }
-                // A moved departure shifts the downstream planned schedule along.
-                if (old != null) {
+                val writes = if (old == null) {
+                    // The stops from the slot on move down one to make room, and an inserted
+                    // stay pushes them back by the nights it takes.
+                    val shoved = stops.filter { at != null && it.orderIndex >= at }
+                        .map { it.copy(orderIndex = it.orderIndex + 1) }
+                    val pushed = insertAt?.let { DateCascade.shift(shoved, it, nights.toLong()) }
+                        .orEmpty().associateBy { it.id }
+                    shoved.map { pushed[it.id] ?: it } + saved
+                } else {
+                    // A moved departure shifts the downstream planned schedule along.
                     val days = ChronoUnit.DAYS.between(
                         old.arrivalDate.plusDays(old.nights.toLong()),
                         state.arrivalDate.plusDays(nights.toLong()),
                     )
-                    shiftAfter(old.orderIndex, days)
+                    listOf(saved) + DateCascade.shift(stops, old.orderIndex, days)
                 }
+                tripRepository.upsertStops(writes)
                 onSaved()
             } finally {
                 saving = false
@@ -306,33 +324,18 @@ class StopEditViewModel(
         }
     }
 
-    private suspend fun shiftAfter(orderIndex: Int, days: Long) {
-        DateCascade.shift(tripRepository.stops(route.tripId).first(), orderIndex, days)
-            .forEach { tripRepository.upsertStop(it) }
-    }
-
     /**
-     * New stops append — except when one is inserted in front of a row; mid-trip with
-     * check-ins, where a spontaneous stop slots in right after the last done stop; and
-     * on a plan that ends with the drive home, which a stop added to the end goes in
-     * front of, pushing it back like any insertion. Either way the stops from there on
-     * move down one.
+     * The slot a new stop takes, or null to append: the row it was inserted in front of;
+     * mid-trip with check-ins, right after the last done stop; on a plan that ends with
+     * the drive home, in front of that — pushing the plan back like any insertion.
      */
-    private suspend fun newOrderIndex(): Int {
-        val stops = tripRepository.stops(route.tripId).first()
+    private fun slot(stops: List<Stop>): Int? {
         val lastDone = stops.filter { it.state == StopState.DONE }.maxOfOrNull { it.orderIndex }
-        val at = when {
+        return when {
             insertAt != null -> insertAt
             tripStatus == TripStatus.ACTIVE && lastDone != null -> lastDone + 1
             else -> HomeStop.returning(stops)?.orderIndex?.also { insertAt = it }
-        } ?: return (stops.maxOfOrNull { it.orderIndex } ?: -1) + 1
-        shoveDown(stops, at)
-        return at
-    }
-
-    private suspend fun shoveDown(stops: List<Stop>, from: Int) {
-        stops.filter { it.orderIndex >= from }
-            .forEach { tripRepository.upsertStop(it.copy(orderIndex = it.orderIndex + 1)) }
+        }
     }
 
     fun delete(onDeleted: () -> Unit) {

--- a/app/src/main/java/com/nuelto/etappli/ui/tripedit/TripEditViewModel.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/tripedit/TripEditViewModel.kt
@@ -102,9 +102,9 @@ class TripEditViewModel(
                 if (base.status == TripStatus.PLANNED) {
                     val days = ChronoUnit.DAYS.between(base.startDate, state.startDate)
                     if (days != 0L) {
-                        tripRepository.stops(savedId).first().forEach {
-                            tripRepository.upsertStop(it.copy(arrivalDate = it.arrivalDate.plusDays(days)))
-                        }
+                        tripRepository.upsertStops(
+                            tripRepository.stops(savedId).first().map { it.copy(arrivalDate = it.arrivalDate.plusDays(days)) },
+                        )
                     }
                 }
                 onSaved(savedId, state.isNew)

--- a/app/src/test/java/com/nuelto/etappli/data/InMemoryTripRepositoryTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/data/InMemoryTripRepositoryTest.kt
@@ -115,26 +115,62 @@ class InMemoryTripRepositoryTest {
     }
 
     @Test
-    fun `reorder rewrites order indexes to match the given id order`() = runTest {
+    fun `several stops land together, ids given out and totals recomputed`() = runTest {
         val id = addTrip()
-        repo.upsertStop(Stop(id = "a", tripId = id, name = "A", orderIndex = 0))
-        repo.upsertStop(Stop(id = "b", tripId = id, name = "B", orderIndex = 1))
-        repo.upsertStop(Stop(id = "c", tripId = id, name = "C", orderIndex = 2))
-        repo.reorderStops(id, listOf("c", "a", "b"))
-        assertEquals(listOf("C", "A", "B"), repo.stops(id).first().map { it.name })
-        assertEquals(listOf(0, 1, 2), repo.stops(id).first().map { it.orderIndex })
+        val other = addTrip(id = "other")
+        val start = LocalDate.of(2026, 6, 1)
+        repo.upsertStop(Stop(id = "a", tripId = id, name = "A", orderIndex = 0, nights = 1, campingCostTotal = 10.0, arrivalDate = start))
+        repo.upsertStops(
+            listOf(
+                Stop(id = "a", tripId = id, name = "A", orderIndex = 1, nights = 2, campingCostTotal = 10.0, arrivalDate = start.plusDays(1)),
+                Stop(tripId = id, name = "New", orderIndex = 0, nights = 1, campingCostTotal = 5.0, arrivalDate = start),
+                Stop(tripId = other, name = "X", orderIndex = 0, nights = 3),
+            ),
+        )
+        val stops = repo.stops(id).first()
+        assertEquals(listOf("New", "A"), stops.map { it.name })
+        assertTrue(stops.first().id.isNotBlank())
+        assertEquals(3, repo.trip(id).first()!!.nights)
+        assertEquals(15.0, repo.trip(id).first()!!.totalCost, 1e-9)
+        assertEquals(3, repo.trip(other).first()!!.nights)
+
+        repo.upsertStops(emptyList())
+        assertEquals(listOf("New", "A"), repo.stops(id).first().map { it.name })
     }
 
     @Test
-    fun `reorder leaves unlisted stops and other trips untouched`() = runTest {
-        val id = addTrip()
-        val other = addTrip(id = "other")
-        repo.upsertStop(Stop(id = "a", tripId = id, orderIndex = 0))
-        repo.upsertStop(Stop(id = "b", tripId = id, orderIndex = 5))
-        repo.upsertStop(Stop(id = "x", tripId = other, orderIndex = 7))
-        repo.reorderStops(id, listOf("a"))
-        assertEquals(5, repo.stops(id).first().single { it.id == "b" }.orderIndex)
-        assertEquals(7, repo.stops(other).first().single().orderIndex)
+    fun `no stop starts before the one in front of it leaves`() = runTest {
+        val start = LocalDate.of(2026, 9, 4)
+        val id = repo.upsertTrip(Trip(id = "plan", name = "Plan", startDate = start, status = TripStatus.PLANNED))
+        repo.upsertStop(Stop(id = "a", tripId = id, orderIndex = 0, arrivalDate = start, nights = 2))
+        repo.upsertStop(Stop(id = "b", tripId = id, orderIndex = 1, arrivalDate = start.plusDays(1), nights = 2))
+        repo.upsertStop(Stop(id = "home", tripId = id, orderIndex = 2, arrivalDate = start.plusDays(3), nights = 0))
+        assertEquals(
+            listOf(start, start.plusDays(2), start.plusDays(4)),
+            repo.stops(id).first().map { it.arrivalDate },
+        )
+    }
+
+    @Test
+    fun `on a tour the planned stops settle too, but a done stop's departure binds nothing`() = runTest {
+        val start = LocalDate.of(2026, 9, 4)
+        val id = repo.upsertTrip(Trip(id = "tour", name = "Tour", startDate = start, status = TripStatus.ACTIVE))
+        repo.upsertStop(Stop(id = "a", tripId = id, orderIndex = 0, arrivalDate = start, nights = 3, state = StopState.DONE))
+        repo.upsertStop(Stop(id = "b", tripId = id, orderIndex = 1, arrivalDate = start.plusDays(1), nights = 2)) // left a early
+        repo.upsertStop(Stop(id = "c", tripId = id, orderIndex = 2, arrivalDate = start.plusDays(2)))
+        assertEquals(
+            listOf(start, start.plusDays(1), start.plusDays(3)),
+            repo.stops(id).first().map { it.arrivalDate },
+        )
+    }
+
+    @Test
+    fun `a finished trip is a record, never re-dated`() = runTest {
+        val start = LocalDate.of(2026, 9, 4)
+        val id = repo.upsertTrip(Trip(id = "done", name = "Done", startDate = start, status = TripStatus.DONE))
+        repo.upsertStop(Stop(id = "a", tripId = id, orderIndex = 0, arrivalDate = start, nights = 2))
+        repo.upsertStop(Stop(id = "b", tripId = id, orderIndex = 1, arrivalDate = start.plusDays(1)))
+        assertEquals(start.plusDays(1), repo.stops(id).first().last().arrivalDate)
     }
 
     @Test
@@ -244,13 +280,15 @@ class InMemoryTripRepositoryTest {
     fun `a plan starts the day its first stop does`() = runTest {
         val start = LocalDate.of(2026, 9, 2)
         val id = repo.upsertTrip(Trip(id = "plan", name = "Plan", startDate = start, status = TripStatus.PLANNED))
-        repo.upsertStop(Stop(id = "s2", tripId = id, orderIndex = 1, arrivalDate = start.plusDays(2)))
-        assertEquals(start.plusDays(2), repo.trip(id).first()!!.startDate)
+        val s2 = Stop(id = "s2", tripId = id, orderIndex = 1, arrivalDate = start.plusDays(6))
+        repo.upsertStop(s2)
+        assertEquals(start.plusDays(6), repo.trip(id).first()!!.startDate)
 
-        repo.upsertStop(Stop(id = "s1", tripId = id, orderIndex = 0, arrivalDate = start.plusDays(4)))
+        val s1 = Stop(id = "s1", tripId = id, orderIndex = 0, arrivalDate = start.plusDays(4))
+        repo.upsertStop(s1)
         assertEquals(start.plusDays(4), repo.trip(id).first()!!.startDate)
 
-        repo.reorderStops(id, listOf("s2", "s1"))
+        repo.upsertStops(listOf(s2.copy(orderIndex = 0, arrivalDate = start.plusDays(2)), s1.copy(orderIndex = 1)))
         assertEquals(start.plusDays(2), repo.trip(id).first()!!.startDate)
 
         repo.upsertStop(Stop(id = "s2", tripId = id, orderIndex = 0, arrivalDate = start, state = StopState.SKIPPED))

--- a/app/src/test/java/com/nuelto/etappli/domain/DateCascadeTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/DateCascadeTest.kt
@@ -115,6 +115,74 @@ class DateCascadeTest {
 
 
     @Test
+    fun `a stop arriving before the one in front of it leaves is pushed back, and the plan behind it along`() {
+        val stops = listOf(
+            stop("a", 0, base, nights = 2),
+            stop("b", 1, base.plusDays(1), nights = 2), // a night too early
+            stop("c", 2, base.plusDays(3), nights = 1),
+            stop("d", 3, base.plusDays(6), nights = 1), // two empty nights in front of it
+        )
+        val changed = DateCascade.settle(stops)
+        assertEquals(listOf("b", "c", "d"), changed.map { it.id })
+        assertEquals(base.plusDays(2), changed[0].arrivalDate)
+        assertEquals(base.plusDays(4), changed[1].arrivalDate)
+        assertEquals(base.plusDays(7), changed[2].arrivalDate) // the empty nights survive
+    }
+
+    @Test
+    fun `settling a consistent plan writes nothing, whatever the list order`() {
+        val stops = listOf(
+            stop("c", 2, base.plusDays(5)),
+            stop("a", 0, base, nights = 2),
+            stop("home", 1, base.plusDays(2), nights = 0), // leaves the day it arrives
+        )
+        assertTrue(DateCascade.settle(stops).isEmpty())
+    }
+
+    @Test
+    fun `settling pushes in order index order, not list order`() {
+        val stops = listOf(stop("b", 1, base), stop("a", 0, base, nights = 3))
+        assertEquals(base.plusDays(3), DateCascade.settle(stops).single().arrivalDate)
+    }
+
+    @Test
+    fun `a stop that leaves early is not pushed onto its own next stop twice`() {
+        // b overlaps a by one night; c is dated off b's old departure, so it moves by one too.
+        val stops = listOf(
+            stop("a", 0, base, nights = 3),
+            stop("b", 1, base.plusDays(2), nights = 1),
+            stop("c", 2, base.plusDays(4), nights = 1), // one empty night after b
+        )
+        val changed = DateCascade.settle(stops)
+        assertEquals(listOf(base.plusDays(3), base.plusDays(5)), changed.map { it.arrivalDate })
+    }
+
+    @Test
+    fun `done stops are never rewritten and bind nothing, skipped stops sit outside`() {
+        val stops = listOf(
+            stop("early", 0, base, nights = 1),
+            stop("done", 1, base, StopState.DONE, nights = 4), // left early — its departure is only a plan
+            stop("skipped", 2, base.minusDays(9), StopState.SKIPPED),
+            stop("x", 3, base.plusDays(1), nights = 2),
+            stop("y", 4, base.plusDays(2), nights = 1),
+        )
+        val changed = DateCascade.settle(stops)
+        assertEquals(listOf("y"), changed.map { it.id })
+        assertEquals(base.plusDays(3), changed.single().arrivalDate)
+    }
+
+    @Test
+    fun `a push does not carry past a done stop`() {
+        val stops = listOf(
+            stop("a", 0, base, nights = 2),
+            stop("b", 1, base.plusDays(1), nights = 1), // pushed to +2, leaves +3
+            stop("done", 2, base.plusDays(3), StopState.DONE, nights = 1),
+            stop("c", 3, base.plusDays(4), nights = 1), // dated off the done stop: stays
+        )
+        assertEquals(listOf("b"), DateCascade.settle(stops).map { it.id })
+    }
+
+    @Test
     fun `start is the arrival of the first stop that is not skipped`() {
         val stops = listOf(
             stop("second", 1, base.plusDays(3)),

--- a/app/src/test/java/com/nuelto/etappli/ui/tripedit/StopEditViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/tripedit/StopEditViewModelTest.kt
@@ -7,6 +7,7 @@ import com.nuelto.etappli.data.InMemorySettingsRepository
 import com.nuelto.etappli.data.InMemoryTripRepository
 import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.data.model.Stop
+import com.nuelto.etappli.data.model.StopElevation
 import com.nuelto.etappli.data.model.StopKind
 import com.nuelto.etappli.data.model.StopState
 import com.nuelto.etappli.data.model.Trip
@@ -313,6 +314,19 @@ class StopEditViewModelTest {
             LocalDate.of(2027, 6, 14),
             tripRepository.stops("t1").first().single { it.id == "s2" }.arrivalDate,
         )
+    }
+
+    @Test
+    fun `saving keeps what was written to the stop while the editor was open`() = runTest {
+        tripRepository.upsertStop(Stop(id = "s1", tripId = "t1", name = "A", orderIndex = 0, location = LatLng(46.0, 7.0)))
+        val vm = editViewModel("s1")
+        val height = StopElevation(LatLng(46.0, 7.0), 1200)
+        tripRepository.upsertStop(tripRepository.stops("t1").first().single().copy(elevation = height))
+        vm.setNotes("late")
+        vm.save {}
+        val saved = tripRepository.stops("t1").first().single()
+        assertEquals(height, saved.elevation)
+        assertEquals("late", saved.notes)
     }
 
     @Test
@@ -684,6 +698,38 @@ class StopEditViewModelTest {
         // The stay pushes the drive home back by the nights it takes.
         assertEquals(start, stops[1].arrivalDate)
         assertEquals(start.plusDays(2), stops.last().arrivalDate)
+    }
+
+    @Test
+    fun `leaving a day later and staying a night longer keep the next stop behind the first`() = runTest {
+        val start = planEndingAtHome()
+        newStopViewModel().apply {
+            setName("Aire")
+            save {}
+        }
+        // Leave home a day later than first planned...
+        editViewModel("out").apply {
+            setArrivalDate(start.plusDays(1))
+            save {}
+        }
+        val aire = tripRepository.stops("t1").first().single { it.name == "Aire" }
+        assertEquals(start.plusDays(1), aire.arrivalDate)
+        // ...and stay a second night: the drive home follows both moves.
+        editViewModel(aire.id).apply {
+            setNights(2)
+            save {}
+        }
+        // The next stop, added in front of the drive home, starts the day the first one ends.
+        val vm = insertViewModel("back")
+        assertEquals(start.plusDays(3), vm.uiState.value.arrivalDate)
+        vm.setName("Grächbiel")
+        vm.setNights(2)
+        vm.save {}
+        assertEquals(listOf("Home", "Aire", "Grächbiel", "Home"), names())
+        assertEquals(
+            listOf(start.plusDays(1), start.plusDays(1), start.plusDays(3), start.plusDays(5)),
+            tripRepository.stops("t1").first().sortedBy { it.orderIndex }.map { it.arrivalDate },
+        )
     }
 
     @Test


### PR DESCRIPTION
## What

Moving the first stop of a plan a day later left the second stop where it was: two nights nobody can sleep in both places. This makes an overlapping plan impossible to store.

- **An edit and the shift it causes are one write.** New `TripRepository.upsertStops` (a Firestore `WriteBatch`, one totals recompute) replaces `upsertStop`-in-a-loop and `reorderStops`. Used by the stop editor, the nights stepper, check-in, unplanned nights, drags, the trip start date, and starting or re-planning a tour.
- **The plan settles itself after every stop write.** `DateCascade.settle` runs from both repositories' `redatePlan`: a PLANNED stop that arrives before the one in front of it leaves is pushed back, and the plan behind it with it, so the spacing survives. A DONE stop binds nothing (a tour can leave a place early); a DONE trip is a record and never re-dated.
- **The editor saves onto the stop as it is now**, so a route, height or region written to it while the editor was open survives the save.

## Why

The shift logic was right on its own, but a stop edit wrote the stop and then, in a second pass, shifted the stops behind it, and nothing ever checked the result. Anything that got between the two passes (a cancelled editor scope, a background writer) lost the shift for good, and the app then kept an impossible schedule.

## For the reviewer

- Behaviour change: setting a stop's arrival earlier than the previous stop's departure now snaps to that departure. Shorten the previous stop's nights to leave earlier.
- The Firestore batch path is device-only (excluded from coverage) and untested on a device; the emulator cannot sign in. Worth one manual run: add a stop, move the departure from home a day, add the next stop.
- `./gradlew test :app:coverageVerify :app:pitest` all green (100% line coverage, mutation threshold met).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
