### PR TITLE
Search like a maps app, and pin a shared place by name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,13 +267,18 @@ MVVM + repository, hand-rolled DI — no Hilt, no Room. Package root:
   `approximate`; a place id is kept **only** from `query_place_id` (never an ftid or cid —
   a wrong one would have PlaceCacheSweeper delete the pin 30 days on); redirects are
   followed only for four allowlisted short-link hosts, by `location/ShareLinkResolver`
-  (one HEAD, redirects off). `MainActivity` offers the result to `domain/ShareIntake` on
-  the container — not to the Activity, since in Firebase mode the share must outlive the
-  sign-in screen — and `AppNavHost` routes it **once** into `AddToTripRoute`, after which
-  it rides the back stack. `ui/share/AddToTripScreen` picks the trip; that opens
-  `StopEditRoute` with the place args over a pushed `TripDetailRoute`, so Save lands on
-  the timeline. A shared coordinate **never** gets `locationCachedAt`: it came from a
-  link, not from the Places API, so no §14.3 clock applies to it.
+  (one HEAD, redirects off). **The Maps app's links name the place and pin nothing** (an
+  ftid only, which nothing turns into a coordinate), so the chooser looks such a share up
+  by name — `AddToTripViewModel` via Text Search (`PlaceSearch.find`), one hit or nothing,
+  biased to the approximate pin or home. That coordinate *is* from the Places API, so
+  `SharedPlace.fromPlaces` rides into `StopEditRoute` and starts the §14.3 clock; without
+  it the stop has no location and so no route. `MainActivity` offers the result to
+  `domain/ShareIntake` on the container — not to the Activity, since in Firebase mode the
+  share must outlive the sign-in screen — and `AppNavHost` routes it **once** into
+  `AddToTripRoute`, after which it rides the back stack. `ui/share/AddToTripScreen` picks
+  the trip; that opens `StopEditRoute` with the place args over a pushed `TripDetailRoute`,
+  so Save lands on the timeline. A coordinate lifted from the link itself **never** gets
+  `locationCachedAt`: it did not come from the Places API, so no §14.3 clock applies to it.
 - **Navigation** (`ui/nav/`): type-safe kotlinx-serialization routes. The location picker
   returns its result through the **previous** back-stack entry's `SavedStateHandle` under
   `PICKED_LOCATION_KEY` (a `DoubleArray`); `AppNavHost` observes it and feeds

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,16 @@ There is no lint/format tooling configured.
   Predictions carry no coordinate, so `PlaceSearch.resolve` fetches it via Place Details
   when a hit is chosen, inside the same billed session token. Tapping a POI Google already
   draws (`onPOIClick`) picks it directly — it arrives with both id and coordinate.
+- **Typing predicts, submitting drops pins.** The search as submitted (IME action or the
+  field's icon) goes to Text Search (`PlaceSearch.find`, `GooglePlaces.searchBody`, Pro-tier
+  field mask only — Place Details still fetches the rest for the one chosen): a name gives
+  the one place, which opens by itself; a kind of place ("camping") gives up to 20 located
+  hits, shown as hollow pins plus a strip of cards along the bottom and framed by the
+  camera. The chosen place's card opens in full and shrinks to a strip
+  (`LocationPickerUiState.expanded`); system back peels the layers innermost first
+  (`LocationPickerViewModel.back`: card → strip → pins → search) before the picker closes.
+  `MapProvider.Canvas` takes `contentPadding` so the camera centres a pin within what the
+  strip leaves visible.
 - **Places coordinates expire.** SST §14.3 caps caching one at 30 days, so such stops carry
   `placeId` + `locationCachedAt`, and `domain/PlaceCacheSweeper` (run from
   TripDetailViewModel) refreshes them via Place Details or **deletes** them. Coordinates

