### PR TITLE
Follow the road actually driven: track the drive in the background

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,14 +85,39 @@ There is no lint/format tooling configured.
   (`StopLeg.hasRoad` false): straight hop, road factor, "No drivable route", and nothing
   asks again for 30 days.
 - **"How far from here"**: on an ACTIVE trip the NowCard replaces the planned leg with a
-  live route from the current GPS fix to the stop you are heading for (`domain/DriveFromHere`
-  + `LiveDrive` rules, `MapProvider.drive`). Never stored — it is true for one fix.
-  `LiveDrive` throttles it: no refetch under 2 km of movement, and nothing shown once you
-  are within 150 m. The line also carries the arrival time (`formatArrival`, rounded to the
-  minute like `formatDuration` so the two agree), read at composition — no ticker, because
-  an endless `LaunchedEffect` would leave the Compose test clock busy forever. Checking in
-  clears it in the combine: you are there, so distance stops being a question. The
-  permission is asked for on tap, never on opening a trip.
+  live route from the last GPS fix to the stop you are heading for. The fix/route logic is
+  `RouteTracker.fix` (one implementation, shared with the tracking service): every fix
+  goes to the app's one `RouteTracker` (`AppContainer.tracker`), which buys the route
+  (`MapProvider.drive`) and publishes it as `RouteTracker.state.drive`, a
+  `domain/DriveFromHere`. Never stored — it is true for one fix. `LiveDrive` throttles it,
+  keyed on where the last route was *asked* from and to, whatever came of it — so a stop
+  with no road never buys a route per fix: no refetch under 2 km of movement, and nothing
+  shown once you are within 150 m. The line also carries the arrival time (`formatArrival`,
+  rounded to the minute like `formatDuration` so the two agree), read at composition — no
+  ticker, because an endless `LaunchedEffect` would leave the Compose test clock busy
+  forever. Checking in clears it in the combine: you are there, so distance stops being a
+  question. The permission is asked for on tap, never on opening a trip.
+- **Tracking the way driven** (`domain/RouteTracker`, `domain/Tracks`,
+  `location/TrackingService`): the *heading* is the stop an ACTIVE trip is driving to
+  (`CurrentStop.heading` — `CurrentStop.of` while it is still PLANNED; mid-stay there is
+  none, and the −1 on the nights stepper is the check-out), *underway* only from the tour's
+  start date on. While one is underway a foreground service takes a fix every
+  `Tracks.FIX_INTERVAL_MS` (2 min, HIGH_ACCURACY — deliberate: a road trace needs GPS and
+  the cadence duty-cycles it), appends it atomically to `Stop.track`
+  (`TripRepository.appendTrack`), and keeps an ongoing notification saying how far the
+  heading still is — about one Routes call per fix on the road, ~30/h, well inside the
+  Essentials free tier for one user. The service starts when the app is open with a heading
+  underway (`MainActivity.TrackingTrigger`, and the NowCard when the permission lands) and
+  stops itself when nothing is underway. Android 12+ refuses a location FGS started from
+  the background, so there is no `ACCESS_BACKGROUND_LOCATION`, no WorkManager, no boot
+  receiver and `START_NOT_STICKY`: **a drive on a day the app is never opened is not
+  recorded.** Both repositories run `Tracks.settle` after every stop write — fixes belong
+  to the drive underway, whichever stop it now arrives at. A track of two or more points is
+  drawn instead of the leg (`MapOverlay`: the drive underway is the track so far plus the
+  rest of the road from the last fix, dashed); an arrival fix (within 150 m) is never
+  recorded, or the evening fix at the campsite would turn the routed road into a straight
+  line. **Never write a `Stop` you did not just read**: a whole-stop write carries the
+  track it loaded, so every writer re-reads first (a second device would lose fixes).
 - **Elevation is not Google**: its Elevation API forbids storing results, so height comes
   from Open-Meteo (Copernicus DEM) via `domain/Elevation`. Two different numbers:
   `Stop.elevation` is **how high the stop is**, one point, stable, and the only one shown

--- a/FIREBASE_SETUP.md
+++ b/FIREBASE_SETUP.md
@@ -35,6 +35,8 @@ Google Sign-In + Firestore sync automatically.
    Choose **production mode** and a region close to you (e.g. `europe-west6`, Zürich).
 2. In the **Rules** tab, paste the contents of [`firestore.rules`](firestore.rules)
    and publish.
+3. **Indexes → Single field → Add exemption**: collection group `stops`, field `track`, every
+   index off — or Firestore indexes every GPS fix ([`firestore.indexes.json`](firestore.indexes.json) says the same for the CLI, which this repo does not deploy with).
 
 ## 4. Rebuild and verify
 

--- a/PLAY_STORE_SETUP.md
+++ b/PLAY_STORE_SETUP.md
@@ -106,7 +106,7 @@ Under **Policy → App content**. All of these are required before any track can
 | --- | --- | --- | --- | --- |
 | Email address | Yes (Google Sign-In) | No | Yes | Account management |
 | User IDs | Yes (Firebase uid) | No | Yes | Account management |
-| Approximate / precise location | Yes, only on explicit tap | No | No | App functionality |
+| Approximate / precise location | Yes — on tap, and every few minutes while a drive is tracked (foreground service with an ongoing notification) | No | No | App functionality |
 | Other user-generated content (trips, stops, notes, costs) | Yes | No | Yes | App functionality |
 
 Encrypted in transit: **yes**. Users can request deletion: **yes**. No data is used for
@@ -123,7 +123,7 @@ signing key, which is what the September 2026 deadline is about.
 `play/listing/store-listing.md`, upload the graphics from `play/listing/`) and passes a
 review that can take days.
 
-## 6. After the first upload — two things will otherwise be broken
+## 6. After the first upload — three things will otherwise be broken
 
 1. **Google Sign-In.** The installed app is signed by Google's app signing key, not your
    upload key, so its fingerprint is unknown to Firebase and sign-in fails. Copy the
@@ -136,6 +136,11 @@ review that can take days.
    to production, at minimum restrict the key to the four APIs it needs (Maps SDK for
    Android, Places API (New), Routes API) and set a billing budget alert and per-API
    quota caps in Google Cloud Console.
+3. **The release waits for the foreground-service declaration.** The bundle declares the
+   `location` foreground-service type, so once it is uploaded Policy → App content grows a
+   *Foreground service permissions* item that has to be completed before the release rolls
+   out. Use case: tracking the drive between the stops of an active trip, started by the
+   user opening the app, visible as an ongoing notification.
 
 ## Developer verification (the deadline in the mail)
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy — Etappli
 
-Last updated: 1 September 2026
+Last updated: 4 September 2026
 
 Etappli ("the app") is a personal trip log for camper travel. This policy
 describes what the app stores and who else sees it.
@@ -14,9 +14,12 @@ describes what the app stores and who else sees it.
   and the coordinates of the stops you pick.
 - **Your settings**: currency, fuel consumption and price, vehicle mass, and your home
   location if you set one.
-- **Your device's location**, only at the moment you tap "I'm here" or ask how far the
-  next stop is. It is used to fill in a stop's coordinates or to measure a distance.
-  The app has no background location access and does not track your movement.
+- **Your device's location**, at the moment you tap "I'm here" or "Track this drive" —
+  to fill in a stop's coordinates or measure a distance — and every few minutes while a
+  drive of an active trip is tracked: after you open the app on a travelling day, until
+  you check in at the next stop. Tracking is shown by an ongoing notification and the
+  fixes are stored as the trip's route. Nothing is tracked while no trip is active, and
+  the app never asks for background location access.
 
 Everything is stored in Google Firebase (Cloud Firestore) under the developer's Firebase
 project, and cached on your device so the app works offline.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,12 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- The drive of an active trip is tracked by a foreground service with an ongoing
+         notification (location/TrackingService). No background-location permission: the
+         service is started while the app is open. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name=".CamperApp"
@@ -41,6 +47,10 @@
                 <data android:scheme="geo" />
             </intent-filter>
         </activity>
+        <service
+            android:name=".location.TrackingService"
+            android:exported="false"
+            android:foregroundServiceType="location" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/nuelto/etappli/CamperApp.kt
+++ b/app/src/main/java/com/nuelto/etappli/CamperApp.kt
@@ -13,9 +13,11 @@ import com.nuelto.etappli.data.InMemoryTripRepository
 import com.nuelto.etappli.data.SettingsRepository
 import com.nuelto.etappli.data.TripRepository
 import com.nuelto.etappli.data.model.LatLng
+import com.nuelto.etappli.domain.RouteTracker
 import com.nuelto.etappli.domain.ShareIntake
 import com.nuelto.etappli.location.LocationProvider
 import com.nuelto.etappli.location.ShareLinkResolver
+import com.nuelto.etappli.location.TrackingService
 import com.nuelto.etappli.ui.map.PlaceholderMapProvider
 import com.nuelto.etappli.ui.map.MapProvider
 
@@ -38,6 +40,10 @@ class AppContainer(
     val shareIntake: ShareIntake = ShareIntake(),
     // Follows a shared short link to the Maps URL behind it; null without a connection.
     val expandShareLink: suspend (String) -> String? = { null },
+    // Follows the drive underway: the track, and how far the next stop is. See domain/RouteTracker.
+    val tracker: RouteTracker = RouteTracker(tripRepository, mapProvider::drive),
+    // Starts the background tracking service where the platform allows it; a no-op in tests.
+    val startTracking: () -> Unit = {},
 ) {
     val firebaseEnabled: Boolean get() = authRepository != null
 
@@ -46,9 +52,10 @@ class AppContainer(
             mapProvider: MapProvider = PlaceholderMapProvider,
             currentLocation: suspend () -> LatLng? = { null },
             expandShareLink: suspend (String) -> String? = { null },
+            startTracking: () -> Unit = {},
         ) = AppContainer(
             null, InMemoryTripRepository(), InMemorySettingsRepository(), mapProvider, currentLocation,
-            expandShareLink = expandShareLink,
+            expandShareLink = expandShareLink, startTracking = startTracking,
         )
     }
 }
@@ -68,7 +75,8 @@ open class CamperApp : Application() {
         val map = googleMapProvider(this) ?: PlaceholderMapProvider
         val locate: suspend () -> LatLng? = { LocationProvider(this).currentLocation() }
         val expand: suspend (String) -> String? = { ShareLinkResolver.expand(it) }
-        return firebaseContainer(this, map, locate, expand) ?: AppContainer.inMemory(map, locate, expand)
+        val track = { TrackingService.start(this) }
+        return firebaseContainer(this, map, locate, expand, track) ?: AppContainer.inMemory(map, locate, expand, track)
     }
 }
 

--- a/app/src/main/java/com/nuelto/etappli/FirebaseBackend.kt
+++ b/app/src/main/java/com/nuelto/etappli/FirebaseBackend.kt
@@ -19,6 +19,7 @@ fun firebaseContainer(
     mapProvider: MapProvider,
     currentLocation: suspend () -> LatLng? = { null },
     expandShareLink: suspend (String) -> String? = { null },
+    startTracking: () -> Unit = {},
 ): AppContainer? {
     val firebaseApp = FirebaseApp.initializeApp(app) ?: return null
     val db = FirebaseFirestore.getInstance()
@@ -37,5 +38,6 @@ fun firebaseContainer(
         settingsRepository = FirestoreSettingsRepository(db, auth),
         currentLocation = currentLocation,
         expandShareLink = expandShareLink,
+        startTracking = startTracking,
     )
 }

--- a/app/src/main/java/com/nuelto/etappli/MainActivity.kt
+++ b/app/src/main/java/com/nuelto/etappli/MainActivity.kt
@@ -7,13 +7,20 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
 import com.nuelto.etappli.domain.SharedPlace
 import com.nuelto.etappli.ui.auth.SignInScreen
 import com.nuelto.etappli.ui.map.LocalMapProvider
 import com.nuelto.etappli.ui.nav.AppNavHost
 import com.nuelto.etappli.ui.theme.CamperTheme
 import androidx.compose.runtime.collectAsState
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -52,6 +59,7 @@ internal fun AppRoot(container: AppContainer) {
         if (authRepository == null) {
             // Local-only mode: Firebase not configured in this build.
             AppNavHost(shared, container.shareIntake::consume)
+            TrackingTrigger(container)
         } else {
             val user by authRepository.authState.collectAsState(initial = authRepository.currentUser)
             if (user == null) {
@@ -59,7 +67,30 @@ internal fun AppRoot(container: AppContainer) {
                 SignInScreen(authRepository)
             } else {
                 AppNavHost(shared, container.shareIntake::consume)
+                // Only here: the Firestore repositories throw without a user.
+                TrackingTrigger(container)
             }
+        }
+    }
+}
+
+/**
+ * Starts tracking whenever the app is open with a drive underway: opening the app on a
+ * travelling day is what starts it, and the service keeps going after. Asked again on
+ * every return to the foreground in case the system ended it — a start landing on a
+ * running service changes nothing.
+ */
+@Composable
+internal fun TrackingTrigger(container: AppContainer) {
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+    LaunchedEffect(container) {
+        lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            container.tracker.heading()
+                .map { it?.takeIf { h -> h.underway }?.stop?.id }
+                .distinctUntilChanged()
+                // A plan that cannot be read starts nothing; the next STARTED asks again.
+                .catch { }
+                .collect { if (it != null) container.startTracking() }
         }
     }
 }

--- a/app/src/main/java/com/nuelto/etappli/data/FirestoreTripRepository.kt
+++ b/app/src/main/java/com/nuelto/etappli/data/FirestoreTripRepository.kt
@@ -3,6 +3,7 @@ package com.nuelto.etappli.data
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.GeoPoint
 import com.google.firebase.firestore.Query
@@ -23,6 +24,7 @@ import com.nuelto.etappli.data.model.TripStatus
 import com.nuelto.etappli.data.model.legacyTripStatus
 import com.nuelto.etappli.domain.CostCalculator
 import com.nuelto.etappli.domain.DateCascade
+import com.nuelto.etappli.domain.Tracks
 import com.nuelto.etappli.domain.TripName
 import java.time.LocalDate
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -106,6 +108,7 @@ class FirestoreTripRepository(
         "region" to region?.let {
             mapOf("at" to GeoPoint(it.at.latitude, it.at.longitude), "name" to it.name, "country" to it.country)
         },
+        "track" to track.map { GeoPoint(it.latitude, it.longitude) },
     )
 
     private fun StopLeg.toMap() = mapOf(
@@ -191,6 +194,9 @@ class FirestoreTripRepository(
                 stored["name"] as? String ?: "",
                 stored["country"] as? String ?: "",
             )
+        },
+        track = (get("track") as? List<*>).orEmpty().mapNotNull { point ->
+            (point as? GeoPoint)?.let { LatLng(it.latitude, it.longitude) }
         },
     )
 
@@ -304,6 +310,7 @@ class FirestoreTripRepository(
         stops.map { it.tripId }.distinct().forEach {
             recomputeTotals(it)
             redatePlan(it)
+            settleTracks(it)
         }
     }
 