--- a/app/src/main/java/com/nuelto/etappli/domain/GooglePlaces.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/GooglePlaces.kt
@@ -18,6 +18,12 @@ object GooglePlaces {
 
     const val AUTOCOMPLETE_URL = "https://places.googleapis.com/v1/places:autocomplete"
     const val MAX_SUGGESTIONS = 8
+    const val SEARCH_URL = "https://places.googleapis.com/v1/places:searchText"
+    const val MAX_RESULTS = 20
+
+    // Pro tier: what a pin and its card need. Rating or photos would move every search
+    // into Enterprise; Place Details fetches them for the one hit that is chosen.
+    const val SEARCH_FIELD_MASK = "places.id,places.displayName,places.formattedAddress,places.location"
 
     /** Place Details for one id, used to refresh an expired coordinate. */
     fun detailsUrl(placeId: String, sessionToken: String? = null): String =
@@ -50,16 +56,26 @@ object GooglePlaces {
         sessionToken: String,
         types: List<String> = emptyList(),
     ): String {
-        val bias = near?.let {
-            ",\"locationBias\":{\"circle\":{\"center\":{\"latitude\":${it.latitude}," +
-                "\"longitude\":${it.longitude}},\"radius\":$BIAS_RADIUS_M}}"
-        }.orEmpty()
         val filter = types.takeIf { it.isNotEmpty() }
             ?.joinToString(",", ",\"includedPrimaryTypes\":[", "]") { it.jsonString() }
             .orEmpty()
         return "{\"input\":${input.jsonString()},\"sessionToken\":${sessionToken.jsonString()}" +
-            "$bias$filter}"
+            "${bias(near)}$filter}"
     }
+
+    /**
+     * Text Search, for the query as submitted: it locates what it finds, so the hits can
+     * be pins. It answers a name with the one place and a kind of place with up to
+     * [MAX_RESULTS] of them around [near] — Google Maps' own two-sided behaviour, which
+     * is why the typing still goes through autocomplete. No session: it is not billed as one.
+     */
+    fun searchBody(query: String, near: LatLng?): String =
+        "{\"textQuery\":${query.jsonString()},\"pageSize\":$MAX_RESULTS${bias(near)}}"
+
+    private fun bias(near: LatLng?): String = near?.let {
+        ",\"locationBias\":{\"circle\":{\"center\":{\"latitude\":${it.latitude}," +
+            "\"longitude\":${it.longitude}},\"radius\":$BIAS_RADIUS_M}}"
+    }.orEmpty()
 
     /**
      * Google's own categories for what the user says they are after. Free camping is not
@@ -96,6 +112,13 @@ object GooglePlaces {
             ?: return null
         val label = (format?.get("secondaryText") as? JsonObject)?.string("text").orEmpty()
         return PlaceSuggestion(name = name, label = label, location = null, id = id)
+    }
+
+    /** A Text Search body: the located places, in Google's order. Lenient like the rest. */
+    fun parseSearch(body: String): List<PlaceSuggestion> {
+        val root = runCatching { Json.parseToJsonElement(body) }.getOrNull() as? JsonObject
+        val places = root?.get("places") as? JsonArray ?: return emptyList()
+        return places.mapNotNull(::suggestion).take(MAX_RESULTS)
     }
 
     /** A Place Details body, for refreshing one expired coordinate. */

--- a/app/src/main/java/com/nuelto/etappli/domain/PlaceSearch.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/PlaceSearch.kt
@@ -50,6 +50,13 @@ interface PlaceSearch {
     suspend fun search(query: String, near: LatLng?, prefer: StopKind?): List<PlaceSuggestion>?
 
     /**
+     * A search as submitted rather than typed: everything matching [query], each with a
+     * coordinate, so the hits can be pins. A kind of place ("camping") gives many around
+     * [near]; a name gives the one. Null when the lookup failed; empty = no matches.
+     */
+    suspend fun find(query: String, near: LatLng?): List<PlaceSuggestion>?
+
+    /**
      * Fills in the coordinate of a hit that came back without one. A provider whose
      * search already returns coordinates just hands the hit straight back.
      */

--- a/app/src/main/java/com/nuelto/etappli/domain/SharedPlace.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/SharedPlace.kt
@@ -20,7 +20,28 @@ data class SharedPlace(
     val link: String = "",
     /** The coordinate is where the map camera sat, not the place — it can be kilometres out. */
     val approximate: Boolean = false,
+    /** The coordinate was looked up on the Places API rather than lifted from the link, so
+     *  the §14.3 clock applies to it like to a picked place. */
+    val fromPlaces: Boolean = false,
 ) {
+    /**
+     * A name and nowhere to put it — the Maps app's links carry only an ftid, which nothing
+     * turns into a coordinate — or a pin that is only the map camera. Not while a link is
+     * still to be followed, and not for a place id, which fetches its own coordinate
+     * ([PlaceCacheSweeper]).
+     */
+    val needsLookup: Boolean
+        get() = link.isBlank() && name.isNotBlank() && placeId.isBlank() && (location == null || approximate)
+
+    /**
+     * Folds in the one place Text Search found for [name] ([PlaceSearch.find], the way the
+     * picker opens a submitted name). Unchanged for no hit, or one with no coordinate.
+     */
+    fun locatedBy(hit: PlaceSuggestion?): SharedPlace {
+        val at = hit?.location ?: return this
+        return copy(location = at, placeId = hit.id.ifBlank { placeId }, approximate = false, fromPlaces = true)
+    }
+
     /**
      * Folds in what following [link] produced. Returns this unchanged — [link] included, so
      * the fetch can be retried — when the redirect was unreachable or named nowhere.

--- a/app/src/main/java/com/nuelto/etappli/location/GooglePlacesSearch.kt
+++ b/app/src/main/java/com/nuelto/etappli/location/GooglePlacesSearch.kt
@@ -48,6 +48,12 @@ class GooglePlacesSearch(private val apiKey: String = BuildConfig.MAPS_API_KEY) 
             null,
         )?.let(GooglePlaces::parseAutocomplete)
 
+    override suspend fun find(query: String, near: LatLng?): List<PlaceSuggestion>? =
+        withContext(Dispatchers.IO) {
+            post(GooglePlaces.SEARCH_URL, GooglePlaces.searchBody(query, near), GooglePlaces.SEARCH_FIELD_MASK)
+                ?.let(GooglePlaces::parseSearch)
+        }
+
     override suspend fun resolve(suggestion: PlaceSuggestion): PlaceSuggestion? {
         // Already complete: a hit that has both a coordinate and what the place is like.
         if (suggestion.location != null && suggestion.details != null) return suggestion

--- a/app/src/main/java/com/nuelto/etappli/ui/map/GoogleMapProvider.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/map/GoogleMapProvider.kt
@@ -1,6 +1,7 @@
 package com.nuelto.etappli.ui.map
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
@@ -89,6 +90,7 @@ object GoogleMapProvider : MapProvider {
         markers: List<MapMarker>,
         routes: List<MapRoute>,
         modifier: Modifier,
+        contentPadding: PaddingValues,
         onMarkerClick: ((tripId: String, stopId: String) -> Boolean)?,
         onLongPress: ((LatLng) -> Unit)?,
         onPoiClick: ((PlaceSuggestion) -> Unit)?,
@@ -96,6 +98,7 @@ object GoogleMapProvider : MapProvider {
         GoogleMap(
             modifier = modifier,
             cameraPositionState = (camera as GoogleCamera).state,
+            contentPadding = contentPadding,
             mapColorScheme = ComposeMapColorScheme.FOLLOW_SYSTEM,
             onMapLongClick = { at -> onLongPress?.invoke(LatLng(at.latitude, at.longitude)) },
             // The aires, campsites and huts Google already draws are choosable directly.

--- a/app/src/main/java/com/nuelto/etappli/ui/map/LocationPickerScreen.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/map/LocationPickerScreen.kt
@@ -1,43 +1,66 @@
 package com.nuelto.etappli.ui.map
 
+import android.graphics.BitmapFactory
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
-import android.graphics.BitmapFactory
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -51,9 +74,11 @@ import com.nuelto.etappli.domain.PlaceSearchStatus
 import com.nuelto.etappli.domain.PlaceSuggestion
 
 /**
- * Search for a place and pick it from the results, the way a maps app works — no
- * coordinates, no aiming. The hits also show on the map, so a tap there picks the same
- * thing. For somewhere with no name, press and hold the map to drop a pin.
+ * Search for a place and pick it, the way a maps app works — no coordinates, no aiming.
+ * Typing offers predictions; the search as submitted drops pins for everything it
+ * matches ("camping" for what is around here); a pin, a prediction or a POI opens a card
+ * that shrinks to a strip so the map around the place can be looked at. For somewhere
+ * with no name, press and hold the map to drop a pin.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -67,13 +92,23 @@ fun LocationPickerScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val provider = LocalMapProvider.current
     val camera = provider.rememberCamera(start = initial, zoom = CLOSE_ZOOM)
+    val keyboard = LocalSoftwareKeyboardController.current
+    val density = LocalDensity.current
+    // What the strip along the bottom covers; the camera centres within the rest.
+    var bottomInset by remember { mutableStateOf(0.dp) }
 
-    // New hits pull the camera over them; tapping one slides the crosshair onto it so
-    // both ways of confirming agree, without yanking the zoom around.
+    // Pins pull the camera over them all; a chosen place slides under it, without
+    // yanking the zoom around — again whenever the card changes height, since Google
+    // Maps applies new padding only on the next camera move.
     LaunchedEffect(state.results) {
         camera.apply(MapOverlay.frame(state.results.mapNotNull { it.location }))
     }
-    LaunchedEffect(state.selected) { state.selected?.location?.let { camera.centerOn(it) } }
+    LaunchedEffect(state.selected, bottomInset) {
+        state.selected?.location?.let { camera.centerOn(it) }
+    }
+
+    // Back peels the picker's own layers off before it closes the picker.
+    BackHandler(enabled = state.canGoBack) { viewModel.back() }
 
     Scaffold(
         topBar = {
@@ -87,12 +122,14 @@ fun LocationPickerScreen(
             )
         },
     ) { padding ->
-        Box(Modifier.fillMaxSize().padding(padding)) {
+        BoxWithConstraints(Modifier.fillMaxSize().padding(padding)) {
+            val cardMaxHeight = maxHeight * CARD_SHARE
             provider.Canvas(
                 camera = camera,
                 markers = state.markers(),
                 routes = emptyList(),
                 modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(bottom = bottomInset),
                 onMarkerClick = { _, id -> state.hit(id)?.also(viewModel::select) != null },
                 onLongPress = viewModel::dropPin,
                 onPoiClick = viewModel::select,
@@ -100,38 +137,58 @@ fun LocationPickerScreen(
             SearchOverlay(
                 state = state,
                 onQueryChange = { query -> viewModel.setQuery(query, camera.center, prefer) },
+                onSearch = {
+                    keyboard?.hide()
+                    viewModel.search(camera.center)
+                },
                 onClear = viewModel::clearSearch,
-                onSelect = viewModel::select,
-                onDeselect = viewModel::clearSelection,
-                onUseSelected = { place ->
-                    place.location?.let { onPicked(it, place.takeIf { p -> p.name.isNotBlank() }) }
+                onSelect = { place ->
+                    keyboard?.hide()
+                    viewModel.select(place)
                 },
                 modifier = Modifier.align(Alignment.TopCenter),
+            )
+            BottomStrip(
+                state = state,
+                photo = rememberDecoded(state.photo),
+                maxHeight = cardMaxHeight,
+                onSelect = viewModel::select,
+                onExpand = viewModel::setExpanded,
+                onUse = { place ->
+                    keyboard?.hide()
+                    place.location?.let { onPicked(it, place.takeIf { p -> p.name.isNotBlank() }) }
+                },
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .onSizeChanged { bottomInset = with(density) { it.height.toDp() } },
             )
         }
     }
 }
 
-/** Hits as markers: the chosen one is filled, the rest are hollow rings. A pin dropped
- *  by hand is not in the results, so it gets a marker of its own. */
+/** The pins as markers: the chosen one is filled, the rest are hollow rings. A dropped
+ *  pin, a POI or a prediction is not among them, so it gets a marker of its own. */
 private fun LocationPickerUiState.markers(): List<MapMarker> {
-    // Predictions have no coordinate until they are chosen, so only some hits show.
-    val hits = results.mapIndexedNotNull { index, place ->
+    val pins = results.mapIndexedNotNull { index, place ->
         place.location?.let {
             MapMarker(
                 tripId = SEARCH_MARKERS,
                 stopId = index.toString(),
                 at = it,
                 accent = MapAccent.PLANNED,
-                hollow = place != selected,
+                hollow = !place.sameAs(selected),
             )
         }
     }
-    val chosen = selected?.takeIf { it !in results }?.location?.let {
+    val chosen = selected?.takeIf { chosen -> results.none { it.sameAs(chosen) } }?.location?.let {
         MapMarker(SEARCH_MARKERS, DROPPED_PIN, it, MapAccent.PLANNED, hollow = false)
     }
-    return hits + listOfNotNull(chosen)
+    return pins + listOfNotNull(chosen)
 }
+
+/** Still the same place once one of the two has been enriched: by id, when there is one. */
+private fun PlaceSuggestion.sameAs(other: PlaceSuggestion?): Boolean =
+    other != null && if (id.isNotBlank()) id == other.id else this == other
 
 private fun LocationPickerUiState.hit(markerId: String): PlaceSuggestion? =
     markerId.toIntOrNull()?.let { results.getOrNull(it) }
@@ -139,19 +196,19 @@ private fun LocationPickerUiState.hit(markerId: String): PlaceSuggestion? =
 private const val SEARCH_MARKERS = "search"
 private const val DROPPED_PIN = "pin"
 
-/** Search field, its one-line status, and the card for whichever marker is tapped. */
+/** How much of the map the chosen place's card may cover at most. */
+private const val CARD_SHARE = 0.6f
+
+/** Search field, its one-line status, and the predictions the typing so far could mean. */
 @Composable
 private fun SearchOverlay(
     state: LocationPickerUiState,
     onQueryChange: (String) -> Unit,
+    onSearch: () -> Unit,
     onClear: () -> Unit,
     onSelect: (PlaceSuggestion) -> Unit,
-    onDeselect: () -> Unit,
-    onUseSelected: (PlaceSuggestion) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val keyboard = LocalSoftwareKeyboardController.current
-
     Column(
         modifier = modifier.fillMaxWidth().padding(12.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -162,7 +219,11 @@ private fun SearchOverlay(
                 onValueChange = onQueryChange,
                 placeholder = { Text("Search a place") },
                 singleLine = true,
-                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                leadingIcon = {
+                    IconButton(onClick = onSearch) {
+                        Icon(Icons.Default.Search, contentDescription = "Search")
+                    }
+                },
                 trailingIcon = {
                     if (state.query.isNotEmpty()) {
                         IconButton(onClick = onClear) {
@@ -170,11 +231,13 @@ private fun SearchOverlay(
                         }
                     }
                 },
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(onSearch = { onSearch() }),
                 colors = TextFieldDefaults.colors(
                     focusedIndicatorColor = Color.Transparent,
                     unfocusedIndicatorColor = Color.Transparent,
                 ),
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().testTag("place-search"),
             )
         }
         searchStatusText(state)?.let {
@@ -187,39 +250,83 @@ private fun SearchOverlay(
                 )
             }
         }
-        val selected = state.selected
-        if (selected == null) {
-            // The hits, as a list you can read — the markers are only there to show where.
-            state.results.forEach { place ->
-                Card(
-                    onClick = {
-                        keyboard?.hide()
-                        onSelect(place)
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Column(Modifier.padding(12.dp)) {
-                        Text(place.name, style = MaterialTheme.typography.titleSmall)
-                        if (place.label.isNotBlank()) {
-                            Text(
-                                place.label,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
+        // A list you can read; picking one locates it. It closes behind the card.
+        if (state.selected == null && state.predictions.isNotEmpty()) {
+            Surface(shape = MaterialTheme.shapes.medium, shadowElevation = 2.dp) {
+                Column {
+                    state.predictions.forEachIndexed { index, place ->
+                        if (index > 0) HorizontalDivider()
+                        Column(
+                            Modifier
+                                .fillMaxWidth()
+                                .clickable { onSelect(place) }
+                                .padding(12.dp),
+                        ) {
+                            Text(place.name, style = MaterialTheme.typography.titleSmall)
+                            if (place.label.isNotBlank()) {
+                                Text(
+                                    place.label,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
                         }
                     }
                 }
             }
-        } else {
-            ChosenPlaceCard(
+        }
+    }
+}
+
+/** Along the bottom: the pins as a row of cards to read, or the chosen place's card. */
+@Composable
+private fun BottomStrip(
+    state: LocationPickerUiState,
+    photo: ImageBitmap?,
+    maxHeight: Dp,
+    onSelect: (PlaceSuggestion) -> Unit,
+    onExpand: (Boolean) -> Unit,
+    onUse: (PlaceSuggestion) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier.fillMaxWidth()) {
+        val selected = state.selected
+        when {
+            selected != null -> ChosenPlaceCard(
                 place = selected,
-                photo = rememberDecoded(state.photo),
-                onUse = {
-                    keyboard?.hide()
-                    onUseSelected(selected)
-                },
-                onDismiss = onDeselect.takeIf { state.results.isNotEmpty() },
+                photo = photo,
+                expanded = state.expanded,
+                maxHeight = maxHeight,
+                onExpand = onExpand,
+                onUse = { onUse(selected) },
+                modifier = Modifier.padding(12.dp),
             )
+            state.results.isNotEmpty() -> LazyRow(
+                contentPadding = PaddingValues(12.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(state.results) { place ->
+                    Card(onClick = { onSelect(place) }, modifier = Modifier.width(220.dp)) {
+                        Column(Modifier.padding(12.dp)) {
+                            Text(
+                                place.name,
+                                style = MaterialTheme.typography.titleSmall,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            if (place.label.isNotBlank()) {
+                                Text(
+                                    place.label,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }
@@ -232,59 +339,112 @@ private fun rememberDecoded(bytes: ByteArray?): ImageBitmap? = remember(bytes) {
     }
 }
 
-/** What the place is actually like, so the choice can be made without leaving the app. */
+/**
+ * What the place is actually like, so the choice can be made without leaving the app —
+ * in full, or as a strip that leaves the map around the place to look at.
+ */
 @Composable
 private fun ChosenPlaceCard(
     place: PlaceSuggestion,
     photo: ImageBitmap?,
+    expanded: Boolean,
+    maxHeight: Dp,
+    onExpand: (Boolean) -> Unit,
     onUse: () -> Unit,
-    onDismiss: (() -> Unit)?,
+    modifier: Modifier = Modifier,
 ) {
     val details = place.details
-    Card(Modifier.fillMaxWidth()) {
-        Column {
-            photo?.let {
-                Image(
-                    bitmap = it,
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    modifier = Modifier.fillMaxWidth().height(140.dp),
-                )
+    // A dropped pin has no name yet; the editor geocodes one.
+    val name = place.name.ifBlank { "Dropped pin" }
+    val label = place.label.takeIf { it.isNotBlank() }
+    Card(modifier.fillMaxWidth().heightIn(max = maxHeight)) {
+        Column(
+            Modifier
+                .clickable(enabled = !expanded) { onExpand(true) }
+                .verticalScroll(rememberScrollState()),
+        ) {
+            if (expanded) {
+                photo?.let {
+                    Image(
+                        bitmap = it,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxWidth().height(140.dp),
+                    )
+                }
             }
             Column(
                 modifier = Modifier.padding(12.dp),
                 verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
-                // A dropped pin has no name yet; the editor geocodes one.
-                Text(place.name.ifBlank { "Dropped pin" }, style = MaterialTheme.typography.titleSmall)
-                if (place.label.isNotBlank()) {
-                    Text(
-                        place.label,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    if (!expanded) {
+                        photo?.let {
+                            Image(
+                                bitmap = it,
+                                contentDescription = null,
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier.size(48.dp).clip(MaterialTheme.shapes.small),
+                            )
+                        }
+                    }
+                    Column(Modifier.weight(1f)) {
+                        Text(
+                            name,
+                            style = MaterialTheme.typography.titleSmall,
+                            maxLines = if (expanded) 2 else 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        if (!expanded) {
+                            (ratingLine(details) ?: label)?.let {
+                                Text(
+                                    it,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
+                        }
+                    }
+                    if (!expanded) {
+                        Button(onClick = onUse, enabled = place.location != null) { Text("Use") }
+                    }
+                    IconButton(onClick = { onExpand(!expanded) }) {
+                        Icon(
+                            if (expanded) Icons.Default.KeyboardArrowDown else Icons.Default.KeyboardArrowUp,
+                            contentDescription = if (expanded) "Show less" else "Show more",
+                        )
+                    }
                 }
-                ratingLine(details)?.let {
-                    Text(it, style = MaterialTheme.typography.bodySmall)
-                }
-                details?.summary?.takeIf { it.isNotBlank() }?.let {
-                    Text(it, style = MaterialTheme.typography.bodySmall)
-                }
-                details?.review?.takeIf { it.isNotBlank() }?.let {
-                    Text(
-                        "\u201C$it\u201D",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 3,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (expanded) {
+                    label?.let {
+                        Text(
+                            it,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    ratingLine(details)?.let {
+                        Text(it, style = MaterialTheme.typography.bodySmall)
+                    }
+                    details?.summary?.takeIf { it.isNotBlank() }?.let {
+                        Text(it, style = MaterialTheme.typography.bodySmall)
+                    }
+                    details?.review?.takeIf { it.isNotBlank() }?.let {
+                        Text(
+                            "“$it”",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 3,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
                     Button(onClick = onUse, enabled = place.location != null) {
                         Text("Use this place")
-                    }
-                    onDismiss?.let {
-                        TextButton(onClick = it) { Text("Back to results") }
                     }
                 }
             }
@@ -297,20 +457,22 @@ private fun ratingLine(details: PlaceDetails?): String? {
     if (details == null) return null
     val stars = details.rating?.let { rating ->
         val count = details.ratingCount.takeIf { it > 0 }?.let { " ($it)" }.orEmpty()
-        "$rating \u2605$count"
+        "$rating ★$count"
     }
     return listOfNotNull(details.kind.takeIf { it.isNotBlank() }, stars)
-        .joinToString(" \u00B7 ")
+        .joinToString(" · ")
         .takeIf { it.isNotBlank() }
 }
 
-/** The results list speaks for itself, so a hit needs no status line. */
+/** The list and the pins speak for themselves, so a hit needs no status line. */
 private fun searchStatusText(state: LocationPickerUiState): String? = when (state.status) {
-    PlaceSearchStatus.IDLE ->
-        "Search, or press and hold the map to drop a pin.".takeIf {
-            state.results.isEmpty() && state.selected == null
-        }
+    PlaceSearchStatus.IDLE -> HINT.takeIf {
+        state.predictions.isEmpty() && state.results.isEmpty() && state.selected == null
+    }
     PlaceSearchStatus.SEARCHING -> "Searching…"
     PlaceSearchStatus.EMPTY -> "Nothing found."
     PlaceSearchStatus.UNAVAILABLE -> "Search unavailable — press and hold the map instead."
 }
+
+private const val HINT =
+    "Type a name, or search “camping” for what is around here. Press and hold the map to drop a pin."

--- a/app/src/main/java/com/nuelto/etappli/ui/map/LocationPickerViewModel.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/map/LocationPickerViewModel.kt
@@ -17,15 +17,26 @@ import kotlinx.coroutines.launch
 
 data class LocationPickerUiState(
     val query: String = "",
+    // What the typing so far could mean: a list to pick from, located once picked.
+    val predictions: List<PlaceSuggestion> = emptyList(),
+    // What a submitted search found, each with a coordinate: the pins on the map.
     val results: List<PlaceSuggestion> = emptyList(),
     val status: PlaceSearchStatus = PlaceSearchStatus.IDLE,
     val selected: PlaceSuggestion? = null,
     val photo: ByteArray? = null,
-)
+    // The chosen place's card shows everything, or shrinks to a strip so the map around
+    // the place can be looked at.
+    val expanded: Boolean = true,
+) {
+    /** Whether back has something of the picker's own to undo before it closes it. */
+    val canGoBack: Boolean
+        get() = selected != null || query.isNotEmpty() || results.isNotEmpty()
+}
 
 /**
- * Debounced place search for the picker map: hits land as markers so you can pick the
- * one in the right spot. Search is additive — the crosshair keeps working without it.
+ * The picker map's search, the way a maps app works: typing offers predictions, the
+ * search as submitted drops pins, and a pin, a prediction or a POI opens a card. Search
+ * is additive — pressing and holding the map keeps working without it.
  */
 class LocationPickerViewModel(
     private val placeSearch: PlaceSearch? = null,
@@ -38,7 +49,7 @@ class LocationPickerViewModel(
     val uiState: StateFlow<LocationPickerUiState> = _uiState
 
     /** One lookup per pause, never for a fragment. [near] is the current map center, so
-     *  hits rank around what you are looking at. */
+     *  hits rank around what you are looking at. The pins stay: they are behind the list. */
     fun setQuery(value: String, near: LatLng?, prefer: StopKind? = null) {
         searchJob?.cancel()
         _uiState.update { it.copy(query = value) }
@@ -46,6 +57,7 @@ class LocationPickerViewModel(
         if (query.length < MIN_QUERY_LENGTH) {
             _uiState.update {
                 it.copy(
+                    predictions = emptyList(),
                     results = emptyList(),
                     selected = null,
                     photo = null,
@@ -61,7 +73,7 @@ class LocationPickerViewModel(
             val found = search.search(query, near, prefer)
             _uiState.update {
                 it.copy(
-                    results = found.orEmpty(),
+                    predictions = found.orEmpty(),
                     selected = null,
                     photo = null,
                     status = when {
@@ -74,7 +86,42 @@ class LocationPickerViewModel(
         }
     }
 
-    /** Back to the results, keeping the query — the card is otherwise a dead end. */
+    /**
+     * The search as submitted: everything it matches, located, as pins. A single hit — a
+     * name, as a rule — is opened straight away, the way a maps app does.
+     */
+    fun search(near: LatLng?) {
+        searchJob?.cancel()
+        val query = _uiState.value.query.trim()
+        if (query.isEmpty()) return
+        val search = placeSearch ?: return
+        searchJob = viewModelScope.launch {
+            _uiState.update {
+                it.copy(
+                    predictions = emptyList(),
+                    selected = null,
+                    photo = null,
+                    status = PlaceSearchStatus.SEARCHING,
+                )
+            }
+            val found = search.find(query, near)
+            // Done: opening the one hit must not cancel this very job.
+            searchJob = null
+            _uiState.update {
+                it.copy(
+                    results = found.orEmpty(),
+                    status = when {
+                        found == null -> PlaceSearchStatus.UNAVAILABLE
+                        found.isEmpty() -> PlaceSearchStatus.EMPTY
+                        else -> PlaceSearchStatus.IDLE
+                    },
+                )
+            }
+            found?.singleOrNull()?.let(::select)
+        }
+    }
+
+    /** Back to the pins or the list, keeping the query — the card is otherwise a dead end. */
     fun clearSelection() = _uiState.update { it.copy(selected = null, photo = null) }
 
     fun clearSearch() {
@@ -82,9 +129,29 @@ class LocationPickerViewModel(
         _uiState.value = LocationPickerUiState()
     }
 
+    /** The card in full, or shrunk to a strip that leaves the map to look at. */
+    fun setExpanded(expanded: Boolean) = _uiState.update { it.copy(expanded = expanded) }
+
+    /**
+     * Back peels the picker's own layers off, innermost first: a full card shrinks to a
+     * strip, a strip goes away, a search is cleared. False = nothing left to undo, so the
+     * picker itself closes.
+     */
+    fun back(): Boolean {
+        val state = _uiState.value
+        when {
+            state.selected != null && state.expanded -> setExpanded(false)
+            state.selected != null -> clearSelection()
+            state.canGoBack -> clearSearch()
+            else -> return false
+        }
+        return true
+    }
+
     /**
      * A prediction names a place but knows neither where it is nor what it is like, and
-     * a tapped POI knows only the former, so choosing either needs a second lookup.
+     * a pin or a tapped POI knows only the former, so choosing any of them needs a second
+     * lookup. The pins stay: they are where the place was found among.
      */
     fun select(place: PlaceSuggestion) {
         // A search still in flight would otherwise land and clear the choice.
@@ -93,6 +160,7 @@ class LocationPickerViewModel(
             it.copy(
                 selected = place,
                 photo = null,
+                expanded = true,
                 status = if (place.location == null) PlaceSearchStatus.SEARCHING else PlaceSearchStatus.IDLE,
             )
         }
@@ -130,7 +198,11 @@ class LocationPickerViewModel(
     fun dropPin(at: LatLng) {
         searchJob?.cancel()
         _uiState.update {
-            it.copy(selected = PlaceSuggestion(name = "", label = "", location = at), photo = null)
+            it.copy(
+                selected = PlaceSuggestion(name = "", label = "", location = at),
+                photo = null,
+                expanded = true,
+            )
         }
     }
 

--- a/app/src/main/java/com/nuelto/etappli/ui/map/MapProvider.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/map/MapProvider.kt
@@ -2,6 +2,7 @@ package com.nuelto.etappli.ui.map
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
@@ -68,9 +69,11 @@ interface MapProvider {
     fun rememberCamera(start: LatLng?, zoom: Double): MapCamera
 
     /**
-     * Draws [markers] and [routes]. [onMarkerClick] gets (tripId, stopId) and returns
-     * true when it consumed the tap; [onLongPress] gets the point pressed and held,
-     * which is how a spot with no name gets chosen.
+     * Draws [markers] and [routes]. [contentPadding] is the part of the surface something
+     * else covers, so the camera centres and frames within what can actually be seen.
+     * [onMarkerClick] gets (tripId, stopId) and returns true when it consumed the tap;
+     * [onLongPress] gets the point pressed and held, which is how a spot with no name
+     * gets chosen.
      */
     @Composable
     fun Canvas(
@@ -78,6 +81,7 @@ interface MapProvider {
         markers: List<MapMarker>,
         routes: List<MapRoute>,
         modifier: Modifier,
+        contentPadding: PaddingValues = PaddingValues(),
         onMarkerClick: ((tripId: String, stopId: String) -> Boolean)? = null,
         onLongPress: ((LatLng) -> Unit)? = null,
         onPoiClick: ((PlaceSuggestion) -> Unit)? = null,
@@ -106,6 +110,7 @@ object PlaceholderMapProvider : MapProvider {
         markers: List<MapMarker>,
         routes: List<MapRoute>,
         modifier: Modifier,
+        contentPadding: PaddingValues,
         onMarkerClick: ((tripId: String, stopId: String) -> Boolean)?,
         onLongPress: ((LatLng) -> Unit)?,
         onPoiClick: ((PlaceSuggestion) -> Unit)?,

--- a/app/src/main/java/com/nuelto/etappli/ui/nav/AppNavHost.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/nav/AppNavHost.kt
@@ -207,6 +207,7 @@ private fun NavController.addToTrip(tripId: String, place: SharedPlace) {
             placeName = place.name.ifBlank { null },
             placeId = place.placeId.ifBlank { null },
             fromShare = true,
+            fromPlaces = place.fromPlaces,
         ),
     )
 }

--- a/app/src/main/java/com/nuelto/etappli/ui/nav/Routes.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/nav/Routes.kt
@@ -28,6 +28,9 @@ data class StopEditRoute(
     // Sharing a place says you are not standing at it: no GPS fix on top, even when the
     // share turned out to carry neither a name nor a coordinate.
     val fromShare: Boolean = false,
+    // The shared coordinate was looked up on the Places API, not lifted from the link, so
+    // it carries the §14.3 clock like a picked place (SharedPlace.fromPlaces).
+    val fromPlaces: Boolean = false,
 )
 
 /**

--- a/app/src/main/java/com/nuelto/etappli/ui/share/AddToTripScreen.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/share/AddToTripScreen.kt
@@ -78,7 +78,7 @@ fun AddToTripScreen(
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
-                    if (state.expanding) LinearProgressIndicator(Modifier.fillMaxWidth())
+                    if (state.busy) LinearProgressIndicator(Modifier.fillMaxWidth())
                     if (state.expandFailed) {
                         TextButton(onClick = viewModel::expand) { Text("Try again") }
                     }
@@ -92,9 +92,9 @@ fun AddToTripScreen(
                         fontWeight = FontWeight.SemiBold,
                     )
                 }
-                // Not while the link is still being followed: choosing now would file the
-                // stop without the coordinate that is one redirect away.
-                val ready = !state.expanding
+                // Not while the link is still being followed or the place looked up: choosing
+                // now would file the stop without the coordinate that is one call away.
+                val ready = !state.busy
                 tripSection("On the road", TripStatus.ACTIVE, state.active, ready) { onAddTo(it, state.place) }
                 tripSection("Planned tours", TripStatus.PLANNED, state.planned, ready) { onAddTo(it, state.place) }
                 tripSection("Done", TripStatus.DONE, state.done, ready) { onAddTo(it, state.place) }
@@ -125,6 +125,7 @@ fun AddToTripScreen(
 /** What we know about the place, in the order that matters to somebody about to camp. */
 private fun status(state: AddToTripUiState): String = when {
     state.expanding -> "Opening the Google Maps link…"
+    state.locating -> "Finding the place on Google Maps…"
     state.expandFailed -> "Couldn't open that link. Check your connection."
     state.place.approximate -> "Approximate spot — check the pin on the map after."
     state.place.location != null -> "Pin from Google Maps."

--- a/app/src/main/java/com/nuelto/etappli/ui/share/AddToTripViewModel.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/share/AddToTripViewModel.kt
@@ -11,6 +11,7 @@ import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
 import com.nuelto.etappli.domain.NewPlan
+import com.nuelto.etappli.domain.PlaceSuggestion
 import com.nuelto.etappli.domain.SharedPlace
 import com.nuelto.etappli.ui.nav.AddToTripRoute
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,10 +29,16 @@ data class AddToTripUiState(
     val planned: List<Trip> = emptyList(),
     val done: List<Trip> = emptyList(),
     val expanding: Boolean = false,
+    // Looking the place up by name, because the link named it but pinned nothing.
+    val locating: Boolean = false,
+    // The link could not be followed, or the lookup did not come back: network, so retry.
     val expandFailed: Boolean = false,
     val loading: Boolean = true,
 ) {
     val hasTrips: Boolean get() = active.isNotEmpty() || planned.isNotEmpty() || done.isNotEmpty()
+
+    /** Choosing a trip now would file the stop without the coordinate still on its way. */
+    val busy: Boolean get() = expanding || locating
 
     /** A pin nobody named still needs a headline. */
     val title: String get() = place.name.ifBlank { "Shared pin" }
@@ -39,14 +46,18 @@ data class AddToTripUiState(
 
 /**
  * The chooser a shared place lands on: which trip does this belong to? Everything about
- * the place is already parsed — the only work here is following a short link, whose
- * coordinate sits behind a redirect, and planning a tour for the place when there is none.
+ * the place is already parsed — the work here is following a short link, whose coordinate
+ * sits behind a redirect, looking the place up when the link only named it, and planning
+ * a tour for the place when there is none.
  */
 class AddToTripViewModel(
     place: SharedPlace,
     private val tripRepository: TripRepository,
     private val settingsRepository: SettingsRepository,
     private val expandLink: suspend (String) -> String? = { null },
+    // Text Search (PlaceSearch.find), for a share that names the place but pins nothing.
+    // Null when the map provider has no search: such a share then stays unpinned.
+    private val find: (suspend (query: String, near: LatLng?) -> List<PlaceSuggestion>?)? = null,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(AddToTripUiState(place = place))
@@ -69,14 +80,39 @@ class AddToTripViewModel(
         expand()
     }
 
-    /** No-op unless the share was a short link; offered again when the fetch failed. */
+    /**
+     * Follows a short link, then looks the place up if that still left it unpinned. A
+     * no-op once there is nothing left to do; offered again when a step failed.
+     */
     fun expand() {
-        val link = _uiState.value.place.link.ifBlank { return }
+        val link = _uiState.value.place.link
+        if (link.isBlank()) return locate()
         _uiState.update { it.copy(expanding = true, expandFailed = false) }
         viewModelScope.launch {
             val expanded = _uiState.value.place.expandedWith(expandLink(link))
             _uiState.update {
                 it.copy(place = expanded, expanding = false, expandFailed = expanded.link.isNotBlank())
+            }
+            locate()
+        }
+    }
+
+    /**
+     * The Maps app's links carry only the place's name and an ftid, and nothing turns an
+     * ftid into a coordinate — but Text Search answers the name with the one place, the way
+     * the picker opens a submitted name. Several hits pin nothing: a wrong campsite is worse
+     * than none. Biased to the pin when there is an approximate one, else to home.
+     */
+    private fun locate() {
+        val place = _uiState.value.place
+        if (!place.needsLookup) return
+        val search = find ?: return
+        _uiState.update { it.copy(locating = true, expandFailed = false) }
+        viewModelScope.launch {
+            val near = place.location ?: settingsRepository.settings().first().homeLocation
+            val found = search(place.name, near)
+            _uiState.update {
+                it.copy(place = it.place.locatedBy(found?.singleOrNull()), locating = false, expandFailed = found == null)
             }
         }
     }
@@ -104,6 +140,7 @@ class AddToTripViewModel(
                 container.tripRepository,
                 container.settingsRepository,
                 container.expandShareLink,
+                container.mapProvider.placeSearch()?.let { it::find },
             )
         }
     }

--- a/app/src/main/java/com/nuelto/etappli/ui/tripedit/StopEditViewModel.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/tripedit/StopEditViewModel.kt
@@ -152,12 +152,13 @@ class StopEditViewModel(
         }
     }
 
-    /** A place shared into the app: what the map picker delivers, minus the Places clock. */
+    /** A place shared into the app: what the map picker delivers — minus the Places clock,
+     *  unless the coordinate had to be looked up there because the link only named the place. */
     private fun applyShared() {
         val name = route.placeName.orEmpty()
         val at = if (route.lat != null && route.lon != null) LatLng(route.lat, route.lon) else null
         if (at != null) {
-            return setPickedLocation(at, name, "", route.placeId.orEmpty(), fromPlaces = false)
+            return setPickedLocation(at, name, "", route.placeId.orEmpty(), fromPlaces = route.fromPlaces)
         }
         // No coordinate, but a place id can still fetch one: PlaceCacheSweeper picks up a
         // stop that has an id and nowhere to be.

--- a/app/src/test/java/com/nuelto/etappli/domain/GooglePlacesTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/GooglePlacesTest.kt
@@ -282,4 +282,58 @@ class GooglePlacesTest {
         assertEquals(emptyList<String>(), GooglePlaces.preferredTypes(StopKind.HOME))
     }
 
+
+    // --- the search as submitted (Text Search) --------------------------------
+
+    @Test
+    fun `a submitted search asks for a page of located places around the map centre`() {
+        assertEquals(
+            """{"textQuery":"camping","pageSize":20,""" +
+                """"locationBias":{"circle":{"center":{"latitude":46.95,"longitude":7.45},""" +
+                """"radius":50000.0}}}""",
+            GooglePlaces.searchBody("camping", LatLng(46.95, 7.45)),
+        )
+        assertEquals(
+            """{"textQuery":"say \"hi\"","pageSize":20}""",
+            GooglePlaces.searchBody("say \"hi\"", near = null),
+        )
+    }
+
+    @Test
+    fun `found places come back located, in Google's order, with nothing more`() {
+        val found = GooglePlaces.parseSearch(
+            response(place(id = "a", name = "Camping Alpenblick"), place(id = "b", name = "Camping Manor Farm")),
+        )
+        assertEquals(listOf("Camping Alpenblick", "Camping Manor Farm"), found.map { it.name })
+        assertEquals(LatLng(46.1712, 8.7936), found.first().location)
+        assertEquals("a", found.first().id)
+        assertEquals("Via Respini 7, 6600 Locarno, Switzerland", found.first().label)
+        assertNull(found.first().details)
+    }
+
+    @Test
+    fun `a found place without a coordinate is no pin`() {
+        val found = GooglePlaces.parseSearch(response(place(id = "a", location = null), place(id = "b")))
+        assertEquals(listOf("b"), found.map { it.id })
+    }
+
+    @Test
+    fun `at most twenty pins, and none from an error body or junk`() {
+        val many = response(*Array(21) { place(id = "p$it") })
+        assertEquals(20, GooglePlaces.parseSearch(many).size)
+        assertTrue(GooglePlaces.parseSearch("""{"error":{"message":"nope"}}""").isEmpty())
+        assertTrue(GooglePlaces.parseSearch("not json").isEmpty())
+        assertTrue(GooglePlaces.parseSearch("""{"places":"x"}""").isEmpty())
+        assertTrue(GooglePlaces.parseSearch("""{"places":[]}""").isEmpty())
+    }
+
+    @Test
+    fun `the search field mask stays in the tier a pin needs`() {
+        val fields = GooglePlaces.SEARCH_FIELD_MASK.split(",")
+        assertEquals(
+            listOf("places.id", "places.displayName", "places.formattedAddress", "places.location"),
+            fields,
+        )
+        assertEquals("https://places.googleapis.com/v1/places:searchText", GooglePlaces.SEARCH_URL)
+    }
 }

--- a/app/src/test/java/com/nuelto/etappli/domain/SharedPlaceTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/SharedPlaceTest.kt
@@ -285,6 +285,48 @@ class SharedPlaceTest {
     }
 
     @Test
+    fun `the Maps app's link names the place and pins nothing, so the name is looked up`() {
+        val redirect = "https://www.google.com/maps/place/Zielhaus+am+Klausenpass/" +
+            "data=!4m2!3m1!1s0x479a7a1b2c3d4e5f:0x6a7b8c9d0e1f2a3b?utm_source=mstt_1&entry=gps&g_ep=CAESBzI"
+        val expanded = parse("https://maps.app.goo.gl/aBcD1234")!!.expandedWith(redirect)
+        assertEquals("Zielhaus am Klausenpass", expanded.name)
+        assertNull(expanded.location)
+        assertEquals("", expanded.placeId)
+        assertEquals("", expanded.link)
+        assertTrue(expanded.needsLookup)
+    }
+
+    @Test
+    fun `only a name with no spot, or an approximate one, needs looking up`() {
+        assertTrue(SharedPlace("Zielhaus am Klausenpass").needsLookup)
+        assertTrue(SharedPlace("Titisee", LatLng(47.89, 8.14), approximate = true).needsLookup)
+        assertFalse(SharedPlace("Titisee", LatLng(47.89, 8.14)).needsLookup)
+        // Not before the link has been followed; a place id fetches its own coordinate.
+        assertFalse(SharedPlace("Camping X", link = "https://maps.app.goo.gl/x1").needsLookup)
+        assertFalse(SharedPlace("Camping X", placeId = "ChIJCyinolJ-hUcR").needsLookup)
+        assertFalse(SharedPlace(location = LatLng(46.5, 8.3), approximate = true).needsLookup)
+        assertFalse(SharedPlace().needsLookup)
+    }
+
+    @Test
+    fun `the one place found for the name becomes the pin, on the Places clock`() {
+        val shared = SharedPlace("Titisee", LatLng(47.89, 8.14), approximate = true)
+        val located = shared.locatedBy(PlaceSuggestion("Titisee", "Baden-Württemberg", LatLng(47.8918, 8.1454), "ChIJ1"))
+        assertEquals("Titisee", located.name)
+        assertEquals(LatLng(47.8918, 8.1454), located.location)
+        assertEquals("ChIJ1", located.placeId)
+        assertFalse(located.approximate)
+        assertTrue(located.fromPlaces)
+        assertFalse(located.needsLookup)
+        // No hit, or one that has no coordinate, changes nothing.
+        assertEquals(shared, shared.locatedBy(null))
+        assertEquals(shared, shared.locatedBy(PlaceSuggestion("Titisee", "")))
+        // A hit without an id keeps the one the share had.
+        val byId = SharedPlace("X", placeId = "ChIJ2").locatedBy(PlaceSuggestion("X", "", LatLng(1.0, 2.0)))
+        assertEquals("ChIJ2", byId.placeId)
+    }
+
+    @Test
     fun `expanding a link folds the redirect in and keeps the name`() {
         val short = parse("Camping Grimselblick\nhttps://maps.app.goo.gl/aBcD1234")!!
         val expanded = short.expandedWith(

--- a/app/src/test/java/com/nuelto/etappli/testutil/TestSupport.kt
+++ b/app/src/test/java/com/nuelto/etappli/testutil/TestSupport.kt
@@ -92,6 +92,21 @@ class FakePlaceSearch : PlaceSearch {
 
     override suspend fun resolve(suggestion: PlaceSuggestion): PlaceSuggestion? = resolved(suggestion)
 
+    val finds = mutableListOf<Pair<String, LatLng?>>()
+
+    /** What a submitted search locates; by default nothing is out there. */
+    var found: List<PlaceSuggestion>? = emptyList()
+
+    override suspend fun find(query: String, near: LatLng?): List<PlaceSuggestion>? {
+        finds += query to near
+        if (gated) {
+            val gate = CompletableDeferred<Unit>()
+            gates += gate
+            gate.await()
+        }
+        return found
+    }
+
     override suspend fun search(
         query: String,
         near: LatLng?,

--- a/app/src/test/java/com/nuelto/etappli/ui/map/LocationPickerScreenTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/map/LocationPickerScreenTest.kt
@@ -1,0 +1,163 @@
+package com.nuelto.etappli.ui.map
+
+import android.os.Looper
+import androidx.activity.OnBackPressedDispatcher
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.nuelto.etappli.data.model.LatLng
+import com.nuelto.etappli.domain.PlaceDetails
+import com.nuelto.etappli.domain.PlaceSuggestion
+import com.nuelto.etappli.testutil.FakePlaceSearch
+import com.nuelto.etappli.testutil.TestCamperApp
+import java.time.Duration
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = TestCamperApp::class)
+class LocationPickerScreenTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val search = FakePlaceSearch()
+    private val picked = mutableListOf<Pair<LatLng, PlaceSuggestion?>>()
+    private var cancelled = 0
+    private lateinit var back: OnBackPressedDispatcher
+
+    private val alpenblick =
+        PlaceSuggestion("Camping Alpenblick", "Unterseen", LatLng(46.68, 7.83), "ChIJa")
+    private val manorFarm =
+        PlaceSuggestion("Camping Manor Farm", "Unterseen", LatLng(46.69, 7.82), "ChIJb")
+
+    private fun setContent() {
+        compose.setContent {
+            back = LocalOnBackPressedDispatcherOwner.current!!.onBackPressedDispatcher
+            LocationPickerScreen(
+                initial = null,
+                onPicked = { at, place -> picked += at to place },
+                onCancel = { cancelled++ },
+                viewModel = LocationPickerViewModel(search),
+            )
+        }
+    }
+
+    private fun submit(query: String) {
+        compose.onNodeWithTag("place-search").performTextInput(query)
+        compose.onNodeWithContentDescription("Search").performClick()
+    }
+
+    private fun pressBack() {
+        compose.runOnUiThread { back.onBackPressed() }
+        compose.waitForIdle()
+    }
+
+    @Test
+    fun `a submitted search lines its pins up as cards, and one of them opens in full`() {
+        search.found = listOf(alpenblick, manorFarm)
+        search.resolved = {
+            it.copy(
+                details = PlaceDetails(
+                    kind = "Campground",
+                    rating = 4.6,
+                    ratingCount = 12,
+                    summary = "Lakeside pitches.",
+                ),
+            )
+        }
+        setContent()
+        submit("camping")
+        compose.onNodeWithText("Camping Alpenblick").assertIsDisplayed()
+        compose.onNodeWithText("Camping Manor Farm").assertIsDisplayed()
+
+        compose.onNodeWithText("Camping Manor Farm").performClick()
+        compose.onNodeWithText("Lakeside pitches.").assertIsDisplayed()
+        compose.onNodeWithText("Campground · 4.6 ★ (12)").assertIsDisplayed()
+        compose.onNodeWithText("Use this place").assertIsDisplayed()
+        // The other pins wait behind the card.
+        compose.onNodeWithText("Camping Alpenblick").assertDoesNotExist()
+    }
+
+    @Test
+    fun `back shrinks the card to a strip, then brings the pins back, then clears the search`() {
+        search.found = listOf(alpenblick, manorFarm)
+        search.resolved = { it.copy(details = PlaceDetails(kind = "Campground", summary = "Lakeside pitches.")) }
+        setContent()
+        submit("camping")
+        compose.onNodeWithText("Camping Manor Farm").performClick()
+
+        pressBack()
+        compose.onNodeWithText("Camping Manor Farm").assertIsDisplayed()
+        compose.onNodeWithText("Lakeside pitches.").assertDoesNotExist()
+        compose.onNodeWithText("Campground").assertIsDisplayed()
+        compose.onNodeWithText("Use").assertIsDisplayed()
+
+        // The strip opens up again on a tap, and folds on its chevron.
+        compose.onNodeWithText("Camping Manor Farm").performClick()
+        compose.onNodeWithText("Lakeside pitches.").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Show less").performClick()
+        compose.onNodeWithText("Lakeside pitches.").assertDoesNotExist()
+        compose.onNodeWithContentDescription("Show more").performClick()
+        compose.onNodeWithText("Lakeside pitches.").assertIsDisplayed()
+        pressBack()
+
+        pressBack()
+        compose.onNodeWithText("Camping Alpenblick").assertIsDisplayed()
+        compose.onNodeWithText("Use").assertDoesNotExist()
+
+        pressBack()
+        compose.onNodeWithText("Camping Alpenblick").assertDoesNotExist()
+        compose.onNodeWithText("Search a place").assertIsDisplayed()
+        assertEquals(0, cancelled)
+    }
+
+    @Test
+    fun `a single hit opens by itself and can be used from the strip`() {
+        search.found = listOf(alpenblick)
+        setContent()
+        submit("alpenblick")
+        compose.onNodeWithText("Use this place").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Show less").performClick()
+        compose.onNodeWithText("Use").performClick()
+        assertEquals(listOf(alpenblick.location!! to alpenblick), picked)
+    }
+
+    @Test
+    fun `typing lists predictions under the field, and picking one closes the list`() {
+        search.result = listOf(PlaceSuggestion("Grimsel Pass", "Obergoms", location = null, id = "ChIJp"))
+        search.resolved = { it.copy(location = LatLng(46.56, 8.34)) }
+        setContent()
+        compose.onNodeWithTag("place-search").performTextInput("grimsel")
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(400))
+        compose.onNodeWithText("Obergoms").assertIsDisplayed()
+
+        compose.onNodeWithText("Grimsel Pass").performClick()
+        compose.onNodeWithText("Use this place").assertIsDisplayed()
+        compose.onNodeWithText("Obergoms").assertIsDisplayed()
+        compose.onNodeWithText("Use this place").performClick()
+        assertEquals(LatLng(46.56, 8.34), picked.single().first)
+        assertEquals("Grimsel Pass", picked.single().second?.name)
+    }
+
+    @Test
+    fun `a search that finds nothing says so, and a dropped pin still works`() {
+        setContent()
+        submit("nirgendwo")
+        compose.onNodeWithText("Nothing found.").assertIsDisplayed()
+        compose.onNodeWithTag("map-placeholder").performClick()
+        compose.onNodeWithText("Dropped pin").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Show less").performClick()
+        compose.onNodeWithText("Dropped pin").assertIsDisplayed()
+    }
+}

--- a/app/src/test/java/com/nuelto/etappli/ui/map/LocationPickerViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/map/LocationPickerViewModelTest.kt
@@ -30,6 +30,11 @@ class LocationPickerViewModelTest {
     private val lauterbrunnen =
         PlaceSuggestion("Lauterbrunnen", "Bern, Switzerland", LatLng(46.5939043, 7.9078016))
 
+    private val alpenblick =
+        PlaceSuggestion("Camping Alpenblick", "Unterseen", LatLng(46.68, 7.83), "ChIJa")
+    private val manorFarm =
+        PlaceSuggestion("Camping Manor Farm", "Unterseen", LatLng(46.69, 7.82), "ChIJb")
+
     private fun viewModel() = LocationPickerViewModel(search)
 
     @Test
@@ -43,7 +48,7 @@ class LocationPickerViewModelTest {
 
         advanceTimeBy(2)
         assertEquals(listOf("Lauter" to bern), search.requests)
-        assertEquals("Lauterbrunnen", vm.uiState.value.results.single().name)
+        assertEquals("Lauterbrunnen", vm.uiState.value.predictions.single().name)
         assertEquals(PlaceSearchStatus.IDLE, vm.uiState.value.status)
         assertEquals("Lauter", vm.uiState.value.query)
     }
@@ -65,12 +70,12 @@ class LocationPickerViewModelTest {
         val vm = viewModel()
         vm.setQuery("Lauter", bern)
         advanceTimeBy(301)
-        assertEquals(1, vm.uiState.value.results.size)
+        assertEquals(1, vm.uiState.value.predictions.size)
 
         vm.setQuery("  La  ", bern)
         advanceTimeBy(1_000)
         assertEquals(1, search.requests.size)
-        assertTrue(vm.uiState.value.results.isEmpty())
+        assertTrue(vm.uiState.value.predictions.isEmpty())
         assertEquals(PlaceSearchStatus.IDLE, vm.uiState.value.status)
     }
 
@@ -85,7 +90,7 @@ class LocationPickerViewModelTest {
         search.result = emptyList()
         search.gates.single().complete(Unit)
         assertEquals(PlaceSearchStatus.EMPTY, vm.uiState.value.status)
-        assertTrue(vm.uiState.value.results.isEmpty())
+        assertTrue(vm.uiState.value.predictions.isEmpty())
     }
 
     @Test
@@ -93,13 +98,13 @@ class LocationPickerViewModelTest {
         val vm = viewModel()
         vm.setQuery("Lauter", bern)
         advanceTimeBy(301)
-        assertEquals(1, vm.uiState.value.results.size)
+        assertEquals(1, vm.uiState.value.predictions.size)
 
         search.result = null
         vm.setQuery("Grindelwald", bern)
         advanceTimeBy(301)
         assertEquals(PlaceSearchStatus.UNAVAILABLE, vm.uiState.value.status)
-        assertTrue(vm.uiState.value.results.isEmpty())
+        assertTrue(vm.uiState.value.predictions.isEmpty())
     }
 
     @Test
@@ -115,7 +120,7 @@ class LocationPickerViewModelTest {
         val vm = viewModel()
         vm.setQuery("Lauter", bern)
         advanceTimeBy(301)
-        vm.select(vm.uiState.value.results.single())
+        vm.select(vm.uiState.value.predictions.single())
         assertEquals(lauterbrunnen, vm.uiState.value.selected)
 
         vm.setQuery("Grindelwald", bern)
@@ -128,7 +133,7 @@ class LocationPickerViewModelTest {
         val vm = viewModel()
         vm.setQuery("Lauter", bern)
         advanceTimeBy(301)
-        vm.select(vm.uiState.value.results.single())
+        vm.select(vm.uiState.value.predictions.single())
         vm.setQuery("La", bern)
         assertNull(vm.uiState.value.selected)
     }
@@ -150,7 +155,7 @@ class LocationPickerViewModelTest {
         advanceTimeBy(1_000)
         assertEquals("Lauterbrunnen", vm.uiState.value.query)
         assertEquals(PlaceSearchStatus.IDLE, vm.uiState.value.status)
-        assertTrue(vm.uiState.value.results.isEmpty())
+        assertTrue(vm.uiState.value.predictions.isEmpty())
     }
 
     @Test
@@ -162,7 +167,7 @@ class LocationPickerViewModelTest {
         vm.setQuery("grimsel", bern)
         advanceTimeBy(301)
 
-        vm.select(vm.uiState.value.results.single())
+        vm.select(vm.uiState.value.predictions.single())
         val selected = vm.uiState.value.selected!!
         assertEquals(LatLng(46.5606, 8.3376), selected.location)
         // The name the user picked from the list survives the lookup.
@@ -179,7 +184,7 @@ class LocationPickerViewModelTest {
         vm.setQuery("grimsel", bern)
         advanceTimeBy(301)
 
-        vm.select(vm.uiState.value.results.single())
+        vm.select(vm.uiState.value.predictions.single())
         assertNull(vm.uiState.value.selected?.location)
         assertEquals(PlaceSearchStatus.UNAVAILABLE, vm.uiState.value.status)
     }
@@ -272,7 +277,7 @@ class LocationPickerViewModelTest {
         vm.setQuery("Lauter", bern)
         advanceTimeBy(301)
         assertNull(vm.uiState.value.selected)
-        assertEquals(1, vm.uiState.value.results.size)
+        assertEquals(1, vm.uiState.value.predictions.size)
     }
 
     @Test
@@ -321,13 +326,167 @@ class LocationPickerViewModelTest {
         val vm = viewModel()
         vm.setQuery("Lauter", bern)
         advanceTimeBy(301)
-        vm.select(vm.uiState.value.results.single())
+        vm.select(vm.uiState.value.predictions.single())
         assertNotNull(vm.uiState.value.selected)
 
         vm.clearSelection()
         assertNull(vm.uiState.value.selected)
         assertNull(vm.uiState.value.photo)
         assertEquals("Lauter", vm.uiState.value.query)
-        assertEquals(1, vm.uiState.value.results.size)
+        assertEquals(1, vm.uiState.value.predictions.size)
+    }
+
+    // --- the search as submitted ---------------------------------------------
+
+    @Test
+    fun `the search as submitted locates its hits as pins and closes the list`() = runTest {
+        search.found = listOf(alpenblick, manorFarm)
+        val vm = viewModel()
+        vm.setQuery("camping", bern)
+        advanceTimeBy(301)
+        assertEquals(1, vm.uiState.value.predictions.size)
+
+        vm.search(bern)
+        assertEquals(listOf("camping" to bern), search.finds)
+        assertEquals(listOf(alpenblick, manorFarm), vm.uiState.value.results)
+        assertTrue(vm.uiState.value.predictions.isEmpty())
+        assertNull(vm.uiState.value.selected)
+        assertEquals(PlaceSearchStatus.IDLE, vm.uiState.value.status)
+        assertEquals("camping", vm.uiState.value.query)
+    }
+
+    @Test
+    fun `submitting cancels the typing lookup still pending`() = runTest {
+        search.found = listOf(alpenblick, manorFarm)
+        val vm = viewModel()
+        vm.setQuery("camping", bern)
+        vm.search(bern)
+        advanceTimeBy(1_000)
+        assertTrue(search.requests.isEmpty())
+        assertEquals(2, vm.uiState.value.results.size)
+    }
+
+    @Test
+    fun `a search that finds one place opens it`() = runTest {
+        search.found = listOf(alpenblick)
+        search.resolved = { it.copy(details = PlaceDetails(rating = 4.6)) }
+        val vm = viewModel()
+        vm.setQuery("alpenblick", bern)
+        vm.search(bern)
+        assertEquals(listOf(alpenblick), vm.uiState.value.results)
+        assertEquals(4.6, vm.uiState.value.selected!!.details!!.rating!!, 1e-9)
+        assertTrue(vm.uiState.value.expanded)
+    }
+
+    @Test
+    fun `a submitted search reads as searching, then empty or unavailable`() = runTest {
+        search.gated = true
+        val vm = viewModel()
+        vm.setQuery("nirgendwo", bern)
+        vm.search(bern)
+        assertEquals(PlaceSearchStatus.SEARCHING, vm.uiState.value.status)
+        search.found = emptyList()
+        search.gates.single().complete(Unit)
+        assertEquals(PlaceSearchStatus.EMPTY, vm.uiState.value.status)
+        assertTrue(vm.uiState.value.results.isEmpty())
+
+        search.gated = false
+        search.found = null
+        vm.search(bern)
+        assertEquals(PlaceSearchStatus.UNAVAILABLE, vm.uiState.value.status)
+    }
+
+    @Test
+    fun `a blank query, or no backend, submits nothing`() = runTest {
+        val vm = viewModel()
+        vm.setQuery("  ", bern)
+        vm.search(bern)
+        assertTrue(search.finds.isEmpty())
+
+        val offline = LocationPickerViewModel()
+        offline.setQuery("camping", bern)
+        offline.search(bern)
+        assertEquals(PlaceSearchStatus.IDLE, offline.uiState.value.status)
+    }
+
+    @Test
+    fun `pins stay while typing on and while choosing, and go with a short query`() = runTest {
+        search.found = listOf(alpenblick, manorFarm)
+        val vm = viewModel()
+        vm.setQuery("camping", bern)
+        vm.search(bern)
+        vm.setQuery("camping interlaken", bern)
+        advanceTimeBy(301)
+        assertEquals(2, vm.uiState.value.results.size)
+        assertEquals(1, vm.uiState.value.predictions.size)
+
+        vm.select(vm.uiState.value.predictions.single())
+        assertEquals(2, vm.uiState.value.results.size)
+
+        vm.setQuery("ca", bern)
+        assertTrue(vm.uiState.value.results.isEmpty())
+    }
+
+    @Test
+    fun `a place chosen while the search is still out is not overridden by its one hit`() = runTest {
+        search.gated = true
+        search.found = listOf(alpenblick)
+        val vm = viewModel()
+        vm.setQuery("alpenblick", bern)
+        vm.search(bern)
+        vm.select(manorFarm.copy(details = PlaceDetails(rating = 4.0)))
+        search.gates.single().complete(Unit)
+        advanceTimeBy(1_000)
+        assertEquals("Camping Manor Farm", vm.uiState.value.selected?.name)
+        assertTrue(vm.uiState.value.results.isEmpty())
+    }
+
+    // --- back ----------------------------------------------------------------
+
+    @Test
+    fun `back shrinks the card, then drops the choice, then clears the search, then gives up`() = runTest {
+        search.found = listOf(alpenblick, manorFarm)
+        val vm = viewModel()
+        assertFalse(vm.uiState.value.canGoBack)
+        assertFalse(vm.back())
+
+        vm.setQuery("camping", bern)
+        vm.search(bern)
+        vm.select(alpenblick)
+        assertTrue(vm.uiState.value.expanded)
+
+        assertTrue(vm.back())
+        assertFalse(vm.uiState.value.expanded)
+        assertEquals(alpenblick, vm.uiState.value.selected)
+
+        assertTrue(vm.back())
+        assertNull(vm.uiState.value.selected)
+        assertEquals(2, vm.uiState.value.results.size)
+
+        assertTrue(vm.back())
+        assertEquals(LocationPickerUiState(), vm.uiState.value)
+        assertFalse(vm.back())
+    }
+
+    @Test
+    fun `a typed fragment is also something to go back from`() {
+        val vm = viewModel()
+        vm.setQuery("ca", bern)
+        assertTrue(vm.uiState.value.canGoBack)
+        assertTrue(vm.back())
+        assertEquals("", vm.uiState.value.query)
+    }
+
+    @Test
+    fun `the card opens in full again for the next choice`() {
+        val vm = viewModel()
+        vm.select(alpenblick)
+        vm.setExpanded(false)
+        assertFalse(vm.uiState.value.expanded)
+        vm.dropPin(LatLng(46.5, 7.9))
+        assertTrue(vm.uiState.value.expanded)
+        vm.setExpanded(false)
+        vm.select(manorFarm)
+        assertTrue(vm.uiState.value.expanded)
     }
 }

--- a/app/src/test/java/com/nuelto/etappli/ui/nav/AppNavHostTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/nav/AppNavHostTest.kt
@@ -16,10 +16,17 @@ import com.nuelto.etappli.AppContainer
 import com.nuelto.etappli.data.InMemorySettingsRepository
 import com.nuelto.etappli.data.InMemoryTripRepository
 import com.nuelto.etappli.data.model.LatLng
+import com.nuelto.etappli.domain.PlaceSearch
+import com.nuelto.etappli.domain.PlaceSuggestion
 import com.nuelto.etappli.domain.SharedPlace
+import com.nuelto.etappli.testutil.FakePlaceSearch
 import com.nuelto.etappli.testutil.TestCamperApp
 import com.nuelto.etappli.ui.map.LocalMapProvider
+import com.nuelto.etappli.ui.map.MapProvider
 import com.nuelto.etappli.ui.map.PlaceholderMapProvider
+import java.time.LocalDate
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -211,6 +218,32 @@ class AppNavHostTest {
         // Saving lands on that trip's timeline, with the stop on it.
         compose.onNodeWithText("Camping Kirnbergsee").assertIsDisplayed()
         compose.onAllNodesWithText("Camping Grimselblick")[0].assertIsDisplayed()
+    }
+
+    @Test
+    fun `a share that only names the place is looked up, and saved with the pin it found`() {
+        // What the Maps app's link comes down to: a name, an ftid, and no coordinate.
+        val search = FakePlaceSearch().apply {
+            found = listOf(PlaceSuggestion("Zielhaus am Klausenpass", "Spiringen", LatLng(46.8695, 8.8543), "ChIJz"))
+        }
+        val repository = InMemoryTripRepository()
+        ApplicationProvider.getApplicationContext<TestCamperApp>().container = AppContainer(
+            null, repository, InMemorySettingsRepository(),
+            mapProvider = object : MapProvider by PlaceholderMapProvider {
+                override fun placeSearch(): PlaceSearch = search
+            },
+        )
+        setContent(SharedPlace("Zielhaus am Klausenpass"))
+        compose.onNodeWithText("Pin from Google Maps.").assertIsDisplayed()
+        compose.onNodeWithText("Schwarzwald").performClick()
+        compose.onNodeWithText("Save").performScrollTo().performClick()
+
+        // Located, so the route and the height can be fetched for it — and on the Places clock.
+        val stop = runBlocking { repository.stops("demo-blackforest").first() }
+            .single { it.name == "Zielhaus am Klausenpass" }
+        assertEquals(LatLng(46.8695, 8.8543), stop.location)
+        assertEquals("ChIJz", stop.placeId)
+        assertEquals(LocalDate.now(), stop.locationCachedAt)
     }
 
     @Test

--- a/app/src/test/java/com/nuelto/etappli/ui/share/AddToTripScreenTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/share/AddToTripScreenTest.kt
@@ -12,7 +12,9 @@ import com.nuelto.etappli.data.InMemoryTripRepository
 import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
+import com.nuelto.etappli.domain.PlaceSuggestion
 import com.nuelto.etappli.domain.SharedPlace
+import com.nuelto.etappli.testutil.FakePlaceSearch
 import com.nuelto.etappli.testutil.FakeShareLinkResolver
 import com.nuelto.etappli.testutil.TestCamperApp
 import java.time.LocalDate
@@ -20,6 +22,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -34,6 +37,7 @@ class AddToTripScreenTest {
 
     private val tripRepository = InMemoryTripRepository(seed = false)
     private val resolver = FakeShareLinkResolver()
+    private val search = FakePlaceSearch()
     private var cancelled = 0
     private val added = mutableListOf<Pair<String, SharedPlace>>()
 
@@ -42,7 +46,9 @@ class AddToTripScreenTest {
             AddToTripScreen(
                 onCancel = { cancelled++ },
                 onAddTo = { tripId, shared -> added += tripId to shared },
-                viewModel = AddToTripViewModel(place, tripRepository, InMemorySettingsRepository(), resolver::expand),
+                viewModel = AddToTripViewModel(
+                    place, tripRepository, InMemorySettingsRepository(), resolver::expand, search::find,
+                ),
             )
         }
     }
@@ -84,6 +90,23 @@ class AddToTripScreenTest {
         seedTrips()
         setContent(SharedPlace(name = "Camping Delta"))
         compose.onNodeWithText("No spot in that link — pick the place on the map after.").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a name with no spot is looked up, and the trips wait for the answer`() {
+        seedTrips()
+        search.gated = true
+        search.found = listOf(PlaceSuggestion("Zielhaus am Klausenpass", "Spiringen", LatLng(46.8695, 8.8543), "ChIJz"))
+        setContent(SharedPlace("Zielhaus am Klausenpass"))
+        compose.onNodeWithText("Finding the place on Google Maps…").assertIsDisplayed()
+        compose.onNodeWithText("Ticino").assertIsNotEnabled()
+
+        search.gates.single().complete(Unit)
+        compose.onNodeWithText("Pin from Google Maps.").assertIsDisplayed()
+        compose.onNodeWithText("Ticino").performClick()
+        val filed = added.single().second
+        assertEquals(LatLng(46.8695, 8.8543), filed.location)
+        assertTrue(filed.fromPlaces)
     }
 
     @Test

--- a/app/src/test/java/com/nuelto/etappli/ui/share/AddToTripViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/share/AddToTripViewModelTest.kt
@@ -6,7 +6,9 @@ import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
 import com.nuelto.etappli.data.model.UserSettings
+import com.nuelto.etappli.domain.PlaceSuggestion
 import com.nuelto.etappli.domain.SharedPlace
+import com.nuelto.etappli.testutil.FakePlaceSearch
 import com.nuelto.etappli.testutil.FakeShareLinkResolver
 import com.nuelto.etappli.testutil.GatedSettingsRepository
 import com.nuelto.etappli.testutil.MainDispatcherRule
@@ -16,6 +18,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -28,9 +31,12 @@ class AddToTripViewModelTest {
     private val tripRepository = InMemoryTripRepository(seed = false)
     private val settingsRepository = InMemorySettingsRepository()
     private val resolver = FakeShareLinkResolver()
+    private val search = FakePlaceSearch()
 
     private fun viewModel(place: SharedPlace) =
-        AddToTripViewModel(place, tripRepository, settingsRepository, resolver::expand)
+        AddToTripViewModel(place, tripRepository, settingsRepository, resolver::expand, search::find)
+
+    private val zielhaus = PlaceSuggestion("Zielhaus am Klausenpass", "Spiringen", LatLng(46.8695, 8.8543), "ChIJz")
 
     private suspend fun trip(name: String, status: TripStatus, start: LocalDate = LocalDate.of(2026, 6, 1)) {
         tripRepository.upsertTrip(Trip(id = name, name = name, startDate = start, status = status))
@@ -55,8 +61,106 @@ class AddToTripViewModelTest {
     fun `a share that already has a coordinate never touches the network`() {
         val vm = viewModel(SharedPlace("Camping X", LatLng(46.5, 8.3)))
         assertEquals(emptyList<String>(), resolver.requests)
-        assertFalse(vm.uiState.value.expanding)
+        assertTrue(search.finds.isEmpty())
+        assertFalse(vm.uiState.value.busy)
         assertEquals("Camping X", vm.uiState.value.title)
+    }
+
+    // --- a name and no spot: the Maps app's links carry only an ftid ----------------------
+
+    @Test
+    fun `a name with no spot is looked up near home, and the one hit is the place`() = runTest {
+        settingsRepository.update(UserSettings(homeName = "Luzern", homeLocation = LatLng(47.05, 8.31)))
+        search.gated = true
+        search.found = listOf(zielhaus)
+        val vm = viewModel(SharedPlace("Zielhaus am Klausenpass"))
+
+        assertTrue(vm.uiState.value.locating)
+        assertTrue(vm.uiState.value.busy)
+        assertFalse(vm.uiState.value.expanding)
+        assertEquals(listOf("Zielhaus am Klausenpass" to LatLng(47.05, 8.31)), search.finds)
+
+        search.gates.single().complete(Unit)
+        val state = vm.uiState.value
+        assertEquals(LatLng(46.8695, 8.8543), state.place.location)
+        assertEquals("ChIJz", state.place.placeId)
+        assertEquals("Zielhaus am Klausenpass", state.place.name)
+        assertTrue(state.place.fromPlaces)
+        assertFalse(state.locating)
+        assertFalse(state.expandFailed)
+    }
+
+    @Test
+    fun `a link that only names the place is followed, then looked up`() {
+        resolver.result = "https://www.google.com/maps/place/Zielhaus+am+Klausenpass/" +
+            "data=!4m2!3m1!1s0x479a:0x6a7b?utm_source=mstt_1&entry=gps"
+        search.found = listOf(zielhaus)
+        val vm = viewModel(SharedPlace(link = "https://maps.app.goo.gl/x1"))
+        assertEquals(listOf("Zielhaus am Klausenpass" to null), search.finds)
+        assertEquals(LatLng(46.8695, 8.8543), vm.uiState.value.place.location)
+        assertEquals("", vm.uiState.value.place.link)
+        assertFalse(vm.uiState.value.busy)
+    }
+
+    @Test
+    fun `without a place search a name stays unpinned, and nothing is tried or reported`() {
+        val vm = AddToTripViewModel(SharedPlace("Zielhaus am Klausenpass"), tripRepository, settingsRepository)
+        assertNull(vm.uiState.value.place.location)
+        assertFalse(vm.uiState.value.busy)
+        assertFalse(vm.uiState.value.expandFailed)
+        vm.expand()
+        assertFalse(vm.uiState.value.busy)
+    }
+
+    @Test
+    fun `a link that could not be followed is not looked up yet`() {
+        viewModel(SharedPlace("Zielhaus am Klausenpass", link = "https://maps.app.goo.gl/x1"))
+        assertTrue(search.finds.isEmpty())
+    }
+
+    @Test
+    fun `several hits pin nothing, and a pinned share or one with an id asks for none`() {
+        search.found = listOf(zielhaus, zielhaus.copy(id = "ChIJother"))
+        val vm = viewModel(SharedPlace("Camping Seeblick"))
+        assertNull(vm.uiState.value.place.location)
+        assertFalse(vm.uiState.value.place.fromPlaces)
+        assertFalse(vm.uiState.value.expandFailed)
+        assertEquals(1, search.finds.size)
+
+        viewModel(SharedPlace("Camping X", LatLng(46.5, 8.3)))
+        viewModel(SharedPlace("Camping X", placeId = "ChIJ1"))
+        assertEquals(1, search.finds.size)
+    }
+
+    @Test
+    fun `a lookup that did not come back can be tried again`() {
+        search.found = null
+        val vm = viewModel(SharedPlace("Zielhaus am Klausenpass"))
+        assertTrue(vm.uiState.value.expandFailed)
+        assertFalse(vm.uiState.value.locating)
+
+        search.found = listOf(zielhaus)
+        search.gated = true
+        vm.expand()
+        assertTrue(vm.uiState.value.locating)
+        assertFalse(vm.uiState.value.expandFailed)
+        search.gates.single().complete(Unit)
+        assertFalse(vm.uiState.value.expandFailed)
+        assertEquals(LatLng(46.8695, 8.8543), vm.uiState.value.place.location)
+        assertEquals(2, search.finds.size)
+
+        // Pinned: nothing left to look up.
+        vm.expand()
+        assertEquals(2, search.finds.size)
+    }
+
+    @Test
+    fun `an approximate pin is looked up near itself and made exact`() {
+        search.found = listOf(PlaceSuggestion("Titisee", "", LatLng(47.8918, 8.1454), "ChIJt"))
+        val vm = viewModel(SharedPlace("Titisee", LatLng(47.89, 8.14), approximate = true))
+        assertEquals(listOf("Titisee" to LatLng(47.89, 8.14)), search.finds)
+        assertEquals(LatLng(47.8918, 8.1454), vm.uiState.value.place.location)
+        assertFalse(vm.uiState.value.place.approximate)
     }
 
     @Test

--- a/app/src/test/java/com/nuelto/etappli/ui/tripedit/StopEditViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/tripedit/StopEditViewModelTest.kt
@@ -48,6 +48,7 @@ class StopEditViewModelTest {
         lon: Double? = 8.332,
         placeName: String? = "Camping Grimselblick",
         placeId: String? = "ChIJCyinolJ-hUcR",
+        fromPlaces: Boolean = false,
     ) = StopEditViewModel(
         SavedStateHandle(
             mapOf(
@@ -57,6 +58,7 @@ class StopEditViewModelTest {
                 "placeName" to placeName,
                 "placeId" to placeId,
                 "fromShare" to true,
+                "fromPlaces" to fromPlaces,
             ),
         ),
         tripRepository,
@@ -614,6 +616,14 @@ class StopEditViewModelTest {
         assertNull(state.locationCachedAt)
         // Somewhere to be already: no unasked-for GPS fix on top of it.
         assertFalse(state.autoLocatePending)
+    }
+
+    @Test
+    fun `a shared place that had to be looked up on Google carries the Places clock`() {
+        val state = sharedViewModel(fromPlaces = true).uiState.value
+        assertEquals(LatLng(46.5601, 8.332), state.location)
+        assertEquals("ChIJCyinolJ-hUcR", state.placeId)
+        assertEquals(LocalDate.now(), state.locationCachedAt)
     }
 
     @Test


### PR DESCRIPTION
Two changes to how a stop finds its spot, both towards #29. The saved-list part of that issue stays open.

## Search like a maps app (8a1b548)
- Typing still autocompletes; the search as submitted goes to Places Text Search. "camping" gives up to 20 pins framed by the camera, with a strip of cards along the bottom to read them by; a name gives the one place, which opens by itself.
- The chosen place's card opens in full and shrinks to a strip, so the map around the place can be looked at and a POI beside it tapped. System back peels the picker's own layers off innermost first: card, strip, pins, search.
- `MapProvider.Canvas` takes `contentPadding`, so the camera centres a pin within what the card leaves visible.
- Text Search asks for the Pro-tier fields only; Place Details still fetches rating, photo and review for the one place chosen.

## Look a shared place up by name when its link pins nothing (adef2c8)
Fixes a stop shared from Google Maps never getting its km and time. The Maps app's share links resolve to the place's name and an ftid with no coordinate, so the stop was saved without a location, and an unlocated stop is off the route.
- The "Add to a trip" chooser now asks Text Search for the name, the way the picker opens a submitted name: one hit is the place, several hits pin nothing. The trip cards wait for the answer.
- That coordinate is from the Places API, so `SharedPlace.fromPlaces` carries the 30-day clock (SST §14.3) into the stop editor. A coordinate lifted from the link itself still never expires.
- An approximate pin (map camera only) is looked up near itself and made exact.
- Without a Maps key there is no search, and such a share stays unpinned as before.

## Verification
- `./gradlew test :app:coverageVerify :app:pitest :app:assembleDebug`: green, 100% line coverage, 95% mutations killed.
- Picker UX walked on the emulator in local-only mode; the share lookup checked live against Text Search, which answers "Zielhaus am Klausenpass" with exactly one hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