@@ -311,6 +318,12 @@ class FirestoreTripRepository(
         trips(uid).document(tripId).collection("stops").document(stopId).delete()
         recomputeTotals(tripId)
         redatePlan(tripId)
+        settleTracks(tripId)
+    }
+
+    override suspend fun appendTrack(tripId: String, stopId: String, point: LatLng) {
+        trips(uid).document(tripId).collection("stops").document(stopId)
+            .update("track", FieldValue.arrayUnion(GeoPoint(point.latitude, point.longitude)))
     }
 
     override suspend fun upsertExpense(expense: Expense) {
@@ -343,6 +356,21 @@ class FirestoreTripRepository(
         if (trip.status != TripStatus.PLANNED) return
         val start = DateCascade.start(stops) ?: return
         if (start != trip.startDate) tripDoc.update("startDate", start.toEpochDay())
+    }
+
+    /**
+     * Fixes belong to the drive underway whichever stop it now arrives at — see
+     * Tracks.settle. From the cache, like [redatePlan], so it holds offline too.
+     */
+    private suspend fun settleTracks(tripId: String) {
+        val tripDoc = trips(uid).document(tripId)
+        val stops = runCatching {
+            tripDoc.collection("stops").get(Source.CACHE).await().documents.map { it.toStop(tripId) }
+        }.getOrNull() ?: return
+        Tracks.settle(stops).forEach { stop ->
+            tripDoc.collection("stops").document(stop.id)
+                .update("track", stop.track.map { GeoPoint(it.latitude, it.longitude) })
+        }
     }
 
     /**

--- a/app/src/main/java/com/nuelto/etappli/data/InMemoryTripRepository.kt
+++ b/app/src/main/java/com/nuelto/etappli/data/InMemoryTripRepository.kt
@@ -11,6 +11,7 @@ import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
 import com.nuelto.etappli.domain.CostCalculator
 import com.nuelto.etappli.domain.DateCascade
+import com.nuelto.etappli.domain.Tracks
 import com.nuelto.etappli.domain.TripName
 import java.time.LocalDate
 import java.util.UUID
@@ -73,6 +74,7 @@ class InMemoryTripRepository(seed: Boolean = true) : TripRepository {
         withIds.map { it.tripId }.distinct().forEach {
             recomputeTotals(it)
             redatePlan(it)
+            settleTracks(it)
         }
     }
 
@@ -80,6 +82,20 @@ class InMemoryTripRepository(seed: Boolean = true) : TripRepository {
         stopsFlow.update { list -> list.filterNot { it.id == stopId } }
         recomputeTotals(tripId)
         redatePlan(tripId)
+        settleTracks(tripId)
+    }
+
+    override suspend fun appendTrack(tripId: String, stopId: String, point: LatLng) {
+        stopsFlow.update { list ->
+            list.map { stop ->
+                // Firestore's arrayUnion drops an element present anywhere in the array.
+                if (stop.id == stopId && stop.tripId == tripId && point !in stop.track) {
+                    stop.copy(track = stop.track + point)
+                } else {
+                    stop
+                }
+            }
+        }
     }
 
     override suspend fun upsertExpense(expense: Expense) {
@@ -106,6 +122,12 @@ class InMemoryTripRepository(seed: Boolean = true) : TripRepository {
         if (trip.status != TripStatus.PLANNED) return
         val start = DateCascade.start(stopsFlow.value.filter { it.tripId == tripId }) ?: return
         tripsFlow.update { list -> list.map { if (it.id == tripId) it.copy(startDate = start) else it } }
+    }
+
+    /** Fixes belong to the drive underway whichever stop it now arrives at — see Tracks.settle. */
+    private fun settleTracks(tripId: String) {
+        val settled = Tracks.settle(stopsFlow.value.filter { it.tripId == tripId }).associateBy { it.id }
+        stopsFlow.update { list -> list.map { settled[it.id] ?: it } }
     }
 
     private fun recomputeTotals(tripId: String) {

--- a/app/src/main/java/com/nuelto/etappli/data/TripRepository.kt
+++ b/app/src/main/java/com/nuelto/etappli/data/TripRepository.kt
@@ -1,6 +1,7 @@
 package com.nuelto.etappli.data
 
 import com.nuelto.etappli.data.model.Expense
+import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.data.model.Stop
 import com.nuelto.etappli.data.model.Trip
 import kotlinx.coroutines.flow.Flow
@@ -28,6 +29,13 @@ interface TripRepository {
      */
     suspend fun upsertStops(stops: List<Stop>)
     suspend fun deleteStop(tripId: String, stopId: String)
+
+    /**
+     * Adds one fix to a stop's track without rewriting the stop: an atomic append that
+     * cannot clobber an edit made meanwhile. Nothing priced or dated changes, so neither
+     * totals nor plan are touched.
+     */
+    suspend fun appendTrack(tripId: String, stopId: String, point: LatLng)
     suspend fun upsertExpense(expense: Expense)
     suspend fun deleteExpense(tripId: String, expenseId: String)
 }

--- a/app/src/main/java/com/nuelto/etappli/data/model/Models.kt
+++ b/app/src/main/java/com/nuelto/etappli/data/model/Models.kt
@@ -153,6 +153,13 @@ data class Stop(
     val leg: StopLeg? = null,
     val elevation: StopElevation? = null,
     val region: StopRegion? = null,
+    // The way actually driven here: GPS fixes taken every few minutes while this was the
+    // stop being headed for (domain/RouteTracker), complete once checked in. Drawn instead
+    // of [leg] once there are two — the road you took, not the one Google suggested.
+    // Appended in place (TripRepository.appendTrack); a whole-stop write carries what it
+    // loaded, so never write a Stop you did not just read (every writer here re-reads
+    // first; a second device would lose fixes).
+    val track: List<LatLng> = emptyList(),
 )
 
 enum class ExpenseType {

--- a/app/src/main/java/com/nuelto/etappli/domain/CurrentStop.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/CurrentStop.kt
@@ -8,22 +8,42 @@ object CurrentStop {
 
     /**
      * Tonight's stop on an active trip. A checked-in stay stays current until it is over
-     * (so the ±nights stepper is at hand mid-stay). A checked-in stop with no nights — the
-     * home a tour set out from, a visit — is behind you the moment it is done, whatever
-     * its date says: a tour started ahead of its start date must head for the first stop,
-     * not sit "checked in" at home. Otherwise the first upcoming stop past the check-in
-     * line — a stop restored behind it only becomes current when nothing lies ahead.
+     * (so the ±nights stepper is at hand mid-stay); otherwise [next].
      */
-    fun of(stops: List<Stop>, today: LocalDate): String? {
-        val ordered = stops.sortedBy { it.orderIndex }.filterNot { it.state == StopState.SKIPPED }
+    fun of(stops: List<Stop>, today: LocalDate): String? =
+        staying(stops, today)?.id ?: next(stops)?.id
+
+    /**
+     * The stop the drive underway arrives at: the first planned stop past the check-in
+     * line, else the first planned stop — a stop restored behind the line only comes up
+     * when nothing lies ahead.
+     */
+    fun next(stops: List<Stop>): Stop? {
+        val ordered = ordered(stops)
         val lastDone = ordered.lastOrNull { it.state == StopState.DONE }
-        if (lastDone != null && lastDone.nights > 0 &&
-            today.isBefore(lastDone.arrivalDate.plusDays(lastDone.nights.toLong()))
-        ) {
-            return lastDone.id
-        }
         val upcoming = ordered.filter { it.state == StopState.PLANNED }
-        return upcoming.firstOrNull { lastDone == null || it.orderIndex > lastDone.orderIndex }?.id
-            ?: upcoming.firstOrNull()?.id
+        return upcoming.firstOrNull { lastDone == null || it.orderIndex > lastDone.orderIndex }
+            ?: upcoming.firstOrNull()
     }
+
+    /**
+     * The stop you are driving to: [next] unless you are mid-stay. Null with nothing
+     * planned. Check-out is implicit — a stay is over the morning after its last night,
+     * and the nights stepper is how you leave early.
+     */
+    fun heading(stops: List<Stop>, today: LocalDate): Stop? =
+        if (staying(stops, today) != null) null else next(stops)
+
+    /**
+     * The checked-in stay that is not over yet. A checked-in stop with no nights — the
+     * home a tour set out from, a visit — is behind you the moment it is done, whatever
+     * its date says: a tour started ahead of its start date must head for the first
+     * stop, not sit "checked in" at home.
+     */
+    private fun staying(stops: List<Stop>, today: LocalDate): Stop? =
+        ordered(stops).lastOrNull { it.state == StopState.DONE }
+            ?.takeIf { it.nights > 0 && today.isBefore(it.arrivalDate.plusDays(it.nights.toLong())) }
+
+    private fun ordered(stops: List<Stop>): List<Stop> =
+        stops.sortedBy { it.orderIndex }.filterNot { it.state == StopState.SKIPPED }
 }

--- a/app/src/main/java/com/nuelto/etappli/domain/DriveFromHere.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/DriveFromHere.kt
@@ -34,11 +34,15 @@ object LiveDrive {
     fun arrived(from: LatLng, to: LatLng): Boolean =
         GeoUtils.haversineKm(from, to) * 1000 < ARRIVED_WITHIN_METERS
 
-    /** True when nothing usable is held for this fix and this destination. */
-    fun needsFetch(current: DriveFromHere?, from: LatLng, to: LatLng): Boolean = when {
-        current == null -> true
+    /**
+     * True when the last route asked for does not answer this fix and this destination.
+     * Keyed on where it was asked from and to, whatever came of it: a failed ask must not
+     * be repeated on every fix.
+     */
+    fun needsFetch(askedFrom: LatLng?, askedTo: LatLng?, from: LatLng, to: LatLng): Boolean = when {
+        askedFrom == null -> true
         // A different destination is a different question, however little you moved.
-        current.to != to -> true
-        else -> GeoUtils.haversineKm(current.from, from) * 1000 >= REFRESH_AFTER_METERS
+        askedTo != to -> true
+        else -> GeoUtils.haversineKm(askedFrom, from) * 1000 >= REFRESH_AFTER_METERS
     }
 }

--- a/app/src/main/java/com/nuelto/etappli/domain/MapOverlay.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/MapOverlay.kt
@@ -73,57 +73,92 @@ object MapOverlay {
 
     /**
      * DONE: one grey line. PLANNED: one dashed blue line. ACTIVE: grey behind (done
-     * stops), green current leg, dashed blue ahead.
+     * stops), green current leg, dashed blue ahead. Wherever a drive was tracked its
+     * fixes stand in for the road (Tracks.drive), and the drive to the very first stop —
+     * which no leg describes — is drawn from its first fix as a leading segment.
      */
     fun routes(data: List<TripMapData>): List<MapRoute> = data.flatMap { entry ->
         val located = entry.stops
             .sortedBy { it.orderIndex }
             .filterNot { it.state == StopState.SKIPPED }
             .filter { it.location != null }
-        if (located.size < 2) return@flatMap emptyList()
-        // The road through the stops, then any ride off it, in the same colour.
-        val section = { stops: List<Stop>, accent: MapAccent, dashed: Boolean ->
-            listOf(MapRoute(entry.trip.id, path(stops), accent, dashed)) +
-                rides(stops).map { MapRoute(entry.trip.id, it, accent, dashed = false, ride = true) }
-        }
+        val first = located.firstOrNull() ?: return@flatMap emptyList()
+        val lead = leading(entry, first)
+        if (located.size < 2) return@flatMap lead
 
-        when (entry.trip.status) {
-            TripStatus.DONE -> section(located, MapAccent.DONE, false)
-            TripStatus.PLANNED -> section(located, MapAccent.PLANNED, true)
+        lead + when (entry.trip.status) {
+            TripStatus.DONE -> section(entry, located, MapAccent.DONE, false)
+            TripStatus.PLANNED -> section(entry, located, MapAccent.PLANNED, true)
             TripStatus.ACTIVE -> {
                 val done = located.filter { it.state == StopState.DONE }
                 val upcoming = located.filter { it.state == StopState.PLANNED }
                 buildList {
-                    if (done.size >= 2) addAll(section(done, MapAccent.DONE, false))
+                    if (done.size >= 2) addAll(section(entry, done, MapAccent.DONE, false))
                     if (done.isNotEmpty() && upcoming.isNotEmpty()) {
-                        addAll(section(listOf(done.last(), upcoming.first()), MapAccent.CURRENT, false))
+                        addAll(currentLeg(entry, done.last(), upcoming.first()))
                     }
-                    if (upcoming.size >= 2) addAll(section(upcoming, MapAccent.PLANNED, true))
+                    if (upcoming.size >= 2) addAll(section(entry, upcoming, MapAccent.PLANNED, true))
                 }
             }
         }
+    }
+
+    /** The road through [stops], then any ride off it, in the same colour. */
+    private fun section(entry: TripMapData, stops: List<Stop>, accent: MapAccent, dashed: Boolean): List<MapRoute> =
+        listOf(MapRoute(entry.trip.id, path(entry.stops, stops), accent, dashed)) + rides(entry, stops, accent)
+
+    /**
+     * The drive underway: the track so far, solid, and the rest of the planned road from
+     * the last fix, dashed — the planned road alone until there is a track.
+     */
+    private fun currentLeg(entry: TripMapData, from: Stop, to: Stop): List<MapRoute> {
+        val track = Tracks.drive(entry.stops, to)
+        if (track.isEmpty()) return section(entry, listOf(from, to), MapAccent.CURRENT, false)
+        return listOf(
+            MapRoute(entry.trip.id, listOf(from.location!!) + track, MapAccent.CURRENT, dashed = false),
+            MapRoute(entry.trip.id, Tracks.remainder(track, road(from, to).orEmpty(), to.location!!), MapAccent.CURRENT, dashed = true),
+        ) + rides(entry, listOf(from, to), MapAccent.CURRENT)
+    }
+
+    /**
+     * The drive to the trip's first stop, from its first fix: solid green with the rest
+     * dashed straight to the pin while it is still being driven, grey to the pin after.
+     */
+    private fun leading(entry: TripMapData, first: Stop): List<MapRoute> {
+        val track = Tracks.drive(entry.stops, first)
+        if (track.isEmpty()) return emptyList()
+        val pin = first.location!!
+        if (entry.trip.status == TripStatus.ACTIVE && first.state == StopState.PLANNED) {
+            return listOf(
+                MapRoute(entry.trip.id, track, MapAccent.CURRENT, dashed = false),
+                MapRoute(entry.trip.id, Tracks.remainder(track, emptyList(), pin), MapAccent.CURRENT, dashed = true),
+            )
+        }
+        return listOf(MapRoute(entry.trip.id, track + pin, MapAccent.DONE, dashed = false))
     }
 
     /**
      * The rides either side of each drive whose stop no road reaches, as lines of their
      * own: the road [path] ends where the vehicle is left, and the ride carries on to the pin.
      */
-    private fun rides(stops: List<Stop>): List<List<LatLng>> = stops.zipWithNext().flatMap { (from, to) ->
-        val leg = RouteCache.usable(from, to) ?: return@flatMap emptyList()
-        listOfNotNull(leg.rideBefore, leg.rideAfter)
-            .map { Polyline.decode(it.polyline) }
-            .filter { it.size >= 2 }
-    }
+    private fun rides(entry: TripMapData, stops: List<Stop>, accent: MapAccent): List<MapRoute> =
+        stops.zipWithNext().flatMap { (from, to) ->
+            val leg = RouteCache.usable(from, to) ?: return@flatMap emptyList()
+            listOfNotNull(leg.rideBefore, leg.rideAfter)
+                .map { Polyline.decode(it.polyline) }
+                .filter { it.size >= 2 }
+        }.map { MapRoute(entry.trip.id, it, accent, dashed = false, ride = true) }
 
     /**
-     * The line through [stops]: the road Google routed wherever there is a leg for it,
-     * and a straight hop between the two pins wherever there is not — no key, no signal,
-     * or a stop moved since the route was fetched.
+     * The line through [stops]: the way actually driven wherever a drive was tracked, the
+     * road Google routed wherever there is a leg for it, and a straight hop between the
+     * two pins wherever there is neither — no key, no signal, or a stop moved since the
+     * route was fetched. [all] is the whole trip, for the fixes of unpinned stops in between.
      */
-    private fun path(stops: List<Stop>): List<LatLng> {
+    private fun path(all: List<Stop>, stops: List<Stop>): List<LatLng> {
         val points = mutableListOf<LatLng>()
         stops.zipWithNext().forEach { (from, to) ->
-            val segment = segment(from, to)
+            val segment = segment(all, from, to)
             // Consecutive segments share the stop between them; a routed one starts at
             // the road, not the pin, so the join is only dropped when it really repeats.
             points += if (points.lastOrNull() == segment.firstOrNull()) segment.drop(1) else segment
@@ -131,10 +166,15 @@ object MapOverlay {
         return points
     }
 
-    private fun segment(from: Stop, to: Stop): List<LatLng> {
-        val road = RouteCache.usable(from, to)?.let { Polyline.decode(it.polyline) }
-        return if (road != null && road.size >= 2) road else listOfNotNull(from.location, to.location)
+    private fun segment(all: List<Stop>, from: Stop, to: Stop): List<LatLng> {
+        val track = Tracks.drive(all, to)
+        if (track.isNotEmpty()) return listOf(from.location!!) + track + to.location!!
+        return road(from, to) ?: listOfNotNull(from.location, to.location)
     }
+
+    /** The road Google routed for the drive, while it still describes it and has a line to draw. */
+    private fun road(from: Stop, to: Stop): List<LatLng>? =
+        RouteCache.usable(from, to)?.let { Polyline.decode(it.polyline) }?.takeIf { it.size >= 2 }
 
     /** Identical coordinates collapse, so a degenerate bounding box never reaches the map. */
     fun frame(points: List<LatLng>): MapFrame {

--- a/app/src/main/java/com/nuelto/etappli/domain/RouteTracker.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/RouteTracker.kt
@@ -1,0 +1,126 @@
+package com.nuelto.etappli.domain
+
+import com.nuelto.etappli.data.TripRepository
+import com.nuelto.etappli.data.model.LatLng
+import com.nuelto.etappli.data.model.Stop
+import com.nuelto.etappli.data.model.TripStatus
+import java.time.LocalDate
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * The stop an active trip is driving to: which trip, where the vehicle is actually driven
+ * to ([target], see Tracks.target), and whether the tour has started — before its start
+ * date the drive is not underway, so nothing is recorded and no service runs, though the
+ * distance still reads.
+ */
+data class Heading(val tripId: String, val stop: Stop, val target: LatLng?, val underway: Boolean)
+
+/**
+ * Follows the drive underway on the active trip: every GPS fix goes onto the track of the
+ * stop being headed for and, throttled by [LiveDrive], buys a route from there to it —
+ * what the NowCard and the tracking notification both show. One per app (AppContainer):
+ * the foreground service feeds it fixes in the background, the timeline feeds it one when
+ * it opens, and both read the same answer.
+ */
+class RouteTracker(
+    private val tripRepository: TripRepository,
+    private val drive: suspend (from: LatLng, to: LatLng) -> RoutedLeg? = { _, _ -> null },
+    private val today: () -> LocalDate = { LocalDate.now() },
+) {
+    data class State(
+        // How far the target is from the last fix; null until routed, and again once
+        // there. Only ever shown against the heading it was asked for: readers compare
+        // [DriveFromHere.to].
+        val drive: DriveFromHere? = null,
+        // The last fix handed in, recorded or not — changes with every fix, so the
+        // service can re-post.
+        val lastFix: LatLng? = null,
+        // The trip whose drive the background service is recording; null while it is not running.
+        val recordingTripId: String? = null,
+    )
+
+    private val _state = MutableStateFlow(State())
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    private val lock = Mutex()
+
+    // Where the last route was asked from and to, whatever came of it: a failed ask must
+    // not be repeated on every fix.
+    private var askedFrom: LatLng? = null
+    private var askedTo: LatLng? = null
+
+    // The stop already reached: what the phone does after that — the ride up from the
+    // parking spot, the run to the shop from the campsite — is not the drive.
+    private var arrivedFor: String? = null
+
+    /**
+     * Where the active trip is heading, re-evaluated as trips and stops change: null
+     * between check-in and check-out and with no active trip. Two active trips: the one
+     * started last.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun heading(): Flow<Heading?> = tripRepository.trips()
+        .map { trips -> trips.filter { it.status == TripStatus.ACTIVE }.maxByOrNull { it.startDate } }
+        // Totals and the region change under a trip without moving its heading.
+        .distinctUntilChanged { a, b -> a?.id == b?.id && a?.startDate == b?.startDate }
+        .flatMapLatest { trip ->
+            if (trip == null) return@flatMapLatest flowOf(null)
+            tripRepository.stops(trip.id).map { stops ->
+                CurrentStop.heading(stops, today())?.let {
+                    Heading(trip.id, it, Tracks.target(stops, it), underway = !today().isBefore(trip.startDate))
+                }
+            }
+        }
+
+    /**
+     * One fix from the phone. Onto the track (only while underway, and nothing from the
+     * arrival fix on), then how far the target still is. [tripId] from a screen keeps a fix off another
+     * active trip's drive; the service passes none. Serialized: the service and a screen
+     * can both deliver one.
+     */
+    suspend fun fix(point: LatLng, tripId: String? = null) {
+        lock.withLock {
+            val heading = heading().first()
+            if (heading == null) {
+                _state.update { it.copy(drive = null, lastFix = point) }
+                return
+            }
+            if (tripId != null && heading.tripId != tripId) return
+            val target = heading.target
+            if (target != null && LiveDrive.arrived(point, target)) arrivedFor = heading.stop.id
+            val arrived = arrivedFor == heading.stop.id
+            if (heading.underway && !arrived && Tracks.accepts(heading.stop.track, point)) {
+                tripRepository.appendTrack(heading.tripId, heading.stop.id, point)
+            }
+            _state.update { it.copy(lastFix = point) }
+            if (target == null || arrived) {
+                _state.update { it.copy(drive = null) }
+                return
+            }
+            if (!LiveDrive.needsFetch(askedFrom, askedTo, point, target)) return
+            askedFrom = point
+            askedTo = target
+            // A route that was due and did not come back leaves nothing behind: an answer
+            // from kilometres back would be wrong now.
+            val leg = drive(point, target)
+            _state.update { state ->
+                state.copy(drive = leg?.let { DriveFromHere(point, target, it.distanceMeters, it.durationSeconds) })
+            }
+        }
+    }
+
+    /** The service reports itself. */
+    fun recording(tripId: String?) = _state.update { it.copy(recordingTripId = tripId) }
+}

--- a/app/src/main/java/com/nuelto/etappli/domain/Tracks.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/Tracks.kt
@@ -1,0 +1,79 @@
+package com.nuelto.etappli.domain
+
+import com.nuelto.etappli.data.model.LatLng
+import com.nuelto.etappli.data.model.Stop
+import com.nuelto.etappli.data.model.StopState
+
+/**
+ * The way actually driven, as the fixes the phone took along it ([Stop.track]): which
+ * fixes are worth keeping, where a drive is really headed, how one drive's fixes read
+ * back together, and whose they are once the plan changes under them. [RouteTracker]
+ * records them; [MapOverlay] draws them.
+ */
+object Tracks {
+
+    /**
+     * How often the phone takes a fix while a drive is tracked. HIGH_ACCURACY at this
+     * cadence is deliberate: a road trace needs GPS, and two minutes keeps it duty-cycled.
+     */
+    const val FIX_INTERVAL_MS = 120_000L
+
+    /** A fix closer than this to the last one recorded is the same place — parked, at the lights, at lunch. */
+    const val MIN_MOVE_METERS = 30.0
+
+    fun accepts(track: List<LatLng>, fix: LatLng): Boolean {
+        val last = track.lastOrNull() ?: return true
+        return GeoUtils.haversineKm(last, fix) * 1000 >= MIN_MOVE_METERS
+    }
+
+    /**
+     * Where the vehicle is driven to for [stop]: its pin; where it is left for the ride up
+     * when no road reaches the stop (ParkAndRide); null when there is no way at all —
+     * nothing to route to or arrive at.
+     */
+    fun target(stops: List<Stop>, stop: Stop): LatLng? {
+        val previous = RouteCache.routed(stops).takeWhile { it.id != stop.id }.lastOrNull() ?: return stop.location
+        val leg = RouteCache.usable(previous, stop) ?: return stop.location
+        if (!leg.hasRoad) return null
+        return leg.rideAfter?.parked ?: stop.location
+    }
+
+    /**
+     * The way actually driven to [to]: its fixes, behind those of every stop with no pin
+     * since the previous routed one (the same drive, which the road skips). Empty below
+     * two points: one fix is a place, not a way.
+     */
+    fun drive(stops: List<Stop>, to: Stop): List<LatLng> {
+        val ordered = stops.sortedBy { it.orderIndex }
+        val before = ordered.take(ordered.indexOfFirst { it.id == to.id }.coerceAtLeast(0))
+        val points = before.takeLastWhile { it.state == StopState.SKIPPED || it.location == null }
+            .flatMap { it.track } + to.track
+        return if (points.size < 2) emptyList() else points
+    }
+
+    /**
+     * The rest of the planned road from the last fix: joins [road] at its nearest vertex
+     * and follows it to the end; straight to [end] with no road. Empty with no fix.
+     */
+    fun remainder(track: List<LatLng>, road: List<LatLng>, end: LatLng): List<LatLng> {
+        val last = track.lastOrNull() ?: return emptyList()
+        if (road.isEmpty()) return listOf(last, end)
+        val nearest = road.withIndex().minBy { (_, vertex) -> GeoUtils.haversineKm(last, vertex) }.index
+        return listOf(last) + road.drop(nearest)
+    }
+
+    /**
+     * Fixes belong to the drive underway, whichever stop it arrives at now: a stop added
+     * or dragged in front of the one being headed for takes them over, a skipped one hands
+     * them on, a restored one takes them back. Run by both repositories after every stop
+     * write, like DateCascade.settle. Returns the stops to rewrite, none when nothing strayed.
+     */
+    fun settle(stops: List<Stop>): List<Stop> {
+        val heading = CurrentStop.next(stops) ?: return emptyList()
+        val strays = stops.sortedBy { it.orderIndex }
+            .filter { it.state != StopState.DONE && it.id != heading.id && it.track.isNotEmpty() }
+        if (strays.isEmpty()) return emptyList()
+        return listOf(heading.copy(track = heading.track + strays.flatMap { it.track })) +
+            strays.map { it.copy(track = emptyList()) }
+    }
+}

--- a/app/src/main/java/com/nuelto/etappli/domain/TripStarter.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/TripStarter.kt
@@ -108,6 +108,7 @@ object TripStarter {
                     tripId = newId,
                     state = StopState.PLANNED,
                     arrivalDate = it.arrivalDate.plusDays(shift),
+                    track = emptyList(),
                 )
             },
         )

--- a/app/src/main/java/com/nuelto/etappli/location/LocationProvider.kt
+++ b/app/src/main/java/com/nuelto/etappli/location/LocationProvider.kt
@@ -10,8 +10,8 @@ import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withTimeoutOrNull
 
 /**
- * One-shot GPS fix for "use current position" — the app never tracks continuously.
- * Caller is responsible for holding ACCESS_FINE_LOCATION before calling.
+ * One-shot GPS fix for "use current position"; the fixes of a tracked drive come from
+ * [TrackingService]. Caller is responsible for holding ACCESS_FINE_LOCATION before calling.
  */
 class LocationProvider(private val context: Context) {
 

--- a/app/src/main/java/com/nuelto/etappli/location/TrackingService.kt
+++ b/app/src/main/java/com/nuelto/etappli/location/TrackingService.kt
@@ -1,0 +1,157 @@
+package com.nuelto.etappli.location
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.app.Notification
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.pm.ServiceInfo
+import android.os.IBinder
+import android.os.Looper
+import androidx.core.app.NotificationChannelCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.ServiceCompat
+import androidx.core.content.ContextCompat
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationResult
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import com.nuelto.etappli.CamperApp
+import com.nuelto.etappli.MainActivity
+import com.nuelto.etappli.R
+import com.nuelto.etappli.data.model.LatLng
+import com.nuelto.etappli.domain.DriveFromHere
+import com.nuelto.etappli.domain.Heading
+import com.nuelto.etappli.domain.RouteTracker
+import com.nuelto.etappli.domain.Tracks
+import com.nuelto.etappli.ui.formatTrackingText
+import com.nuelto.etappli.ui.formatTrackingTitle
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+
+/**
+ * Records the drive underway: a GPS fix every [Tracks.FIX_INTERVAL_MS] into the
+ * container's [RouteTracker], under an ongoing notification that says how far the stop
+ * you are heading for still is. Started while the app is open (MainActivity's
+ * TrackingTrigger, the NowCard) — Android 12+ refuses a location service started from
+ * the background, and so does this one: no background-location permission, no
+ * WorkManager, no boot receiver, not sticky. Stops itself once nothing is underway.
+ */
+class TrackingService : Service() {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val tracker: RouteTracker get() = (application as CamperApp).container.tracker
+    private val client by lazy { LocationServices.getFusedLocationProviderClient(this) }
+    private var started = false
+    // What the notification shows now: a start landing on a running service must not blank it.
+    private var shown: Notification? = null
+
+    private val callback = object : LocationCallback() {
+        override fun onLocationResult(result: LocationResult) {
+            // One coroutine per batch keeps the fixes in the order they were taken.
+            scope.launch { result.locations.forEach { runCatching { tracker.fix(LatLng(it.latitude, it.longitude)) } } }
+        }
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        NotificationManagerCompat.from(this).createNotificationChannel(
+            NotificationChannelCompat.Builder(CHANNEL, NotificationManagerCompat.IMPORTANCE_LOW)
+                .setName("Trip tracking")
+                .build(),
+        )
+    }
+
+    @SuppressLint("MissingPermission") // start() checks it.
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val foreground = runCatching {
+            ServiceCompat.startForeground(this, ID, shown ?: notification(null, null), ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION)
+        }
+        if (intent == null || foreground.isFailure) {
+            stopSelf()
+            return START_NOT_STICKY
+        }
+        if (!started) {
+            started = true
+            client.requestLocationUpdates(
+                LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, Tracks.FIX_INTERVAL_MS)
+                    .setMinUpdateIntervalMillis(Tracks.FIX_INTERVAL_MS / 2)
+                    .setMinUpdateDistanceMeters(Tracks.MIN_MOVE_METERS.toFloat())
+                    .build(),
+                callback,
+                Looper.getMainLooper(),
+            )
+            scope.launch {
+                runCatching {
+                    combine(tracker.heading(), tracker.state) { heading, state -> heading to state }
+                        .collect { (heading, state) ->
+                            if (heading == null || !heading.underway) {
+                                stopSelf()
+                            } else {
+                                tracker.recording(heading.tripId)
+                                notify(heading, state.drive?.takeIf { it.to == heading.target })
+                            }
+                        }
+                }.onFailure { if (it !is CancellationException) stopSelf() } // signing out makes the repository throw
+            }
+        }
+        return START_NOT_STICKY
+    }
+
+    override fun onDestroy() {
+        client.removeLocationUpdates(callback)
+        scope.cancel()
+        tracker.recording(null)
+        super.onDestroy()
+    }
+
+    /** Re-posted on every state emission: each fix changes lastFix, so the text is at most one fix old. */
+    private fun notify(heading: Heading, drive: DriveFromHere?) {
+        val notification = notification(heading, drive).also { shown = it }
+        runCatching { NotificationManagerCompat.from(this).notify(ID, notification) }
+    }
+
+    private fun notification(heading: Heading?, drive: DriveFromHere?): Notification {
+        val open = PendingIntent.getActivity(
+            this, 0, Intent(this, MainActivity::class.java),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+        return NotificationCompat.Builder(this, CHANNEL)
+            .setSmallIcon(R.drawable.ic_tracking)
+            .setContentTitle(heading?.let { formatTrackingTitle(it.stop.name) } ?: "Trip tracking")
+            .setContentText(formatTrackingText(drive))
+            .setOngoing(true)
+            .setSilent(true)
+            .setOnlyAlertOnce(true)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+            .setContentIntent(open)
+            .build()
+    }
+
+    companion object {
+        private const val ID = 1
+        private const val CHANNEL = "tracking"
+
+        /**
+         * Starts tracking if precise location is granted — the product gate: a coarse-only
+         * grant gives a 2 km grid, no track. Failing to start (the app is in the background
+         * on 12+) is silent; the next foreground asks again.
+         */
+        fun start(context: Context) {
+            if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) return
+            runCatching { ContextCompat.startForegroundService(context, Intent(context, TrackingService::class.java)) }
+        }
+    }
+}

--- a/app/src/main/java/com/nuelto/etappli/ui/Format.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/Format.kt
@@ -5,6 +5,7 @@ import com.nuelto.etappli.data.model.TransitRide
 import com.nuelto.etappli.data.model.TravelMode
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
+import com.nuelto.etappli.domain.DriveFromHere
 import java.text.NumberFormat
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -98,3 +99,13 @@ fun formatArrival(durationSeconds: Int, now: LocalDateTime): String {
 fun formatDriveFromHere(distanceMeters: Int, durationSeconds: Int, now: LocalDateTime): String =
     "${formatDistance(distanceMeters)} · ${formatDuration(durationSeconds)} from here · " +
         formatArrival(durationSeconds, now)
+
+/**
+ * The tracking notification: where you are heading, and how far it still is once a route
+ * has come back — no arrival clock, which would drift between posts.
+ */
+fun formatTrackingTitle(stopName: String): String = "Heading for $stopName"
+
+fun formatTrackingText(drive: DriveFromHere?): String =
+    drive?.let { "${formatDistance(it.distanceMeters)} · ${formatDuration(it.durationSeconds)}" }
+        ?: "Recording the way as you go"

--- a/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreen.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreen.kt
@@ -8,6 +8,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.compose.rememberLauncherForActivityResult
 import android.content.pm.PackageManager
 import android.Manifest
+import android.os.Build
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.border
@@ -200,9 +201,19 @@ fun TripDetailScreen(
         }
     }
 
-    // "How far from here" needs a fix. Asked for on tap rather than on open: a permission
+    // Tracking the drive needs a fix. Asked for on tap rather than on open: a permission
     // dialog the moment a trip is opened is not a trade the user agreed to.
     val locationContext = LocalContext.current
+    // One expression on one line: Robolectric runs sdk 35, and an if/else would leave the
+    // other branch's line uncovered.
+    var notificationsGranted by remember { mutableStateOf(Build.VERSION.SDK_INT < 33 || ContextCompat.checkSelfPermission(locationContext, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) }
+    val notificationPermission = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted -> notificationsGranted = granted }
+    // The ongoing notification is what makes tracking visible; the service records without it.
+    fun askNotifications() {
+        if (Build.VERSION.SDK_INT >= 33 && !notificationsGranted) notificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
+    }
     var locationGranted by remember {
         mutableStateOf(
             ContextCompat.checkSelfPermission(
@@ -211,9 +222,23 @@ fun TripDetailScreen(
             ) == PackageManager.PERMISSION_GRANTED,
         )
     }
+    // Coarse alone is a 2 km grid, no track: the card then says what is missing.
+    var coarseOnly by remember {
+        mutableStateOf(
+            !locationGranted && ContextCompat.checkSelfPermission(
+                locationContext,
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+            ) == PackageManager.PERMISSION_GRANTED,
+        )
+    }
+    // Both at once — a fine-only request is ignored on some Android 12 builds.
     val locationPermission = rememberLauncherForActivityResult(
-        ActivityResultContracts.RequestPermission(),
-    ) { granted -> locationGranted = granted }
+        ActivityResultContracts.RequestMultiplePermissions(),
+    ) { result ->
+        locationGranted = result[Manifest.permission.ACCESS_FINE_LOCATION] == true
+        coarseOnly = !locationGranted && result[Manifest.permission.ACCESS_COARSE_LOCATION] == true
+        if (locationGranted) askNotifications()
+    }
     // Keyed on the grant too, so answering the dialog is what triggers the first fix —
     // the launcher callback only has to record it.
     LaunchedEffect(state.currentStopId, locationGranted) {
@@ -432,11 +457,18 @@ fun TripDetailScreen(
                             stop = row.stop,
                             leg = state.drives[row.stop.id],
                             fromHere = state.driveFromHere,
+                            tracking = state.tracking,
+                            preciseNeeded = coarseOnly,
                             onLocate = if (locationGranted) {
                                 null
                             } else {
-                                { locationPermission.launch(Manifest.permission.ACCESS_FINE_LOCATION) }
+                                {
+                                    locationPermission.launch(
+                                        arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION),
+                                    )
+                                }
                             },
+                            onNotify = if (state.tracking && !notificationsGranted) ::askNotifications else null,
                             settings = state.settings,
                             onClick = { onEditStop(trip.id, row.stop.id) },
                             onChangeNights = { delta -> viewModel.changeNights(row.stop.id, delta) },
@@ -587,8 +619,14 @@ private fun NowCard(
     stop: Stop,
     leg: StopLeg?,
     fromHere: DriveFromHere?,
+    // The background service is recording this drive.
+    tracking: Boolean,
+    // Only coarse location was granted, which gives no track.
+    preciseNeeded: Boolean,
     // Null once the location permission is held; otherwise, what to call to ask for it.
     onLocate: (() -> Unit)?,
+    // Asks to show the tracking as a notification; null once it may, or with nothing tracked.
+    onNotify: (() -> Unit)?,
     settings: UserSettings,
     onClick: () -> Unit,
     onChangeNights: (Int) -> Unit,
@@ -608,14 +646,15 @@ private fun NowCard(
                 fontWeight = FontWeight.Bold,
             )
             // Where you are beats where you came from: on the stop you are driving to, the
-            // live distance replaces the planned leg rather than sitting beside it.
+            // live distance replaces the planned leg rather than sitting beside it. The
+            // ViewModel has already matched [fromHere] to this stop's target.
             when {
-                fromHere != null && fromHere.to == stop.location -> Text(
+                fromHere != null -> Text(
                     // "now" is read at composition: opening the trip gives a current
                     // answer, and every state change refreshes it. It does not tick on
                     // its own — an endless timer in a LaunchedEffect would leave the
                     // Compose test clock permanently busy.
-                    formatDriveFromHere(
+                    (if (tracking) "Tracking · " else "") + formatDriveFromHere(
                         fromHere.distanceMeters,
                         fromHere.durationSeconds,
                         LocalDateTime.now(),
@@ -623,13 +662,27 @@ private fun NowCard(
                     style = MaterialTheme.typography.labelSmall,
                     color = ActiveGreen,
                 )
+                // Says what the permission buys: the track, not just a number.
                 onLocate != null && stop.location != null && stop.state != StopState.DONE -> Text(
-                    "Show distance from here",
+                    if (preciseNeeded) "Precise location needed to track" else "Track this drive",
                     style = MaterialTheme.typography.labelSmall,
                     color = ActiveGreen,
                     modifier = Modifier.clickable(onClick = onLocate),
                 )
+                tracking -> Text(
+                    "Tracking this drive",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = ActiveGreen,
+                )
                 else -> DriveLine(leg)
+            }
+            if (onNotify != null) {
+                Text(
+                    "Show tracking as a notification",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = ActiveGreen,
+                    modifier = Modifier.clickable(onClick = onNotify),
+                )
             }
             Row(
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailViewModel.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailViewModel.kt
@@ -11,8 +11,6 @@ import com.nuelto.etappli.data.SettingsRepository
 import com.nuelto.etappli.data.TripRepository
 import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.domain.DriveFromHere
-import com.nuelto.etappli.domain.LiveDrive
-import com.nuelto.etappli.domain.RoutedLeg
 import com.nuelto.etappli.data.model.Expense
 import com.nuelto.etappli.data.model.ExpenseType
 import com.nuelto.etappli.data.model.Stop
@@ -33,8 +31,10 @@ import com.nuelto.etappli.domain.PlaceCacheSweeper
 import com.nuelto.etappli.domain.RegionResolver
 import com.nuelto.etappli.domain.RouteCache
 import com.nuelto.etappli.domain.RouteRefresher
+import com.nuelto.etappli.domain.RouteTracker
 import com.nuelto.etappli.domain.Timeline
 import com.nuelto.etappli.domain.TimelineRow
+import com.nuelto.etappli.domain.Tracks
 import com.nuelto.etappli.domain.TripEstimator
 import com.nuelto.etappli.domain.TripStarter
 import com.nuelto.etappli.domain.VignetteTable
@@ -42,7 +42,6 @@ import com.nuelto.etappli.location.PlaceNameResolver
 import com.nuelto.etappli.ui.nav.TripDetailRoute
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -73,6 +72,8 @@ data class TripDetailUiState(
     // Live distance to the stop you are heading for, from the last GPS fix. Null until
     // one is taken, and again once you are there.
     val driveFromHere: DriveFromHere? = null,
+    // The background service is recording this trip's drive.
+    val tracking: Boolean = false,
     val vignetteSuggestions: List<VignetteTable.Choice> = emptyList(),
     val settings: UserSettings = UserSettings(),
     val loading: Boolean = true,
@@ -93,8 +94,11 @@ class TripDetailViewModel(
     private val regionResolver: RegionResolver? = null,
     // One-shot GPS fix; null unless the screen has the location permission.
     private val currentLocation: suspend () -> LatLng? = { null },
-    // A single route, for "how far is it from here". Never stored — see DriveFromHere.
-    private val drive: suspend (from: LatLng, to: LatLng) -> RoutedLeg? = { _, _ -> null },
+    // Where the active trip is heading and how far that still is. Shared with the
+    // tracking service, which keeps feeding it fixes once this screen is gone.
+    private val tracker: RouteTracker = RouteTracker(tripRepository),
+    // Starts the tracking service; a no-op without the platform.
+    private val startTracking: () -> Unit = {},
 ) : ViewModel() {
 
     private val tripId: String = savedStateHandle.toRoute<TripDetailRoute>().tripId
@@ -125,16 +129,14 @@ class TripDetailViewModel(
         }
     }
 
-    private val liveDrive = MutableStateFlow<DriveFromHere?>(null)
-
     val uiState: StateFlow<TripDetailUiState> =
         combine(
             tripRepository.trip(tripId),
             tripRepository.stops(tripId),
             tripRepository.expenses(tripId),
             settingsRepository.settings(),
-            liveDrive,
-        ) { trip, stops, expenses, settings, fromHere ->
+            tracker.state,
+        ) { trip, stops, expenses, settings, tracking ->
             val planning = trip != null && trip.status != TripStatus.DONE
             val currentId = if (trip?.status == TripStatus.ACTIVE) {
                 CurrentStop.of(stops, LocalDate.now())
@@ -142,6 +144,7 @@ class TripDetailViewModel(
                 null
             }
             val current = stops.find { it.id == currentId }
+            val heading = current != null && current.state == StopState.PLANNED
             TripDetailUiState(
                 trip = trip,
                 stops = stops,
@@ -153,8 +156,10 @@ class TripDetailViewModel(
                 currentStopId = currentId,
                 drives = RouteCache.byStop(stops),
                 // Once you have checked in you are there, so how far away it is stops
-                // being a question — whatever the last fix said.
-                driveFromHere = fromHere?.takeIf { current?.state != StopState.DONE },
+                // being a question — whatever the last fix said. Matched on the target,
+                // which may be the parking spot of a ride rather than the pin.
+                driveFromHere = tracking.drive?.takeIf { heading && it.to == Tracks.target(stops, current!!) },
+                tracking = heading && tracking.recordingTripId == tripId,
                 vignetteSuggestions = if (planning) vignetteSuggestions(stops, expenses) else emptyList(),
                 settings = settings,
                 loading = false,
@@ -165,31 +170,26 @@ class TripDetailViewModel(
     private var locating = false
 
     /**
-     * Takes a GPS fix and asks Google how far the stop you are heading for is from it.
-     * Silent about every failure — no permission, no fix, no signal — because the card
-     * simply falls back to the planned drive.
+     * Takes a GPS fix and hands it to the tracker, which asks Google how far the stop you
+     * are heading for is from it. Silent about every failure — no permission, no fix, no
+     * signal — because the card simply falls back to the planned drive.
      */
     fun refreshDriveFromHere() {
         val state = uiState.value
+        val trip = state.trip ?: return
         val stop = state.stops.find { it.id == state.currentStopId } ?: return
         // No route is worth buying for somewhere you have already arrived.
         if (stop.state == StopState.DONE) return
-        val target = stop.location ?: return
         if (locating) return
+        // The permission just landed or the trip just opened. The service is what keeps
+        // going once the screen is gone: it checks the permission itself and stops when
+        // nothing is underway — but is not asked before the tour's day, or its notification
+        // would flash on every open of a tour started ahead of its date.
+        if (!LocalDate.now().isBefore(trip.startDate)) startTracking()
         locating = true
         viewModelScope.launch {
             try {
-                val here = currentLocation() ?: return@launch
-                if (LiveDrive.arrived(here, target)) {
-                    liveDrive.value = null
-                    return@launch
-                }
-                // Drop an answer to a different question before asking the new one, or a
-                // failed fetch would leave the old stop's distance on screen.
-                if (liveDrive.value?.to != target) liveDrive.value = null
-                if (!LiveDrive.needsFetch(liveDrive.value, here, target)) return@launch
-                val leg = drive(here, target) ?: return@launch
-                liveDrive.value = DriveFromHere(here, target, leg.distanceMeters, leg.durationSeconds)
+                currentLocation()?.let { tracker.fix(it, tripId) }
             } finally {
                 locating = false
             }
@@ -409,7 +409,8 @@ class TripDetailViewModel(
                     RegionResolver(container.tripRepository, PlaceNameResolver(it)::region)
                 },
                 container.currentLocation,
-                container.mapProvider::drive,
+                container.tracker,
+                container.startTracking,
             )
         }
     }

--- a/app/src/main/res/drawable/ic_tracking.xml
+++ b/app/src/main/res/drawable/ic_tracking.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Notification small icon: white on transparent, the system tints it. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M21,3L3,10.53v0.98l6.84,2.65L12.48,21h0.98L21,3z" />
+</vector>

--- a/app/src/test/java/com/nuelto/etappli/AppWiringTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/AppWiringTest.kt
@@ -8,11 +8,21 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.nuelto.etappli.data.AuthUser
 import com.nuelto.etappli.data.InMemorySettingsRepository
 import com.nuelto.etappli.data.InMemoryTripRepository
+import com.nuelto.etappli.data.TripRepository
 import com.nuelto.etappli.data.model.LatLng
+import com.nuelto.etappli.data.model.Stop
+import com.nuelto.etappli.data.model.StopState
+import com.nuelto.etappli.data.model.Trip
+import com.nuelto.etappli.data.model.TripStatus
 import com.nuelto.etappli.domain.SharedPlace
 import com.nuelto.etappli.testutil.FakeAuthRepository
 import com.nuelto.etappli.testutil.TestCamperApp
+import java.time.LocalDate
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -105,5 +115,66 @@ class AppRootTest {
         compose.onNodeWithText("Trips").assertIsDisplayed()
         auth.signOut()
         compose.onNodeWithText("Sign in with Google").assertIsDisplayed()
+    }
+
+    // --- tracking trigger ----------------------------------------------------------------
+
+    private val today = LocalDate.now()
+
+    /** A trip of [status] started on [start], its first stop in [first]. */
+    private fun tour(
+        status: TripStatus = TripStatus.ACTIVE,
+        start: LocalDate = today,
+        first: StopState = StopState.PLANNED,
+    ) = InMemoryTripRepository(seed = false).apply {
+        runBlocking {
+            upsertTrip(Trip(id = "t1", name = "Tour", startDate = start, status = status))
+            upsertStop(
+                Stop(
+                    id = "s1", tripId = "t1", name = "A", nights = 2, orderIndex = 0,
+                    location = LatLng(46.0, 8.0), arrivalDate = start, state = first,
+                ),
+            )
+            upsertStop(
+                Stop(
+                    id = "s2", tripId = "t1", name = "B", nights = 1, orderIndex = 1,
+                    location = LatLng(46.5, 8.5), arrivalDate = start.plusDays(2),
+                ),
+            )
+        }
+    }
+
+    private fun assertStarts(expected: Int, repository: TripRepository, auth: FakeAuthRepository? = null) {
+        var starts = 0
+        compose.setContent {
+            AppRoot(AppContainer(auth, repository, InMemorySettingsRepository(), startTracking = { starts++ }))
+        }
+        compose.waitForIdle()
+        assertEquals(expected, starts)
+    }
+
+    @Test
+    fun `an open app with a drive underway starts tracking`() = assertStarts(1, tour())
+
+    @Test
+    fun `signed in, firebase mode starts tracking too`() =
+        assertStarts(1, tour(), FakeAuthRepository(AuthUser("u1")))
+
+    @Test
+    fun `mid-stay nothing starts`() = assertStarts(0, tour(first = StopState.DONE))
+
+    @Test
+    fun `before the start date nothing starts`() = assertStarts(0, tour(start = today.plusDays(1)))
+
+    @Test
+    fun `without an active trip nothing starts`() = assertStarts(0, tour(status = TripStatus.PLANNED))
+
+    @Test
+    fun `a plan that cannot be read starts nothing`() {
+        // What the Firestore repositories do without a user; the list screen never asks this.
+        val unreadable = object : TripRepository by tour() {
+            override fun stops(tripId: String): Flow<List<Stop>> = flow { throw IllegalStateException("no user") }
+        }
+        assertStarts(0, unreadable)
     }
 }

--- a/app/src/test/java/com/nuelto/etappli/data/InMemoryTripRepositoryTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/data/InMemoryTripRepositoryTest.kt
@@ -276,6 +276,81 @@ class InMemoryTripRepositoryTest {
     }
 
 
+    private suspend fun stop(tripId: String, id: String) = repo.stops(tripId).first().single { it.id == id }
+
+    @Test
+    fun `append track adds fixes in order and drops a point already on the track`() = runTest {
+        val id = addTrip()
+        repo.upsertStop(Stop(id = "s1", tripId = id, nights = 2, campingCostTotal = 50.0))
+        val a = LatLng(46.0, 7.0)
+        val b = LatLng(46.1, 7.1)
+        repo.appendTrack(id, "s1", a)
+        repo.appendTrack(id, "s1", b)
+        repo.appendTrack(id, "s1", b)
+        // Like Firestore's arrayUnion: a point present anywhere is not added again.
+        repo.appendTrack(id, "s1", a)
+        assertEquals(listOf(a, b), stop(id, "s1").track)
+        // An unknown stop, or the right stop on the wrong trip, is a no-op.
+        repo.appendTrack(id, "nope", a)
+        repo.appendTrack("other", "s1", b)
+        assertEquals(listOf("s1"), repo.stops(id).first().map { it.id })
+        assertEquals(listOf(a, b), stop(id, "s1").track)
+        assertEquals(50.0, repo.trip(id).first()!!.totalCost, 1e-9)
+        assertEquals(2, repo.trip(id).first()!!.nights)
+    }
+
+    @Test
+    fun `fixes follow the drive underway when the plan changes`() = runTest {
+        val start = LocalDate.of(2026, 9, 4)
+        val id = repo.upsertTrip(Trip(id = "tour", name = "Tour", startDate = start, status = TripStatus.ACTIVE))
+        repo.upsertStop(Stop(id = "a", tripId = id, orderIndex = 0, arrivalDate = start, state = StopState.DONE, nights = 0))
+        repo.upsertStop(Stop(id = "b", tripId = id, orderIndex = 1, arrivalDate = start))
+        repo.upsertStop(Stop(id = "c", tripId = id, orderIndex = 2, arrivalDate = start.plusDays(1)))
+        val fixes = listOf(LatLng(46.0, 7.0), LatLng(46.1, 7.1))
+        fixes.forEach { repo.appendTrack(id, "b", it) }
+        assertEquals(fixes, stop(id, "b").track)
+
+        // A stop inserted in front of the heading takes the fixes over.
+        repo.upsertStops(
+            listOf(
+                Stop(id = "n", tripId = id, orderIndex = 1, arrivalDate = start),
+                stop(id, "b").copy(orderIndex = 2),
+                stop(id, "c").copy(orderIndex = 3),
+            ),
+        )
+        assertEquals(fixes, stop(id, "n").track)
+        assertTrue(stop(id, "b").track.isEmpty())
+
+        // Dragged back in front, it takes them back.
+        repo.upsertStops(listOf(stop(id, "b").copy(orderIndex = 1), stop(id, "n").copy(orderIndex = 2)))
+        assertEquals(fixes, stop(id, "b").track)
+        assertTrue(stop(id, "n").track.isEmpty())
+
+        // Skipped, it hands them on; restored, it takes them back.
+        repo.upsertStop(stop(id, "b").copy(state = StopState.SKIPPED))
+        assertEquals(fixes, stop(id, "n").track)
+        assertTrue(stop(id, "b").track.isEmpty())
+        repo.upsertStop(stop(id, "b").copy(state = StopState.PLANNED))
+        assertEquals(fixes, stop(id, "b").track)
+        assertTrue(stop(id, "n").track.isEmpty())
+    }
+
+    @Test
+    fun `deleting the checked-in stop hands the fixes to the stop now heading`() = runTest {
+        val start = LocalDate.of(2026, 9, 4)
+        val id = repo.upsertTrip(Trip(id = "tour", name = "Tour", startDate = start, status = TripStatus.ACTIVE))
+        // Restored behind the check-in line, the checked-in stop, and the heading with fixes.
+        repo.upsertStop(Stop(id = "r", tripId = id, orderIndex = 0, arrivalDate = start))
+        repo.upsertStop(Stop(id = "d", tripId = id, orderIndex = 1, arrivalDate = start, state = StopState.DONE, nights = 0))
+        repo.upsertStop(Stop(id = "h", tripId = id, orderIndex = 2, arrivalDate = start.plusDays(1)))
+        val fixes = listOf(LatLng(46.0, 7.0), LatLng(46.1, 7.1))
+        fixes.forEach { repo.appendTrack(id, "h", it) }
+
+        repo.deleteStop(id, "d")
+        assertEquals(fixes, stop(id, "r").track)
+        assertTrue(stop(id, "h").track.isEmpty())
+    }
+
     @Test
     fun `a plan starts the day its first stop does`() = runTest {
         val start = LocalDate.of(2026, 9, 2)

--- a/app/src/test/java/com/nuelto/etappli/domain/CurrentStopTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/CurrentStopTest.kt
@@ -64,4 +64,34 @@ class CurrentStopTest {
         val first = stop("first", 1, arrival = today.plusDays(1))
         assertEquals("first", CurrentStop.of(listOf(home, first), today))
     }
+
+    @Test
+    fun `next is the first planned stop past the check-in line, whatever the date says`() {
+        val here = stop("here", 0, StopState.DONE, arrival = today.minusDays(1), nights = 2)
+        assertEquals("next", CurrentStop.next(listOf(stop("later", 2), stop("next", 1), here))!!.id)
+        assertEquals("restored", CurrentStop.next(listOf(stop("restored", 0), here.copy(orderIndex = 1)))!!.id)
+        assertNull(CurrentStop.next(listOf(here, stop("skipped", 1, StopState.SKIPPED))))
+        assertNull(CurrentStop.next(emptyList()))
+    }
+
+    @Test
+    fun `heading is the next stop unless you are mid-stay`() {
+        val stops = listOf(stop("here", 0, StopState.DONE, arrival = today.minusDays(1), nights = 2), stop("next", 1))
+        assertNull(CurrentStop.heading(stops, today))
+        assertEquals("next", CurrentStop.heading(stops, today.plusDays(1))!!.id)
+        // Nothing planned: nowhere to head for, mid-stay or not.
+        assertNull(CurrentStop.heading(stops.take(1), today.plusDays(5)))
+        // A zero-night check-in never holds the heading.
+        val visited = stop("visited", 0, StopState.DONE, nights = 0)
+        assertEquals("next", CurrentStop.heading(listOf(visited, stop("next", 1)), today)!!.id)
+    }
+
+    @Test
+    fun `shortening the stay with the stepper is the check-out`() {
+        val here = stop("here", 0, StopState.DONE, arrival = today.minusDays(1), nights = 3)
+        assertNull(CurrentStop.heading(listOf(here, stop("next", 1)), today))
+        val shortened = listOf(here.copy(nights = 1), stop("next", 1))
+        assertEquals("next", CurrentStop.heading(shortened, today)!!.id)
+        assertEquals("next", CurrentStop.of(shortened, today))
+    }
 }

--- a/app/src/test/java/com/nuelto/etappli/domain/LiveDriveTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/LiveDriveTest.kt
@@ -31,28 +31,30 @@ class LiveDriveTest {
     }
 
     @Test
-    fun `nothing held means fetch`() {
-        assertTrue(LiveDrive.needsFetch(null, here, there))
+    fun `nothing asked yet means fetch`() {
+        assertTrue(LiveDrive.needsFetch(null, null, here, there))
     }
 
     @Test
     fun `a different destination is fetched however little you moved`() {
         val held = drive(here, there)
         // One metre from the recorded fix, but heading somewhere else now.
-        assertTrue(LiveDrive.needsFetch(held, north(here, 1.0), LatLng(47.0, 8.0)))
+        assertTrue(LiveDrive.needsFetch(held.from, held.to, north(here, 1.0), LatLng(47.0, 8.0)))
     }
 
     @Test
-    fun `staying put does not spend a route`() {
+    fun `staying put does not spend a route, whatever the last ask came back with`() {
         val held = drive(here, there)
-        assertFalse(LiveDrive.needsFetch(held, here, there))
-        assertFalse(LiveDrive.needsFetch(held, north(here, 1_999.0), there))
+        assertFalse(LiveDrive.needsFetch(held.from, held.to, here, there))
+        assertFalse(LiveDrive.needsFetch(held.from, held.to, north(here, 1_999.0), there))
+        // Keyed on the ask, not the answer: a failed one is not repeated on every fix.
+        assertFalse(LiveDrive.needsFetch(here, there, north(here, 1_999.0), there))
     }
 
     @Test
     fun `moving the refresh distance fetches again`() {
         val held = drive(here, there)
-        assertTrue(LiveDrive.needsFetch(held, north(here, 2_001.0), there))
+        assertTrue(LiveDrive.needsFetch(held.from, held.to, north(here, 2_001.0), there))
         assertEquals(2_000.0, LiveDrive.REFRESH_AFTER_METERS, 1e-9)
     }
 }

--- a/app/src/test/java/com/nuelto/etappli/domain/MapOverlayTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/MapOverlayTest.kt
@@ -308,4 +308,84 @@ class MapOverlayTest {
         assertEquals(Polyline.decode(current), routes[1].points)
         assertEquals(Polyline.decode(ahead), routes[2].points)
     }
+
+    // --- routes: the way actually driven --------------------------------------
+
+    private val fixes = listOf(LatLng(46.3, 7.2), LatLng(46.6, 7.7))
+
+    @Test
+    fun `a tracked drive is drawn from its fixes with the pins at both ends`() {
+        val a = stop("a", 0, state = StopState.DONE)
+        val b = stop("b", 1, state = StopState.DONE).road(a, roadAB).copy(track = fixes)
+        val points = MapOverlay.routes(data(TripStatus.DONE, listOf(a, b))).single().points
+        assertEquals(listOf(a.location!!) + fixes + b.location!!, points)
+    }
+
+    @Test
+    fun `one fix keeps the road`() {
+        val a = stop("a", 0)
+        val b = stop("b", 1).road(a, roadAB).copy(track = fixes.take(1))
+        assertEquals(Polyline.decode(roadAB), MapOverlay.routes(data(TripStatus.DONE, listOf(a, b))).single().points)
+    }
+
+    @Test
+    fun `the drive to the first stop leads in from its first fix`() {
+        val first = stop("a", 0).copy(track = fixes)
+        val next = stop("b", 1)
+        // Underway: the fixes solid green, then dashed green straight on to the pin.
+        val routes = MapOverlay.routes(data(TripStatus.ACTIVE, listOf(first, next)))
+        assertEquals(listOf(MapAccent.CURRENT, MapAccent.CURRENT, MapAccent.PLANNED), routes.map { it.accent })
+        assertEquals(listOf(false, true, true), routes.map { it.dashed })
+        assertEquals(fixes, routes[0].points)
+        assertEquals(listOf(fixes.last(), first.location), routes[1].points)
+        // Drawn even while it is the only stop on the map.
+        assertEquals(routes.take(2), MapOverlay.routes(data(TripStatus.ACTIVE, listOf(first))))
+        // Once checked in it is grey, to the pin.
+        val arrived = first.copy(state = StopState.DONE)
+        val checkedIn = MapOverlay.routes(data(TripStatus.ACTIVE, listOf(arrived, next)))
+        assertEquals(listOf(MapAccent.DONE, MapAccent.CURRENT), checkedIn.map { it.accent })
+        assertEquals(fixes + arrived.location!!, checkedIn[0].points)
+        assertFalse(checkedIn[0].dashed)
+        val finished = MapOverlay.routes(data(TripStatus.DONE, listOf(arrived, next.copy(state = StopState.DONE))))
+        assertEquals(fixes + arrived.location!!, finished[0].points)
+        assertEquals(MapAccent.DONE, finished[0].accent)
+        // A lone fix leads nowhere.
+        assertTrue(MapOverlay.routes(data(TripStatus.ACTIVE, listOf(first.copy(track = fixes.take(1))))).isEmpty())
+    }
+
+    @Test
+    fun `an unlocated stop's fixes fold into the next drive`() {
+        val a = stop("a", 0, state = StopState.DONE)
+        val nowhere = stop("x", 1, location = null, state = StopState.DONE).copy(track = fixes.take(1))
+        val b = stop("b", 2, state = StopState.DONE).copy(track = fixes.drop(1))
+        val points = MapOverlay.routes(data(TripStatus.DONE, listOf(a, nowhere, b))).single().points
+        assertEquals(listOf(a.location!!) + fixes + b.location!!, points)
+    }
+
+    @Test
+    fun `the drive underway is the track so far and the rest of the road, dashed`() {
+        val a = stop("a", 0, state = StopState.DONE)
+        val track = listOf(LatLng(46.2, 7.1), LatLng(46.45, 7.35))
+        val b = stop("b", 1).road(a, roadAB).copy(track = track)
+        val routes = MapOverlay.routes(data(TripStatus.ACTIVE, listOf(a, b), currentStopId = "b"))
+        assertEquals(listOf(MapAccent.CURRENT, MapAccent.CURRENT), routes.map { it.accent })
+        assertEquals(listOf(false, true), routes.map { it.dashed })
+        assertEquals(listOf(a.location!!) + track, routes[0].points)
+        // Joins the road at (46.4, 7.3), its nearest vertex, and follows it to the end.
+        assertEquals(listOf(track.last()) + Polyline.decode(roadAB).drop(1), routes[1].points)
+
+        // With no road the rest is a straight line to the pin; a ride still rides along.
+        val parked = LatLng(46.9, 7.9)
+        val ride = TransitRide(parked = parked, polyline = Polyline.encode(listOf(parked, b.location!!)))
+        val noRoad = b.copy(leg = StopLeg(from = a.location!!, to = b.location!!, distanceMeters = 1, rideAfter = ride))
+        val straight = MapOverlay.routes(data(TripStatus.ACTIVE, listOf(a, noRoad), currentStopId = "b"))
+        assertEquals(listOf(false, false, true), straight.map { it.ride })
+        assertEquals(listOf(track.last(), b.location), straight[1].points)
+        assertEquals(listOf(parked, b.location), straight[2].points)
+
+        // Without a track the current leg is the road it always was.
+        val untracked = MapOverlay.routes(data(TripStatus.ACTIVE, listOf(a, b.copy(track = emptyList())), currentStopId = "b"))
+        assertEquals(Polyline.decode(roadAB), untracked.single().points)
+        assertFalse(untracked.single().dashed)
+    }
 }

--- a/app/src/test/java/com/nuelto/etappli/domain/RouteTrackerTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/RouteTrackerTest.kt
@@ -1,0 +1,314 @@
+package com.nuelto.etappli.domain
+
+import app.cash.turbine.test
+import com.nuelto.etappli.data.InMemoryTripRepository
+import com.nuelto.etappli.data.model.LatLng
+import com.nuelto.etappli.data.model.Stop
+import com.nuelto.etappli.data.model.StopLeg
+import com.nuelto.etappli.data.model.StopState
+import com.nuelto.etappli.data.model.TransitRide
+import com.nuelto.etappli.data.model.Trip
+import com.nuelto.etappli.data.model.TripStatus
+import java.time.LocalDate
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RouteTrackerTest {
+
+    private val today = LocalDate.of(2026, 9, 4)
+    private val here = LatLng(46.8709, 8.2492)
+    private val there = LatLng(46.1591, 8.7853)
+    private val repository = InMemoryTripRepository(seed = false)
+    private val asked = mutableListOf<Pair<LatLng, LatLng>>()
+    private var answer: RoutedLeg? = RoutedLeg("", 90_000, 5_400)
+
+    private fun tracker() = RouteTracker(repository, { from, to -> asked += from to to; answer }, { today })
+
+    /** [meters] north of [from], close enough that a degree of latitude is a straight ruler. */
+    private fun north(from: LatLng, meters: Double) =
+        LatLng(from.latitude + meters / 111_195.0, from.longitude)
+
+    private suspend fun trip(id: String, status: TripStatus = TripStatus.ACTIVE, start: LocalDate = today) =
+        repository.upsertTrip(Trip(id = id, name = id, startDate = start, status = status))
+
+    private suspend fun stop(
+        tripId: String,
+        id: String,
+        order: Int,
+        location: LatLng? = there,
+        state: StopState = StopState.PLANNED,
+        nights: Int = 1,
+        leg: StopLeg? = null,
+    ) = repository.upsertStop(
+        Stop(
+            id = id, tripId = tripId, name = id, orderIndex = order, location = location,
+            state = state, nights = nights, arrivalDate = today, leg = leg,
+        ),
+    )
+
+    private suspend fun stop(tripId: String, id: String) = repository.stops(tripId).first().single { it.id == id }
+
+    private suspend fun track(tripId: String, id: String) = stop(tripId, id).track
+
+    // --- heading -------------------------------------------------------------
+
+    @Test
+    fun `no active trip, no heading`() = runTest {
+        tracker().heading().test {
+            assertNull(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+        trip("p", TripStatus.PLANNED)
+        stop("p", "s1", 0)
+        assertNull(tracker().heading().first())
+    }
+
+    @Test
+    fun `an active trip heads for its first planned stop`() = runTest {
+        trip("t")
+        stop("t", "s1", 0)
+        stop("t", "s2", 1)
+        val heading = tracker().heading().first()!!
+        assertEquals("t", heading.tripId)
+        assertEquals("s1", heading.stop.id)
+        assertEquals(there, heading.target)
+        assertTrue(heading.underway)
+    }
+
+    @Test
+    fun `mid-stay there is no heading`() = runTest {
+        trip("t")
+        stop("t", "s1", 0, state = StopState.DONE, nights = 2)
+        stop("t", "s2", 1)
+        assertNull(tracker().heading().first())
+    }
+
+    @Test
+    fun `of two active trips the one started last is followed`() = runTest {
+        trip("old", start = today.minusDays(3))
+        stop("old", "o1", 0)
+        trip("new", start = today.minusDays(1))
+        stop("new", "n1", 0)
+        val heading = tracker().heading().first()!!
+        assertEquals("new", heading.tripId)
+        assertTrue(heading.underway)
+    }
+
+    @Test
+    fun `before the start date the drive is not underway`() = runTest {
+        trip("t", start = today.plusDays(1))
+        stop("t", "s1", 0)
+        val heading = tracker().heading().first()!!
+        assertEquals("s1", heading.stop.id)
+        assertFalse(heading.underway)
+    }
+
+    @Test
+    fun `the target is where the vehicle is left for the ride up`() = runTest {
+        trip("t")
+        stop("t", "s1", 0, location = here, state = StopState.DONE, nights = 0)
+        val parked = LatLng(46.5, 8.5)
+        stop(
+            "t", "s2", 1,
+            leg = StopLeg(from = here, to = there, distanceMeters = 1, rideAfter = TransitRide(parked = parked)),
+        )
+        assertEquals(parked, tracker().heading().first()!!.target)
+    }
+
+    @Test
+    fun `the heading re-emits on check-in`() = runTest {
+        trip("t")
+        stop("t", "s1", 0)
+        tracker().heading().test {
+            assertEquals("s1", awaitItem()!!.stop.id)
+            repository.upsertStop(stop("t", "s1").copy(state = StopState.DONE))
+            assertNull(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // --- fix -----------------------------------------------------------------
+
+    @Test
+    fun `a fix goes onto the heading stop's track and buys a route`() = runTest {
+        trip("t")
+        stop("t", "s1", 0)
+        val tracker = tracker()
+        tracker.fix(here)
+        assertEquals(listOf(here), track("t", "s1"))
+        assertEquals(listOf(here to there), asked)
+        assertEquals(DriveFromHere(here, there, 90_000, 5_400), tracker.state.value.drive)
+        assertEquals(here, tracker.state.value.lastFix)
+    }
+
+    @Test
+    fun `a fix within thirty metres of the last is not recorded but is the last fix`() = runTest {
+        trip("t")
+        stop("t", "s1", 0)
+        val tracker = tracker()
+        tracker.fix(here)
+        tracker.fix(north(here, 20.0))
+        assertEquals(listOf(here), track("t", "s1"))
+        assertEquals(north(here, 20.0), tracker.state.value.lastFix)
+        tracker.fix(north(here, 40.0))
+        assertEquals(listOf(here, north(here, 40.0)), track("t", "s1"))
+    }
+
+    @Test
+    fun `an arrival fix is never recorded and clears the distance`() = runTest {
+        trip("t")
+        stop("t", "s1", 0)
+        val tracker = tracker()
+        tracker.fix(here)
+        assertNotNull(tracker.state.value.drive)
+        val arrival = north(there, 50.0)
+        tracker.fix(arrival)
+        assertEquals(listOf(here), track("t", "s1"))
+        assertNull(tracker.state.value.drive)
+        assertEquals(arrival, tracker.state.value.lastFix)
+        assertEquals(1, asked.size)
+    }
+
+    @Test
+    fun `nothing after the arrival is recorded until the heading changes`() = runTest {
+        trip("t")
+        stop("t", "s1", 0, nights = 0)
+        stop("t", "s2", 1, location = here)
+        val tracker = tracker()
+        tracker.fix(here)
+        tracker.fix(north(there, 50.0))
+        // The run to the shop from the campsite, and the way back: not the drive.
+        tracker.fix(north(there, 900.0))
+        tracker.fix(north(there, 60.0))
+        assertEquals(listOf(here), track("t", "s1"))
+        assertEquals(1, asked.size)
+        // Checked in and heading on: recording resumes for the next stop.
+        repository.upsertStop(stop("t", "s1").copy(state = StopState.DONE))
+        val onwards = north(there, 400.0)
+        tracker.fix(onwards)
+        assertEquals(listOf(onwards), track("t", "s2"))
+        assertEquals(2, asked.size)
+    }
+
+    @Test
+    fun `the heading follows a tour being started and re-dated, not a note being edited`() = runTest {
+        repository.upsertTrip(Trip(id = "t", name = "t", startDate = today, status = TripStatus.PLANNED))
+        stop("t", "s1", 0)
+        tracker().heading().test {
+            assertNull(awaitItem())
+            val trip = repository.trip("t").first()!!
+            repository.upsertTrip(trip.copy(status = TripStatus.ACTIVE))
+            assertTrue(awaitItem()!!.underway)
+            repository.upsertTrip(trip.copy(status = TripStatus.ACTIVE, startDate = today.plusDays(1)))
+            assertFalse(awaitItem()!!.underway)
+            repository.upsertTrip(trip.copy(status = TripStatus.ACTIVE, startDate = today.plusDays(1), notes = "packed"))
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `before the start date a fix is routed but not recorded`() = runTest {
+        trip("t", start = today.plusDays(1))
+        stop("t", "s1", 0)
+        val tracker = tracker()
+        tracker.fix(here)
+        assertTrue(track("t", "s1").isEmpty())
+        assertEquals(listOf(here to there), asked)
+        assertEquals(90_000, tracker.state.value.drive!!.distanceMeters)
+    }
+
+    @Test
+    fun `a fix for another trip records nothing`() = runTest {
+        trip("t")
+        stop("t", "s1", 0)
+        val tracker = tracker()
+        tracker.fix(here, tripId = "other")
+        assertTrue(track("t", "s1").isEmpty())
+        assertTrue(asked.isEmpty())
+        assertNull(tracker.state.value.lastFix)
+        tracker.fix(here, tripId = "t")
+        assertEquals(listOf(here), track("t", "s1"))
+        assertEquals(1, asked.size)
+    }
+
+    @Test
+    fun `no route is bought again within two kilometres`() = runTest {
+        trip("t")
+        stop("t", "s1", 0)
+        val tracker = tracker()
+        tracker.fix(here)
+        tracker.fix(north(here, 1_999.0))
+        assertEquals(1, asked.size)
+        assertEquals(here, tracker.state.value.drive!!.from)
+        tracker.fix(north(here, 2_001.0))
+        assertEquals(2, asked.size)
+        assertEquals(north(here, 2_001.0), tracker.state.value.drive!!.from)
+    }
+
+    @Test
+    fun `a failed ask is not repeated until two kilometres on, and a due one that fails clears the answer`() = runTest {
+        trip("t")
+        stop("t", "s1", 0)
+        answer = null
+        val tracker = tracker()
+        tracker.fix(here)
+        tracker.fix(north(here, 1_000.0))
+        assertEquals(1, asked.size)
+        assertNull(tracker.state.value.drive)
+        answer = RoutedLeg("", 80_000, 5_000)
+        tracker.fix(north(here, 2_500.0))
+        assertEquals(2, asked.size)
+        assertEquals(80_000, tracker.state.value.drive!!.distanceMeters)
+        answer = null
+        tracker.fix(north(here, 5_000.0))
+        assertEquals(3, asked.size)
+        assertNull(tracker.state.value.drive)
+    }
+
+    @Test
+    fun `a stop no road reaches is recorded but never routed`() = runTest {
+        trip("t")
+        stop("t", "s1", 0, location = here, state = StopState.DONE, nights = 0)
+        stop("t", "s2", 1, leg = StopLeg(from = here, to = there, distanceMeters = 0))
+        val tracker = tracker()
+        val fix = north(here, 500.0)
+        tracker.fix(fix)
+        assertEquals(listOf(fix), track("t", "s2"))
+        assertTrue(asked.isEmpty())
+        assertNull(tracker.state.value.drive)
+        assertEquals(fix, tracker.state.value.lastFix)
+    }
+
+    @Test
+    fun `with no heading a fix clears the distance and records nothing`() = runTest {
+        trip("t")
+        stop("t", "s1", 0, nights = 2)
+        val tracker = tracker()
+        tracker.fix(here)
+        assertNotNull(tracker.state.value.drive)
+        repository.upsertStop(stop("t", "s1").copy(state = StopState.DONE))
+        val later = north(here, 3_000.0)
+        tracker.fix(later)
+        assertNull(tracker.state.value.drive)
+        assertEquals(later, tracker.state.value.lastFix)
+        assertEquals(listOf(here), track("t", "s1"))
+        assertEquals(1, asked.size)
+    }
+
+    @Test
+    fun `recording flips the trip being recorded`() {
+        val tracker = tracker()
+        assertNull(tracker.state.value.recordingTripId)
+        tracker.recording("t")
+        assertEquals("t", tracker.state.value.recordingTripId)
+        tracker.recording(null)
+        assertNull(tracker.state.value.recordingTripId)
+    }
+}

--- a/app/src/test/java/com/nuelto/etappli/domain/TracksTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/TracksTest.kt
@@ -1,0 +1,188 @@
+package com.nuelto.etappli.domain
+
+import com.nuelto.etappli.data.model.LatLng
+import com.nuelto.etappli.data.model.Stop
+import com.nuelto.etappli.data.model.StopLeg
+import com.nuelto.etappli.data.model.StopState
+import com.nuelto.etappli.data.model.TransitRide
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TracksTest {
+
+    private val a = LatLng(46.0, 7.0)
+    private val b = LatLng(47.0, 8.0)
+    private val c = LatLng(48.0, 9.0)
+    private val t1 = listOf(LatLng(46.1, 7.1), LatLng(46.2, 7.2))
+    private val t2 = listOf(LatLng(46.3, 7.3), LatLng(46.4, 7.4))
+
+    /** [meters] north of [from], close enough that a degree of latitude is a straight ruler. */
+    private fun north(from: LatLng, meters: Double) =
+        LatLng(from.latitude + meters / 111_195.0, from.longitude)
+
+    private fun stop(
+        id: String,
+        order: Int,
+        location: LatLng? = b,
+        state: StopState = StopState.PLANNED,
+        track: List<LatLng> = emptyList(),
+        leg: StopLeg? = null,
+    ) = Stop(id = id, orderIndex = order, location = location, state = state, track = track, leg = leg)
+
+    // --- accepts -------------------------------------------------------------
+
+    @Test
+    fun `the first fix is always kept`() {
+        assertTrue(Tracks.accepts(emptyList(), a))
+    }
+
+    @Test
+    fun `a fix short of the minimum move is the same place, one past it is not`() {
+        assertFalse(Tracks.accepts(listOf(a, b), north(b, 29.0)))
+        assertTrue(Tracks.accepts(listOf(a, b), north(b, 31.0)))
+        // Measured from the last fix, not the first.
+        assertTrue(Tracks.accepts(listOf(b, a), north(b, 10.0)))
+        assertEquals(30.0, Tracks.MIN_MOVE_METERS, 1e-9)
+        assertEquals(120_000L, Tracks.FIX_INTERVAL_MS)
+    }
+
+    // --- target --------------------------------------------------------------
+
+    @Test
+    fun `the target is the pin without a leg, for the first stop, and for a leg with a road`() {
+        val first = stop("a", 0, a)
+        val second = stop("b", 1, b)
+        assertEquals(a, Tracks.target(listOf(first, second), first))
+        assertEquals(b, Tracks.target(listOf(first, second), second))
+        val routed = stop("b", 1, b, leg = StopLeg(from = a, to = b, distanceMeters = 5))
+        assertEquals(b, Tracks.target(listOf(first, routed), routed))
+        // A leg that no longer describes the drive says nothing about it.
+        val stale = stop("b", 1, b, leg = StopLeg(from = c, to = b, distanceMeters = 0))
+        assertEquals(b, Tracks.target(listOf(first, stale), stale))
+    }
+
+    @Test
+    fun `with a ride up the target is where the vehicle is left`() {
+        val parked = LatLng(46.5, 7.5)
+        val first = stop("a", 0, a)
+        val second = stop("b", 1, b, leg = StopLeg(from = a, to = b, distanceMeters = 1, rideAfter = TransitRide(parked = parked)))
+        assertEquals(parked, Tracks.target(listOf(first, second), second))
+    }
+
+    @Test
+    fun `a leg with no road has no target, judged against the previous routed stop`() {
+        val first = stop("a", 0, a)
+        val skipped = stop("s", 1, c, StopState.SKIPPED)
+        val second = stop("b", 2, b, leg = StopLeg(from = a, to = b, distanceMeters = 0))
+        assertNull(Tracks.target(listOf(first, skipped, second), second))
+    }
+
+    // --- drive ---------------------------------------------------------------
+
+    @Test
+    fun `a drive is the stop's own track`() {
+        val to = stop("b", 1, b, track = t1)
+        assertEquals(t1, Tracks.drive(listOf(stop("a", 0, a), to), to))
+    }
+
+    @Test
+    fun `an unlocated done stop's fixes come in front, a skipped stop in between hands nothing on`() {
+        val first = stop("a", 0, a, StopState.DONE)
+        val nowhere = stop("x", 1, null, StopState.DONE, track = t1)
+        val skipped = stop("s", 2, c, StopState.SKIPPED)
+        val to = stop("b", 3, b, track = t2)
+        assertEquals(t1 + t2, Tracks.drive(listOf(first, nowhere, skipped, to), to))
+        assertEquals(t1 + t2, Tracks.drive(listOf(to, skipped, nowhere, first), to))
+    }
+
+    @Test
+    fun `the walk back ends at the previous routed stop`() {
+        val first = stop("a", 0, a, StopState.DONE, track = listOf(a, a))
+        val nowhere = stop("x", 1, null, StopState.DONE, track = t1)
+        val middle = stop("b", 2, b, StopState.DONE, track = t2)
+        val to = stop("c", 3, c, track = listOf(c, c))
+        val stops = listOf(first, nowhere, middle, to)
+        assertEquals(listOf(c, c), Tracks.drive(stops, to))
+        assertEquals(t1 + t2, Tracks.drive(stops, middle))
+    }
+
+    @Test
+    fun `a stop not in the list gives its own track, and one point is no way`() {
+        val alone = stop("z", 9, c, track = t1)
+        assertEquals(t1, Tracks.drive(emptyList(), alone))
+        assertTrue(Tracks.drive(emptyList(), alone.copy(track = t1.take(1))).isEmpty())
+        assertTrue(Tracks.drive(listOf(stop("a", 0, a), alone), alone.copy(track = emptyList())).isEmpty())
+        // Two single fixes on one drive are a way.
+        val nowhere = stop("x", 0, null, track = t1.take(1))
+        val to = stop("b", 1, b, track = t2.take(1))
+        assertEquals(t1.take(1) + t2.take(1), Tracks.drive(listOf(nowhere, to), to))
+    }
+
+    // --- remainder -----------------------------------------------------------
+
+    @Test
+    fun `no fix means no remainder, no road means straight to the end`() {
+        assertTrue(Tracks.remainder(emptyList(), listOf(a, b), b).isEmpty())
+        assertEquals(listOf(t1.last(), b), Tracks.remainder(t1, emptyList(), b))
+    }
+
+    @Test
+    fun `the remainder joins the road at its nearest vertex and follows it to the end`() {
+        val road = listOf(a, LatLng(46.5, 7.5), LatLng(46.8, 7.8), b)
+        val last = LatLng(46.6, 7.6)
+        assertEquals(listOf(last, road[1], road[2], b), Tracks.remainder(listOf(a, last), road, b))
+        // Nearest the last vertex: just the hop onto it.
+        val nearly = LatLng(46.95, 7.95)
+        assertEquals(listOf(nearly, b), Tracks.remainder(listOf(nearly), road, b))
+    }
+
+    // --- settle --------------------------------------------------------------
+
+    @Test
+    fun `nothing strayed, nothing to rewrite`() {
+        val stops = listOf(stop("a", 0, a, StopState.DONE), stop("b", 1, b, track = t1), stop("c", 2, c))
+        assertTrue(Tracks.settle(stops).isEmpty())
+    }
+
+    @Test
+    fun `a stop inserted in front of the heading takes its fixes over`() {
+        val inserted = stop("n", 1, c)
+        val heading = stop("b", 2, b, track = t1)
+        assertEquals(
+            listOf(inserted.copy(track = t1), heading.copy(track = emptyList())),
+            Tracks.settle(listOf(stop("a", 0, a, StopState.DONE), inserted, heading)),
+        )
+    }
+
+    @Test
+    fun `a skipped stop hands its fixes on`() {
+        val skipped = stop("b", 1, b, StopState.SKIPPED, track = t1)
+        val next = stop("c", 2, c)
+        assertEquals(
+            listOf(next.copy(track = t1), skipped.copy(track = emptyList())),
+            Tracks.settle(listOf(stop("a", 0, a, StopState.DONE), skipped, next)),
+        )
+    }
+
+    @Test
+    fun `a restored stop takes its fixes back, its own first and the strays in order`() {
+        val restored = stop("b", 1, b, track = t1)
+        val c1 = stop("c", 2, c, track = t2)
+        val d1 = stop("d", 3, c, track = listOf(c, c))
+        assertEquals(
+            listOf(restored.copy(track = t1 + t2 + listOf(c, c)), c1.copy(track = emptyList()), d1.copy(track = emptyList())),
+            Tracks.settle(listOf(d1, stop("a", 0, a, StopState.DONE), c1, restored)),
+        )
+    }
+
+    @Test
+    fun `done stops keep their tracks and with no heading nothing moves`() {
+        val done = listOf(stop("a", 0, a, StopState.DONE, track = t1), stop("b", 1, b, StopState.DONE, track = t2))
+        assertTrue(Tracks.settle(done + stop("c", 2, c, track = listOf(c, c)) + stop("d", 3, c)).isEmpty())
+        assertTrue(Tracks.settle(done + stop("s", 2, c, StopState.SKIPPED, track = t1)).isEmpty())
+        assertTrue(Tracks.settle(emptyList()).isEmpty())
+    }
+}

--- a/app/src/test/java/com/nuelto/etappli/domain/TripStarterTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/TripStarterTest.kt
@@ -3,6 +3,7 @@ package com.nuelto.etappli.domain
 import com.nuelto.etappli.data.InMemoryTripRepository
 import com.nuelto.etappli.data.model.Expense
 import com.nuelto.etappli.data.model.ExpenseType
+import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.data.model.Stop
 import com.nuelto.etappli.data.model.StopKind
 import com.nuelto.etappli.data.model.StopState
@@ -169,6 +170,23 @@ class TripStarterTest {
         assertEquals(newStart, copied.date)
         assertNull(copied.stopId)
         assertEquals(2, repo.expenses(doneId).first().size)
+    }
+
+    @Test
+    fun `plan again leaves the way driven behind`() = runTest {
+        val driven = listOf(LatLng(46.0, 7.0), LatLng(46.5, 7.5))
+        val doneId = repo.upsertTrip(
+            Trip(id = "done", name = "Driven", startDate = LocalDate.of(2025, 9, 12), status = TripStatus.DONE),
+        )
+        repo.upsertStop(
+            Stop(
+                id = "d1", tripId = doneId, name = "Durance", arrivalDate = LocalDate.of(2025, 9, 12),
+                orderIndex = 0, state = StopState.DONE, track = driven,
+            ),
+        )
+        val newId = TripStarter.planAgain(repo, doneId, LocalDate.of(2026, 9, 12))
+        assertTrue(repo.stops(newId).first().single().track.isEmpty())
+        assertEquals(driven, repo.stops(doneId).first().single().track)
     }
 
     @Test

--- a/app/src/test/java/com/nuelto/etappli/ui/FormatTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/FormatTest.kt
@@ -1,10 +1,12 @@
 package com.nuelto.etappli.ui
 
+import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.data.model.StopLeg
 import com.nuelto.etappli.data.model.TransitRide
 import com.nuelto.etappli.data.model.TravelMode
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
+import com.nuelto.etappli.domain.DriveFromHere
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -211,6 +213,14 @@ class FormatTest {
             "arrive ${at(22, 30)} on ${formatDate(LocalDate.of(2026, 9, 3))}",
             formatArrival(2 * 24 * 3_600, evening),
         )
+    }
+
+    @Test
+    fun `the tracking notification names the stop and, once routed, how far it is`() {
+        assertEquals("Heading for Camping Delta", formatTrackingTitle("Camping Delta"))
+        val drive = DriveFromHere(LatLng(46.9, 8.5), LatLng(46.16, 8.79), 47_000, 3_300)
+        assertEquals("47 km · 55 min", formatTrackingText(drive))
+        assertEquals("Recording the way as you go", formatTrackingText(null))
     }
 
 }

--- a/app/src/test/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreenTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreenTest.kt
@@ -6,6 +6,7 @@ import android.Manifest
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.nuelto.etappli.domain.RoutedLeg
+import com.nuelto.etappli.domain.RouteTracker
 import org.robolectric.Shadows.shadowOf
 import androidx.activity.result.ActivityResultRegistry
 import androidx.activity.result.ActivityResultRegistryOwner
@@ -154,11 +155,11 @@ class TripDetailScreenTest {
             tripRepository,
             settingsRepository,
         ),
-        // Answers any permission request with this, so the grant flow can be driven.
-        permissionAnswer: Boolean? = null,
+        // What each permission request is answered with, so the grant flow can be driven.
+        permissions: Map<String, Boolean> = emptyMap(),
     ) {
         val registryOwner = object : ActivityResultRegistryOwner {
-            override val activityResultRegistry = answeringRegistry(permissionAnswer ?: false)
+            override val activityResultRegistry = answeringRegistry(permissions)
         }
         compose.setContent {
             CompositionLocalProvider(
@@ -797,12 +798,13 @@ class TripDetailScreenTest {
             .grantPermissions(Manifest.permission.ACCESS_FINE_LOCATION)
     }
 
-    private fun locatingViewModel(fix: LatLng?, leg: RoutedLeg?) = TripDetailViewModel(
+    private fun locatingViewModel(fix: LatLng?, leg: RoutedLeg?, recording: Boolean = false) = TripDetailViewModel(
         SavedStateHandle(mapOf("tripId" to "a1")),
         tripRepository,
         settingsRepository,
         currentLocation = { fix },
-        drive = { _, _ -> leg },
+        // The service reports itself on the tracker; here it is simply said to be running.
+        tracker = RouteTracker(tripRepository, drive = { _, _ -> leg }).apply { if (recording) recording("a1") },
     )
 
     @Test
@@ -820,8 +822,8 @@ class TripDetailScreenTest {
         seedActive()
         setContent("a1", locatingViewModel(LatLng(46.9, 8.5), RoutedLeg("", 47_000, 3_300)))
         compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
-        compose.onNodeWithText("Show distance from here", useUnmergedTree = true).assertIsDisplayed()
-        compose.onAllNodesWithText("from here", substring = true).assertCountEquals(1)
+        compose.onNodeWithText("Track this drive", useUnmergedTree = true).assertIsDisplayed()
+        compose.onAllNodesWithText("from here", substring = true).assertCountEquals(0)
     }
 
     @Test
@@ -844,16 +846,28 @@ class TripDetailScreenTest {
         compose.onAllNodesWithText("from here", substring = true).assertCountEquals(0)
     }
 
-    /** A registry that answers a permission request immediately, without a system dialog. */
+    private val fine = Manifest.permission.ACCESS_FINE_LOCATION
+    private val coarse = Manifest.permission.ACCESS_COARSE_LOCATION
+    private val notifications = Manifest.permission.POST_NOTIFICATIONS
+
+    // Every permission asked for, in the order it was asked, through either launcher.
+    private val requested = mutableListOf<String>()
+
+    /** A registry that answers a permission request immediately from [answers], without a system dialog. */
     @Suppress("UNCHECKED_CAST")
-    private fun answeringRegistry(granted: Boolean) = object : ActivityResultRegistry() {
+    private fun answeringRegistry(answers: Map<String, Boolean>) = object : ActivityResultRegistry() {
         override fun <I, O> onLaunch(
             requestCode: Int,
             contract: ActivityResultContract<I, O>,
             input: I,
             options: ActivityOptionsCompat?,
         ) {
-            dispatchResult(requestCode, granted as O)
+            // RequestPermission asks for one name and gets a Boolean; RequestMultiplePermissions
+            // asks for an array and gets a map.
+            val names = if (input is String) listOf(input) else (input as Array<*>).map { it as String }
+            requested += names
+            val granted = names.associateWith { answers[it] == true }
+            dispatchResult(requestCode, (if (input is String) granted.getValue(input) else granted) as O)
         }
     }
 
@@ -863,10 +877,10 @@ class TripDetailScreenTest {
         setContent(
             "a1",
             locatingViewModel(LatLng(46.9, 8.5), RoutedLeg("", 47_000, 3_300)),
-            permissionAnswer = true,
+            permissions = mapOf(fine to true, coarse to true),
         )
         compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
-        compose.onNodeWithText("Show distance from here", useUnmergedTree = true).performClick()
+        compose.onNodeWithText("Track this drive", useUnmergedTree = true).performClick()
         compose.onNodeWithText("47 km · 55 min from here", substring = true, useUnmergedTree = true)
             .assertIsDisplayed()
     }
@@ -877,11 +891,104 @@ class TripDetailScreenTest {
         setContent(
             "a1",
             locatingViewModel(LatLng(46.9, 8.5), RoutedLeg("", 47_000, 3_300)),
-            permissionAnswer = false,
+            permissions = mapOf(fine to false, coarse to false),
         )
         compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
-        compose.onNodeWithText("Show distance from here", useUnmergedTree = true).performClick()
+        compose.onNodeWithText("Track this drive", useUnmergedTree = true).performClick()
         compose.onAllNodesWithText("47 km", substring = true).assertCountEquals(0)
+        compose.onNodeWithText("Track this drive", useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a coarse-only answer says precise location is needed`() {
+        seedActive()
+        setContent(
+            "a1",
+            locatingViewModel(LatLng(46.9, 8.5), RoutedLeg("", 47_000, 3_300)),
+            permissions = mapOf(coarse to true),
+        )
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
+        compose.onNodeWithText("Track this drive", useUnmergedTree = true).performClick()
+        compose.onNodeWithText("Precise location needed to track", useUnmergedTree = true).assertIsDisplayed()
+        // Both were asked for together; no track, so nothing to notify about.
+        assertEquals(listOf(fine, coarse), requested)
+    }
+
+    @Test
+    fun `a coarse-only grant made earlier is seen on open`() {
+        seedActive()
+        shadowOf(ApplicationProvider.getApplicationContext<Application>()).grantPermissions(coarse)
+        setContent("a1", locatingViewModel(LatLng(46.9, 8.5), RoutedLeg("", 47_000, 3_300)))
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
+        compose.onNodeWithText("Precise location needed to track", useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun `granting location goes on to ask for the notification`() {
+        seedActive()
+        setContent(
+            "a1",
+            locatingViewModel(LatLng(46.9, 8.5), RoutedLeg("", 47_000, 3_300)),
+            permissions = mapOf(fine to true, coarse to true),
+        )
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
+        compose.onNodeWithText("Track this drive", useUnmergedTree = true).performClick()
+        assertEquals(listOf(fine, coarse, notifications), requested)
+    }
+
+    @Test
+    fun `while this drive is recorded the distance says so`() {
+        seedActive()
+        grantLocation()
+        setContent("a1", locatingViewModel(LatLng(46.9, 8.5), RoutedLeg("", 47_000, 3_300), recording = true))
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
+        compose.onNodeWithText("Tracking · 47 km · 55 min from here", substring = true, useUnmergedTree = true)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `recording without a route still says the drive is tracked`() {
+        seedActive()
+        grantLocation()
+        setContent("a1", locatingViewModel(fix = null, leg = null, recording = true))
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
+        compose.onNodeWithText("Tracking this drive", useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the notification is offered while tracking without it, and gone once granted`() {
+        seedActive()
+        grantLocation()
+        setContent(
+            "a1",
+            locatingViewModel(fix = null, leg = null, recording = true),
+            permissions = mapOf(notifications to true),
+        )
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
+        compose.onNodeWithText("Show tracking as a notification", useUnmergedTree = true).performClick()
+        assertEquals(listOf(notifications), requested)
+        compose.onAllNodesWithText("Show tracking as a notification").assertCountEquals(0)
+    }
+
+    @Test
+    fun `nothing offers a notification while nothing is tracked, or once it is allowed`() {
+        seedActive()
+        grantLocation()
+        setContent("a1", locatingViewModel(fix = null, leg = null))
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
+        compose.onAllNodesWithText("Show tracking as a notification").assertCountEquals(0)
+        compose.onAllNodesWithText("Tracking this drive").assertCountEquals(0)
+    }
+
+    @Test
+    fun `a notification already allowed is not offered`() {
+        seedActive()
+        grantLocation()
+        shadowOf(ApplicationProvider.getApplicationContext<Application>()).grantPermissions(notifications)
+        setContent("a1", locatingViewModel(fix = null, leg = null, recording = true))
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
+        compose.onNodeWithText("Tracking this drive", useUnmergedTree = true).assertIsDisplayed()
+        compose.onAllNodesWithText("Show tracking as a notification").assertCountEquals(0)
     }
 
     @Test
@@ -919,7 +1026,7 @@ class TripDetailScreenTest {
         }
         setContent("a1", locatingViewModel(LatLng(46.9, 8.5), RoutedLeg("", 47_000, 3_300)))
         compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
-        compose.onAllNodesWithText("Show distance from here").assertCountEquals(0)
+        compose.onAllNodesWithText("Track this drive").assertCountEquals(0)
     }
 
     @Test
@@ -995,7 +1102,7 @@ class TripDetailScreenTest {
         compose.onNodeWithTag("timeline").performScrollToNode(hasText("Locarno"))
         compose.onNodeWithText("TONIGHT").assertIsDisplayed()
         compose.onNodeWithText("Navigate").assertIsDisplayed()
-        compose.onNodeWithText("Show distance from here", useUnmergedTree = true).assertIsDisplayed()
+        compose.onNodeWithText("Track this drive", useUnmergedTree = true).assertIsDisplayed()
         compose.onAllNodesWithText("Checked in", useUnmergedTree = true).assertCountEquals(0)
     }
 }

--- a/app/src/test/java/com/nuelto/etappli/ui/tripdetail/TripDetailViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/tripdetail/TripDetailViewModelTest.kt
@@ -19,6 +19,7 @@ import com.nuelto.etappli.domain.PlaceCacheSweeper
 import com.nuelto.etappli.domain.RegionResolver
 import com.nuelto.etappli.domain.RoutedLeg
 import com.nuelto.etappli.domain.RouteRefresher
+import com.nuelto.etappli.domain.RouteTracker
 import com.nuelto.etappli.testutil.MainDispatcherRule
 import java.time.LocalDate
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -551,13 +552,16 @@ class TripDetailViewModelTest {
 
     private fun locatingViewModel(
         fix: suspend () -> LatLng?,
+        startTracking: () -> Unit = {},
+        tracker: RouteTracker? = null,
         drive: suspend (LatLng, LatLng) -> RoutedLeg?,
     ) = TripDetailViewModel(
         SavedStateHandle(mapOf("tripId" to "t1")),
         tripRepository,
         settingsRepository,
         currentLocation = fix,
-        drive = drive,
+        tracker = tracker ?: RouteTracker(tripRepository, drive = drive),
+        startTracking = startTracking,
     )
 
     @Test
@@ -650,6 +654,68 @@ class TripDetailViewModelTest {
         vm.refreshDriveFromHere()
         assertEquals(1, calls)
         assertNull(vm.uiState.value.driveFromHere)
+    }
+
+    // --- tracking ----------------------------------------------------------------------
+
+    @Test
+    fun `the opening fix lands on the track of the stop you are heading for`() = runTest {
+        seedOnTheRoad()
+        var here = hereFix
+        val vm = locatingViewModel({ here }) { _, _ -> null }
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect { } }
+        vm.refreshDriveFromHere()
+        here = LatLng(46.8, 8.3)
+        vm.refreshDriveFromHere()
+
+        assertEquals(listOf(hereFix, LatLng(46.8, 8.3)), stops().single().track)
+    }
+
+    @Test
+    fun `tracking follows what the service records and drops on check-in`() = runTest {
+        seedOnTheRoad()
+        val tracker = RouteTracker(tripRepository)
+        val vm = locatingViewModel({ hereFix }, tracker = tracker) { _, _ -> null }
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect { } }
+        assertFalse(vm.uiState.value.tracking)
+
+        tracker.recording("t1")
+        assertTrue(vm.uiState.value.tracking)
+        tracker.recording("other")
+        assertFalse(vm.uiState.value.tracking)
+
+        tracker.recording("t1")
+        vm.arrived("s1")
+        assertFalse(vm.uiState.value.tracking)
+    }
+
+    @Test
+    fun `opening the trip starts the service, but not once you have checked in`() = runTest {
+        seedOnTheRoad()
+        var starts = 0
+        val vm = locatingViewModel({ hereFix }, startTracking = { starts++ }) { _, _ -> null }
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect { } }
+        vm.refreshDriveFromHere()
+        assertEquals(1, starts)
+
+        vm.arrived("s1")
+        vm.refreshDriveFromHere()
+        assertEquals(1, starts)
+    }
+
+    @Test
+    fun `a tour started ahead of its date does not start the service before the day`() = runTest {
+        seedOnTheRoad()
+        tripRepository.upsertTrip(tripRepository.trip("t1").first()!!.copy(startDate = LocalDate.now().plusDays(1)))
+        var starts = 0
+        val vm = locatingViewModel({ hereFix }, startTracking = { starts++ }) { _, _ -> RoutedLeg("", 90_000, 5_400) }
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect { } }
+        vm.refreshDriveFromHere()
+
+        assertEquals(0, starts)
+        // The distance still reads; nothing lands on the track.
+        assertEquals(90_000, vm.uiState.value.driveFromHere!!.distanceMeters)
+        assertTrue(stops().single().track.isEmpty())
     }
 
 }

--- a/app/src/test/java/com/nuelto/etappli/ui/tripedit/StopEditViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/tripedit/StopEditViewModelTest.kt
@@ -595,6 +595,23 @@ class StopEditViewModelTest {
     }
 
     @Test
+    fun `a stop added mid-drive takes over the fixes recorded so far`() = runTest {
+        tripRepository.upsertTrip(
+            Trip(id = "t1", name = "Trip", startDate = LocalDate.of(2026, 8, 20), status = TripStatus.ACTIVE),
+        )
+        tripRepository.upsertStop(Stop(id = "done", tripId = "t1", name = "Done", orderIndex = 0, state = StopState.DONE))
+        val track = listOf(LatLng(46.9, 8.5), LatLng(46.8, 8.6))
+        tripRepository.upsertStop(Stop(id = "up", tripId = "t1", name = "Upcoming", orderIndex = 1, track = track))
+        val vm = newStopViewModel()
+        vm.setName("Spontan")
+        vm.save {}
+        // The FAB slots it in front of the old heading, so the drive underway now arrives here.
+        val stops = tripRepository.stops("t1").first()
+        assertEquals(track, stops.single { it.name == "Spontan" }.track)
+        assertTrue(stops.single { it.id == "up" }.track.isEmpty())
+    }
+
+    @Test
     fun `an active trip without check-ins keeps appending`() = runTest {
         tripRepository.upsertTrip(
             Trip(id = "t1", name = "Trip", startDate = LocalDate.of(2026, 8, 20), status = TripStatus.ACTIVE),

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,10 @@
+{
+  "indexes": [],
+  "fieldOverrides": [
+    {
+      "collectionGroup": "stops",
+      "fieldPath": "track",
+      "indexes": []
+    }
+  ]
+}


### PR DESCRIPTION
Closes #3.

## What changed

- **Tracking.** While an active trip is heading for a stop (after check-out, or before the first check-in, from the tour's start date on) a foreground service takes a GPS fix every two minutes and appends it to that stop's `track`, under an ongoing notification that says how far and how long the stop still is ("Heading for Rütli · 23 km · 24 min"). It starts whenever the app is opened with a drive underway or when location is granted on the NowCard, and stops itself at check-in.
- **Map.** A driven leg is drawn from its fixes instead of the routed road; the drive underway is the track so far, solid, then the rest of the planned road dashed. Legs ahead stay planned. The drive to a tour's first stop is drawn too.
- **NowCard.** "Tracking · 36 km · 39 min from here · arrive 19:30"; "Track this drive" grants location (fine and coarse together, with a "Precise location needed" line for a coarse-only grant); "Show tracking as a notification" until that permission is held.
- **Data.** `Stop.track` (list of fixes) appended atomically with `arrayUnion`; `Tracks.settle` runs in both repositories after every stop write so fixes follow the drive underway across inserts, reorders, skips and restores. An arrival fix is never recorded, and a track needs two points before it replaces the road.
- **One implementation.** `RouteTracker` (domain) serves the NowCard and the service; the old one-shot drive-from-here logic moved into it. `LiveDrive` now keys the refetch throttle on where the last route was *asked* from, so a stop with no road never buys a route per fix; a park-and-ride stop routes to its parking spot.
- Docs: CLAUDE.md, PRIVACY.md, PLAY_STORE_SETUP.md, FIREBASE_SETUP.md.

## Why this shape

No `ACCESS_BACKGROUND_LOCATION`: a location foreground service started while the app is open keeps access after it goes to the background, which is what the issue asks for, without the Play background-location review. `START_NOT_STICKY`, because a sticky restart is always a background start (refused on 12+). Consequence, documented: a drive on a day the app is never opened is not recorded. The nights stepper is the check-out.

## Verification

- `./gradlew test :app:coverageVerify :app:pitest :app:assembleDebug`: 821 tests, 100% line coverage, 94% mutants killed.
- Emulator (local-only build): service running as a location FGS, notification posted after the grant, live distance and notification text updating from moved fixes, track drawn on the mini map, tracking continuing with the app in the background, service and notification gone on check-in, no crashes.
- Not covered here: the Firestore write path (`arrayUnion`, `settleTracks`) and the two-dialog permission chain on a real device.

## After merge

- Play Console: the `location` foreground-service declaration appears after the next bundle upload (PLAY_STORE_SETUP.md §6.3).
- Firestore: add the single-field index exemption for `stops.track` (FIREBASE_SETUP.md, `firestore.indexes.json`).

Out of scope: check-out button, auto check-in, tracked distances in the timeline, opening the notification on the trip, a stop-tracking action, a service kept alive across stays, restart after reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)