### PR TITLE
Check in by standing there: ten minutes at the planned stop, and a Check out

### DIFF
--- a/.claude/skills/add-model-field/SKILL.md
+++ b/.claude/skills/add-model-field/SKILL.md
@@ -15,8 +15,8 @@ every read must tolerate its absence.
 2. **Firestore mapping is manual — two places or the field silently doesn't persist:**
    - Trip/Stop/Expense: `toMap()` **and** the `DocumentSnapshot.toX()` reader in
      `FirestoreTripRepository`, null-safe (`getX(...) ?: default`). Types: `LocalDate`
-     → `toEpochDay()` Long; `LatLng` → `GeoPoint`; enums → `name` string with
-     `runCatching { valueOf }` fallback on read.
+     → `toEpochDay()` Long; `LocalTime` → `toSecondOfDay()` Long; `LatLng` → `GeoPoint`;
+     enums → `name` string with `runCatching { valueOf }` fallback on read.
    - UserSettings: `update()` map **and** the snapshot reader in
      `FirestoreSettingsRepository` (defaults come from `UserSettings()`).
 3. **`InMemoryTripRepository`** usually needs no mapping change, but keep behavior in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,24 +100,44 @@ There is no lint/format tooling configured.
 - **Tracking the way driven** (`domain/RouteTracker`, `domain/Tracks`,
   `location/TrackingService`): the *heading* is the stop an ACTIVE trip is driving to
   (`CurrentStop.heading` — `CurrentStop.of` while it is still PLANNED; mid-stay there is
-  none, and the −1 on the nights stepper is the check-out), *underway* only from the tour's
-  start date on. While one is underway a foreground service takes a fix every
-  `Tracks.FIX_INTERVAL_MS` (2 min, HIGH_ACCURACY — deliberate: a road trace needs GPS and
-  the cadence duty-cycles it), appends it atomically to `Stop.track`
-  (`TripRepository.appendTrack`), and keeps an ongoing notification saying how far the
-  heading still is — about one Routes call per fix on the road, ~30/h, well inside the
-  Essentials free tier for one user. The service starts when the app is open with a heading
-  underway (`MainActivity.TrackingTrigger`, and the NowCard when the permission lands) and
-  stops itself when nothing is underway. Android 12+ refuses a location FGS started from
-  the background, so there is no `ACCESS_BACKGROUND_LOCATION`, no WorkManager, no boot
-  receiver and `START_NOT_STICKY`: **a drive on a day the app is never opened is not
-  recorded.** Both repositories run `Tracks.settle` after every stop write — fixes belong
-  to the drive underway, whichever stop it now arrives at. A track of two or more points is
-  drawn instead of the leg (`MapOverlay`: the drive underway is the track so far plus the
-  rest of the road from the last fix, dashed); an arrival fix (within 150 m) is never
-  recorded, or the evening fix at the campsite would turn the routed road into a straight
-  line. **Never write a `Stop` you did not just read**: a whole-stop write carries the
-  track it loaded, so every writer re-reads first (a second device would lose fixes).
+  none, and **Check out** on the NowCard or the −1 on the nights stepper ends a stay
+  early), *underway* only from the tour's start date on. While one is underway a
+  foreground service takes a fix every `Tracks.FIX_INTERVAL_MS` (2 min, HIGH_ACCURACY —
+  deliberate: a road trace needs GPS and the cadence duty-cycles it), appends it
+  atomically to `Stop.track` (`TripRepository.appendTrack`), and keeps an ongoing
+  notification saying how far the heading still is — about one Routes call per fix on the
+  road, ~30/h, well inside the Essentials free tier for one user. The service starts when
+  the app is open with a heading underway (`MainActivity.TrackingTrigger`, and the NowCard
+  when the permission lands) and stops itself when nothing is underway. Android 12+
+  refuses a location FGS started from the background, so there is no
+  `ACCESS_BACKGROUND_LOCATION`, no WorkManager, no boot receiver and `START_NOT_STICKY`:
+  **a drive on a day the app is never opened is not recorded.** Both repositories run
+  `Tracks.settle` after every stop write — fixes belong to the drive underway, whichever
+  stop it now arrives at. A track of two or more points is drawn instead of the leg
+  (`MapOverlay`: the drive underway is the track so far plus the rest of the road from the
+  last fix, dashed); an arrival fix (within 150 m) is never recorded, or the evening fix
+  at the campsite would turn the routed road into a straight line. **Never write a `Stop`
+  you did not just read**: a whole-stop write carries the track it loaded, so every writer
+  re-reads first (a second device would lose fixes).
+- **Arriving is automatic** (`domain/Stay`, run from `RouteTracker.fix`): ten minutes
+  (`Stay.CHECK_IN_AFTER`) of fixes within 500 m of the heading stop's own pin — none more
+  than `Stay.FIX_GAP` apart, so a drive-by and a drive-back are not a stay, and only a fix
+  `Stay.LEFT_BEYOND_METERS` away resets the clock, so a pitch on the edge of the site does
+  not — underway, on or after the day it is planned for, check it in: stamped with the
+  *first* of those fixes (`Stop.arrivalTime`, the time of day; `arrivalDate` is the day,
+  so editing the date keeps them together), the plan behind shifted by the lateness —
+  `Stay.checkIn`, the same write as ✓ Arrived, PLANNED stops only, so a tap and the
+  tracker cannot stamp twice. Hence the service's location request has **no distance
+  filter** (a parked phone must keep delivering) and drops fixes worse than
+  `Tracks.MAX_ACCURACY_METERS` (a cell fix would reset the dwell). A stay's check-in
+  leaves no heading, so the service stops; a zero-night stop hands the heading on and the
+  dwell starts over. **Undo check-in** (`Stay.undoCheckIn`; on the card, and on the row of
+  a zero-night stop checked in last, which had no card) holds the tracker off that stop
+  until a fix has left it (`RouteTracker.holdOff` — in memory, so a restart at the same
+  spot checks you in again). A day early is not an arrival: tap ✓ Arrived, or the service
+  keeps fixing all night and checks you in just after midnight. The checked-in card shows
+  the arrival, "Night 2 of 3 · leaving …", Check out, and the ≈ price tappable until it is
+  typed (no price prompt in the background).
 - **Elevation is not Google**: its Elevation API forbids storing results, so height comes
   from Open-Meteo (Copernicus DEM) via `domain/Elevation`. Two different numbers:
   `Stop.elevation` is **how high the stop is**, one point, stable, and the only one shown

--- a/app/src/main/java/com/nuelto/etappli/data/FirestoreTripRepository.kt
+++ b/app/src/main/java/com/nuelto/etappli/data/FirestoreTripRepository.kt
@@ -27,6 +27,7 @@ import com.nuelto.etappli.domain.DateCascade
 import com.nuelto.etappli.domain.Tracks
 import com.nuelto.etappli.domain.TripName
 import java.time.LocalDate
+import java.time.LocalTime
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -92,6 +93,7 @@ class FirestoreTripRepository(
         "name" to name,
         "location" to location?.let { GeoPoint(it.latitude, it.longitude) },
         "arrivalDate" to arrivalDate.toEpochDay(),
+        "arrivalTime" to arrivalTime?.toSecondOfDay(),
         "nights" to nights,
         "campingCostTotal" to campingCostTotal,
         "orderIndex" to orderIndex,
@@ -171,6 +173,7 @@ class FirestoreTripRepository(
         name = getString("name") ?: "",
         location = getGeoPoint("location")?.let { LatLng(it.latitude, it.longitude) },
         arrivalDate = LocalDate.ofEpochDay(getLong("arrivalDate") ?: 0L),
+        arrivalTime = getLong("arrivalTime")?.let { runCatching { LocalTime.ofSecondOfDay(it) }.getOrNull() },
         nights = (getLong("nights") ?: 1L).toInt(),
         campingCostTotal = getDouble("campingCostTotal") ?: 0.0,
         orderIndex = (getLong("orderIndex") ?: 0L).toInt(),

--- a/app/src/main/java/com/nuelto/etappli/data/InMemoryTripRepository.kt
+++ b/app/src/main/java/com/nuelto/etappli/data/InMemoryTripRepository.kt
@@ -14,6 +14,7 @@ import com.nuelto.etappli.domain.DateCascade
 import com.nuelto.etappli.domain.Tracks
 import com.nuelto.etappli.domain.TripName
 import java.time.LocalDate
+import java.time.LocalTime
 import java.util.UUID
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -238,6 +239,7 @@ class InMemoryTripRepository(seed: Boolean = true) : TripRepository {
                 id = "demo-v1", tripId = vierwald.id, name = "Camping Seefeld Sarnen",
                 location = LatLng(46.8709, 8.2492), arrivalDate = LocalDate.now().minusDays(1),
                 nights = 2, campingCostTotal = 84.0, orderIndex = 0, state = StopState.DONE,
+                arrivalTime = LocalTime.of(16, 40),
                 elevation = StopElevation(LatLng(46.8709, 8.2492), 473),
             ),
             Stop(

--- a/app/src/main/java/com/nuelto/etappli/data/model/Models.kt
+++ b/app/src/main/java/com/nuelto/etappli/data/model/Models.kt
@@ -1,6 +1,7 @@
 package com.nuelto.etappli.data.model
 
 import java.time.LocalDate
+import java.time.LocalTime
 
 data class LatLng(
     val latitude: Double,
@@ -133,6 +134,9 @@ data class Stop(
     val name: String = "",
     val location: LatLng? = null,
     val arrivalDate: LocalDate = LocalDate.now(),
+    // The time of day you got there, stamped at check-in (domain/Stay) — [arrivalDate] is
+    // then the day. Null while planned, and for stops checked in before it was recorded.
+    val arrivalTime: LocalTime? = null,
     val nights: Int = 1,
     val campingCostTotal: Double = 0.0,
     val orderIndex: Int = 0,

--- a/app/src/main/java/com/nuelto/etappli/domain/CurrentStop.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/CurrentStop.kt
@@ -28,8 +28,8 @@ object CurrentStop {
 
     /**
      * The stop you are driving to: [next] unless you are mid-stay. Null with nothing
-     * planned. Check-out is implicit — a stay is over the morning after its last night,
-     * and the nights stepper is how you leave early.
+     * planned. A stay is over the morning after its last night; the Check out button
+     * (Stay.checkOut) and the nights stepper are how you leave early.
      */
     fun heading(stops: List<Stop>, today: LocalDate): Stop? =
         if (staying(stops, today) != null) null else next(stops)

--- a/app/src/main/java/com/nuelto/etappli/domain/RouteTracker.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/RouteTracker.kt
@@ -4,8 +4,9 @@ import com.nuelto.etappli.data.TripRepository
 import com.nuelto.etappli.data.model.LatLng
 import com.nuelto.etappli.data.model.Stop
 import com.nuelto.etappli.data.model.TripStatus
-import java.time.LocalDate
+import java.time.ZonedDateTime
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -18,6 +19,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 
 /**
  * The stop an active trip is driving to: which trip, where the vehicle is actually driven
@@ -30,14 +32,15 @@ data class Heading(val tripId: String, val stop: Stop, val target: LatLng?, val 
 /**
  * Follows the drive underway on the active trip: every GPS fix goes onto the track of the
  * stop being headed for and, throttled by [LiveDrive], buys a route from there to it —
- * what the NowCard and the tracking notification both show. One per app (AppContainer):
- * the foreground service feeds it fixes in the background, the timeline feeds it one when
- * it opens, and both read the same answer.
+ * what the NowCard and the tracking notification both show. Standing at the stop for
+ * [Stay.CHECK_IN_AFTER] checks you in. One per app (AppContainer): the foreground service
+ * feeds it fixes in the background, the timeline feeds it one when it opens, and both read
+ * the same answer.
  */
 class RouteTracker(
     private val tripRepository: TripRepository,
     private val drive: suspend (from: LatLng, to: LatLng) -> RoutedLeg? = { _, _ -> null },
-    private val today: () -> LocalDate = { LocalDate.now() },
+    private val now: () -> ZonedDateTime = { ZonedDateTime.now() },
 ) {
     data class State(
         // How far the target is from the last fix; null until routed, and again once
@@ -65,6 +68,13 @@ class RouteTracker(
     // parking spot, the run to the shop from the campsite — is not the drive.
     private var arrivedFor: String? = null
 
+    // The fixes at the stop being headed for so far: Stay.CHECK_IN_AFTER of them is arriving.
+    private var dwell: Stay.Dwell? = null
+
+    // A stop not to check in at until a fix has left it: the one just checked in, so that
+    // taking that back is not undone by the next fix, or the one the user took back.
+    private var heldOff: String? = null
+
     /**
      * Where the active trip is heading, re-evaluated as trips and stops change: null
      * between check-in and check-out and with no active trip. Two active trips: the one
@@ -78,20 +88,22 @@ class RouteTracker(
         .flatMapLatest { trip ->
             if (trip == null) return@flatMapLatest flowOf(null)
             tripRepository.stops(trip.id).map { stops ->
-                CurrentStop.heading(stops, today())?.let {
-                    Heading(trip.id, it, Tracks.target(stops, it), underway = !today().isBefore(trip.startDate))
+                val today = now().toLocalDate()
+                CurrentStop.heading(stops, today)?.let {
+                    Heading(trip.id, it, Tracks.target(stops, it), underway = !today.isBefore(trip.startDate))
                 }
             }
         }
 
     /**
      * One fix from the phone. Onto the track (only while underway, and nothing from the
-     * arrival fix on), then how far the target still is. [tripId] from a screen keeps a fix off another
-     * active trip's drive; the service passes none. Serialized: the service and a screen
-     * can both deliver one.
+     * arrival fix on), then whether you have arrived for good, then how far the target
+     * still is. [tripId] from a screen keeps a fix off another active trip's drive; the
+     * service passes none. Serialized: the service and a screen can both deliver one.
      */
     suspend fun fix(point: LatLng, tripId: String? = null) {
         lock.withLock {
+            val at = now()
             val heading = heading().first()
             if (heading == null) {
                 _state.update { it.copy(drive = null, lastFix = point) }
@@ -105,6 +117,11 @@ class RouteTracker(
                 tripRepository.appendTrack(heading.tripId, heading.stop.id, point)
             }
             _state.update { it.copy(lastFix = point) }
+            // Before the arrival return below: the fixes that check you in are the ones inside it.
+            if (stay(heading, point, at)) {
+                _state.update { it.copy(drive = null) }
+                return
+            }
             if (target == null || arrived) {
                 _state.update { it.copy(drive = null) }
                 return
@@ -119,6 +136,40 @@ class RouteTracker(
                 state.copy(drive = leg?.let { DriveFromHere(point, target, it.distanceMeters, it.durationSeconds) })
             }
         }
+    }
+
+    /**
+     * The dwell that checks you in: [Stay.CHECK_IN_AFTER] of fixes at the stop being headed
+     * for (Stay.near), on a drive underway — stamped with the first of them, which is when
+     * you got there. True once the check-in is written.
+     */
+    private suspend fun stay(heading: Heading, point: LatLng, at: ZonedDateTime): Boolean {
+        val stop = heading.stop
+        val left = Stay.left(point, stop)
+        if (heldOff == stop.id && left) heldOff = null
+        if (!heading.underway || heldOff == stop.id || left) {
+            dwell = null
+            return false
+        }
+        // Between near and left, or not yet the stop's day: neither at it nor away from it.
+        if (!Stay.near(point, stop, at.toLocalDate())) return false
+        val here = Stay.dwell(dwell, stop.id, at).also { dwell = it }
+        if (!here.checksIn) return false
+        val stops = tripRepository.stops(heading.tripId).first()
+        // The write ends the drive, which stops the service, which cancels the coroutine
+        // this runs in: the repository must still get to settle the plan behind the write.
+        withContext(NonCancellable) {
+            tripRepository.upsertStops(Stay.checkIn(stops, stop.id, here.since.toLocalDateTime()))
+        }
+        // The next fix starts over by itself: no heading, or this stop held off.
+        heldOff = stop.id
+        return true
+    }
+
+    /** You are not at [stopId] after all: no check-in there until a fix has left it, and the drive to it is on again. */
+    suspend fun holdOff(stopId: String) = lock.withLock {
+        heldOff = stopId
+        arrivedFor = null
     }
 
     /** The service reports itself. */

--- a/app/src/main/java/com/nuelto/etappli/domain/Stay.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/Stay.kt
@@ -1,0 +1,111 @@
+package com.nuelto.etappli.domain
+
+import com.nuelto.etappli.data.model.LatLng
+import com.nuelto.etappli.data.model.Stop
+import com.nuelto.etappli.data.model.StopState
+import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+
+/**
+ * Checking in and out of a stop, and where a stay stands: pure, so the tracker can check you
+ * in from the background exactly as the ✓ Arrived button does. [checkIn], [undoCheckIn] and
+ * [checkOut] return the stops to write as one [com.nuelto.etappli.data.TripRepository.upsertStops]
+ * — the stop and the shift it causes in the plan behind it — and nothing when there is
+ * nothing to do.
+ */
+object Stay {
+
+    /** Standing this close to the stop you are heading for... */
+    const val CHECK_IN_WITHIN_METERS = 500.0
+
+    /** ...for this long is arriving, and the tracker checks you in (RouteTracker). */
+    val CHECK_IN_AFTER: Duration = Duration.ofMinutes(10)
+
+    /**
+     * Only a fix this far away has left the stop. In between — a pitch on the far edge of
+     * the site, GPS wandering — a fix neither adds to the stay nor breaks it.
+     */
+    const val LEFT_BEYOND_METERS = 1_000.0
+
+    /**
+     * Fixes at the stop further apart than this are two visits, not one stay: a couple of
+     * missed fixes are fine, a drive-by and a drive-back are not.
+     */
+    val FIX_GAP: Duration = Duration.ofMillis(3 * Tracks.FIX_INTERVAL_MS)
+
+    /** The fixes at one stop so far: the first and the latest. Zoned, so a night the clocks change counts real minutes. */
+    data class Dwell(val stopId: String, val since: ZonedDateTime, val last: ZonedDateTime) {
+        /** [CHECK_IN_AFTER] of them: you have arrived. */
+        val checksIn: Boolean get() = Duration.between(since, last) >= CHECK_IN_AFTER
+    }
+
+    /** One more fix at [stopId]: onto [previous] when that is the same stop within [FIX_GAP], else a fresh one. */
+    fun dwell(previous: Dwell?, stopId: String, at: ZonedDateTime): Dwell =
+        if (previous != null && previous.stopId == stopId && Duration.between(previous.last, at) <= FIX_GAP) {
+            previous.copy(last = at)
+        } else {
+            Dwell(stopId, at, at)
+        }
+
+    /**
+     * Check-in at [at]: the stop is reached, its arrival is that day and time, and a late
+     * (or early) arrival shifts the plan behind it by the days it was off. Only a PLANNED
+     * stop: a check-in is not repeated, so a tap and the tracker racing each other leave
+     * the first stamp standing.
+     */
+    fun checkIn(stops: List<Stop>, stopId: String, at: LocalDateTime): List<Stop> {
+        val stop = stops.find { it.id == stopId }?.takeIf { it.state == StopState.PLANNED } ?: return emptyList()
+        val day = at.toLocalDate()
+        return listOf(stop.copy(state = StopState.DONE, arrivalDate = day, arrivalTime = at.toLocalTime().truncatedTo(ChronoUnit.MINUTES))) +
+            DateCascade.shift(stops, stop.orderIndex, ChronoUnit.DAYS.between(stop.arrivalDate, day))
+    }
+
+    /**
+     * Takes a check-in back — the tracker got it wrong, or a thumb did — leaving the stop
+     * planned for the day it was stamped with, so the plan behind it stays where it is.
+     */
+    fun undoCheckIn(stops: List<Stop>, stopId: String): List<Stop> =
+        stops.find { it.id == stopId }?.takeIf { it.state == StopState.DONE }
+            ?.let { listOf(it.copy(state = StopState.PLANNED, arrivalTime = null)) }
+            .orEmpty()
+
+    /**
+     * Check-out on [today]: the stay is as many nights as were slept, and the plan behind it
+     * moves up by the nights it lost — the stepper's −1, as many times as it takes. Never
+     * lengthens a stay: on or after the planned departure there is nothing to do.
+     */
+    fun checkOut(stops: List<Stop>, stopId: String, today: LocalDate): List<Stop> {
+        val stop = stops.find { it.id == stopId }?.takeIf { it.state == StopState.DONE } ?: return emptyList()
+        val nights = ChronoUnit.DAYS.between(stop.arrivalDate, today).coerceIn(0, stop.nights.toLong()).toInt()
+        if (nights == stop.nights) return emptyList()
+        return listOf(stop.copy(nights = nights)) + DateCascade.shift(stops, stop.orderIndex, (nights - stop.nights).toLong())
+    }
+
+    /**
+     * Whether a fix is at [stop] as far as arriving goes: within [CHECK_IN_WITHIN_METERS] of
+     * its own pin — not the parking spot of a ride, the phone rides up with you — and on or
+     * after the day it is planned for. A day early you may just be passing; a day late is
+     * still arriving.
+     */
+    fun near(point: LatLng, stop: Stop, today: LocalDate): Boolean {
+        val location = stop.location ?: return false
+        return !today.isBefore(stop.arrivalDate) && GeoUtils.haversineKm(point, location) * 1000 < CHECK_IN_WITHIN_METERS
+    }
+
+    /** Whether a fix has left [stop] for good — [LEFT_BEYOND_METERS] from its pin, or it has none. */
+    fun left(point: LatLng, stop: Stop): Boolean {
+        val location = stop.location ?: return true
+        return GeoUtils.haversineKm(point, location) * 1000 >= LEFT_BEYOND_METERS
+    }
+
+    /** Where a stay stands on a day: nights slept, nights still to sleep, and the morning it ends. */
+    data class Progress(val stayed: Int, val ahead: Int, val departure: LocalDate)
+
+    fun progress(stop: Stop, today: LocalDate): Progress {
+        val stayed = ChronoUnit.DAYS.between(stop.arrivalDate, today).coerceIn(0, stop.nights.toLong()).toInt()
+        return Progress(stayed, stop.nights - stayed, stop.arrivalDate.plusDays(stop.nights.toLong()))
+    }
+}

--- a/app/src/main/java/com/nuelto/etappli/domain/Tracks.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/Tracks.kt
@@ -21,6 +21,9 @@ object Tracks {
     /** A fix closer than this to the last one recorded is the same place — parked, at the lights, at lunch. */
     const val MIN_MOVE_METERS = 30.0
 
+    /** A fix less sure than this is a cell tower, not GPS: the service drops it (see CLAUDE.md, arriving). */
+    const val MAX_ACCURACY_METERS = 250.0
+
     fun accepts(track: List<LatLng>, fix: LatLng): Boolean {
         val last = track.lastOrNull() ?: return true
         return GeoUtils.haversineKm(last, fix) * 1000 >= MIN_MOVE_METERS

--- a/app/src/main/java/com/nuelto/etappli/domain/TripStarter.kt
+++ b/app/src/main/java/com/nuelto/etappli/domain/TripStarter.kt
@@ -66,6 +66,7 @@ object TripStarter {
                     tripId = newId,
                     state = if (it.id == departed) StopState.DONE else StopState.PLANNED,
                     arrivalDate = it.arrivalDate.plusDays(shift),
+                    arrivalTime = null,
                 )
             },
         )
@@ -108,6 +109,7 @@ object TripStarter {
                     tripId = newId,
                     state = StopState.PLANNED,
                     arrivalDate = it.arrivalDate.plusDays(shift),
+                    arrivalTime = null,
                     track = emptyList(),
                 )
             },

--- a/app/src/main/java/com/nuelto/etappli/location/TrackingService.kt
+++ b/app/src/main/java/com/nuelto/etappli/location/TrackingService.kt
@@ -59,7 +59,8 @@ class TrackingService : Service() {
     private val callback = object : LocationCallback() {
         override fun onLocationResult(result: LocationResult) {
             // One coroutine per batch keeps the fixes in the order they were taken.
-            scope.launch { result.locations.forEach { runCatching { tracker.fix(LatLng(it.latitude, it.longitude)) } } }
+            val fixes = result.locations.filterNot { it.hasAccuracy() && it.accuracy > Tracks.MAX_ACCURACY_METERS }
+            scope.launch { fixes.forEach { runCatching { tracker.fix(LatLng(it.latitude, it.longitude)) } } }
         }
     }
 
@@ -86,9 +87,9 @@ class TrackingService : Service() {
         if (!started) {
             started = true
             client.requestLocationUpdates(
+                // No distance filter: a parked phone must keep delivering (CLAUDE.md, arriving).
                 LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, Tracks.FIX_INTERVAL_MS)
                     .setMinUpdateIntervalMillis(Tracks.FIX_INTERVAL_MS / 2)
-                    .setMinUpdateDistanceMeters(Tracks.MIN_MOVE_METERS.toFloat())
                     .build(),
                 callback,
                 Looper.getMainLooper(),

--- a/app/src/main/java/com/nuelto/etappli/ui/Format.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/Format.kt
@@ -6,9 +6,11 @@ import com.nuelto.etappli.data.model.TravelMode
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
 import com.nuelto.etappli.domain.DriveFromHere
+import com.nuelto.etappli.domain.Stay
 import java.text.NumberFormat
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.time.temporal.ChronoUnit
@@ -74,6 +76,23 @@ private fun ridePart(ride: TransitRide) =
     DrivePart(ride.modes.ifEmpty { listOf(TravelMode.TRANSIT) }, formatDuration(ride.durationSeconds))
 
 private val timeFormatter: DateTimeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
+private val dateTimeFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM, FormatStyle.SHORT)
+
+/** When you got to the stop: the day, and the time of day once one was recorded. */
+fun formatArrived(date: LocalDate, time: LocalTime?): String =
+    "Arrived " + (time?.let { date.atTime(it).format(dateTimeFormatter) } ?: formatDate(date))
+
+/**
+ * Where the stay stands: "Night 2 of 3 · leaving Sep 7, 2026" — the night ahead of you
+ * counted, so it reads the same on every day of the stay. Only the leaving on a card left
+ * open past the last morning.
+ */
+fun formatStay(progress: Stay.Progress): String {
+    val leaving = formatDate(progress.departure)
+    if (progress.ahead == 0) return "Leaving $leaving"
+    return "Night ${progress.stayed + 1} of ${progress.stayed + progress.ahead} · leaving $leaving"
+}
 
 /**
  * When you get there if you set off now. Names the day too once the drive crosses

--- a/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreen.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Undo
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
@@ -115,6 +116,7 @@ import com.nuelto.etappli.domain.TripMapData
 import com.nuelto.etappli.domain.Elevation
 import com.nuelto.etappli.domain.GapRow
 import com.nuelto.etappli.domain.HomeStop
+import com.nuelto.etappli.domain.Stay
 import com.nuelto.etappli.domain.StopRow
 import com.nuelto.etappli.domain.TripEstimator
 import com.nuelto.etappli.domain.title
@@ -124,8 +126,10 @@ import com.nuelto.etappli.ui.components.StatusBadge
 import com.nuelto.etappli.ui.components.parseDecimal
 import com.nuelto.etappli.ui.components.rememberReorderState
 import com.nuelto.etappli.ui.components.reorderable
+import com.nuelto.etappli.ui.formatArrived
 import com.nuelto.etappli.ui.formatCurrency
 import com.nuelto.etappli.ui.formatDate
+import com.nuelto.etappli.ui.formatStay
 import com.nuelto.etappli.ui.driveParts
 import com.nuelto.etappli.ui.components.modeIcon
 import com.nuelto.etappli.ui.tripedit.displayName
@@ -173,6 +177,10 @@ fun TripDetailScreen(
     // rows — and the current stop, which is simply where you are — are anchors.
     // The home the plan sets out from reads as its start; any other home is the way back.
     val departureId = HomeStop.departure(state.stops)?.id
+    // A zero-night stop the tracker checked in never had a card to take it back from: its
+    // row keeps the undo while it is the stop checked in last.
+    val lastArrivedId = state.stops.filter { it.state == StopState.DONE }.maxByOrNull { it.orderIndex }
+        ?.takeIf { it.nights == 0 && it.arrivalTime != null && trip?.status == TripStatus.ACTIVE }?.id
     val movableKeys = state.rows
         .filter {
             trip?.status != TripStatus.DONE &&
@@ -476,6 +484,9 @@ fun TripDetailScreen(
                                 viewModel.arrived(row.stop.id)
                                 if (row.stop.kind.isStay) arrivalPromptStop = row.stop
                             },
+                            onCheckOut = { viewModel.checkOut(row.stop.id) },
+                            onUndoArrival = { viewModel.undoArrival(row.stop.id) },
+                            onPrice = { arrivalPromptStop = row.stop },
                             onSkip = { skipWithUndo(row.stop) },
                         )
                     } else {
@@ -489,6 +500,7 @@ fun TripDetailScreen(
                             onClick = { onEditStop(trip.id, row.stop.id) },
                             onSkip = { skipWithUndo(row.stop) },
                             onRestore = { viewModel.restore(row.stop.id) },
+                            onUndoArrival = if (row.stop.id == lastArrivedId) { { viewModel.undoArrival(row.stop.id) } } else null,
                             modifier = rowModifier,
                         )
                     }
@@ -613,7 +625,7 @@ private fun TimelineBottomBar(
     }
 }
 
-/** Tonight's stop on an active trip: check in, adjust the stay, hand off navigation. */
+/** Tonight's stop on an active trip: check in and out, adjust the stay, hand off navigation. */
 @Composable
 private fun NowCard(
     stop: Stop,
@@ -631,6 +643,10 @@ private fun NowCard(
     onClick: () -> Unit,
     onChangeNights: (Int) -> Unit,
     onArrived: () -> Unit,
+    onCheckOut: () -> Unit,
+    onUndoArrival: () -> Unit,
+    // Opens the price prompt from a checked-in card whose price is still an estimate.
+    onPrice: () -> Unit,
     onSkip: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -640,7 +656,11 @@ private fun NowCard(
     ) {
         Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
             Text(
-                if (stop.kind.isStay) "TONIGHT" else "NEXT",
+                when {
+                    stop.state == StopState.DONE -> "CHECKED IN"
+                    stop.kind.isStay -> "TONIGHT"
+                    else -> "NEXT"
+                },
                 style = MaterialTheme.typography.labelSmall,
                 color = ActiveGreen,
                 fontWeight = FontWeight.Bold,
@@ -709,16 +729,22 @@ private fun NowCard(
                     Text(
                         stopPriceText(stop, TripStatus.ACTIVE, settings),
                         style = MaterialTheme.typography.titleSmall,
+                        // Checked in by the tracker, the price prompt never came: the
+                        // estimate stays tappable until it is the price.
+                        modifier = if (stop.state == StopState.DONE && !stop.costKnown) Modifier.clickable(onClick = onPrice) else Modifier,
                     )
                 }
             }
             if (stop.kind.isStay) {
                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                    Text(
-                        "${formatDate(stop.arrivalDate)} ·",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                    // Checked in, the arrival line below carries the date.
+                    if (stop.state != StopState.DONE) {
+                        Text(
+                            "${formatDate(stop.arrivalDate)} ·",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                     IconButton(onClick = { onChangeNights(-1) }) {
                         Icon(Icons.Default.KeyboardArrowDown, contentDescription = "One night less")
                     }
@@ -732,12 +758,18 @@ private fun NowCard(
                 }
             }
             if (stop.state == StopState.DONE) {
-                // Mid-stay: checked in, staying — only the stepper above matters.
+                // Mid-stay: when you got here, where the stay stands, and the way out — the
+                // stepper above is still how you stay longer.
                 Text(
-                    "Checked in",
+                    formatArrived(stop.arrivalDate, stop.arrivalTime),
                     style = MaterialTheme.typography.bodyMedium,
-                    color = ActiveGreen,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                Text(formatStay(Stay.progress(stop, LocalDate.now())), style = MaterialTheme.typography.bodyMedium)
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Button(onClick = onCheckOut) { Text("Check out") }
+                    TextButton(onClick = onUndoArrival) { Text("Undo check-in") }
+                }
             } else {
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     Button(onClick = onArrived) { Text("✓ Arrived") }
@@ -861,6 +893,8 @@ private fun TimelineStopRow(
     onClick: () -> Unit,
     onSkip: () -> Unit,
     onRestore: () -> Unit,
+    // Set on a zero-night stop checked in last: a check-in with no card to take it back from.
+    onUndoArrival: (() -> Unit)?,
     modifier: Modifier = Modifier,
 ) {
     Card(onClick = onClick, modifier = modifier.fillMaxWidth()) {
@@ -908,6 +942,11 @@ private fun TimelineStopRow(
             if (tripStatus == TripStatus.ACTIVE && stop.state == StopState.SKIPPED) {
                 IconButton(onClick = onRestore) {
                     Icon(Icons.Default.Refresh, contentDescription = "Restore stop")
+                }
+            }
+            if (onUndoArrival != null) {
+                IconButton(onClick = onUndoArrival) {
+                    Icon(Icons.AutoMirrored.Filled.Undo, contentDescription = "Undo check-in")
                 }
             }
         }

--- a/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailViewModel.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/tripdetail/TripDetailViewModel.kt
@@ -32,6 +32,7 @@ import com.nuelto.etappli.domain.RegionResolver
 import com.nuelto.etappli.domain.RouteCache
 import com.nuelto.etappli.domain.RouteRefresher
 import com.nuelto.etappli.domain.RouteTracker
+import com.nuelto.etappli.domain.Stay
 import com.nuelto.etappli.domain.Timeline
 import com.nuelto.etappli.domain.TimelineRow
 import com.nuelto.etappli.domain.Tracks
@@ -41,7 +42,7 @@ import com.nuelto.etappli.domain.VignetteTable
 import com.nuelto.etappli.location.PlaceNameResolver
 import com.nuelto.etappli.ui.nav.TripDetailRoute
 import java.time.LocalDate
-import java.time.temporal.ChronoUnit
+import java.time.LocalDateTime
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -247,17 +248,30 @@ class TripDetailViewModel(
         }
     }
 
-    /** Check-in: stamps today as the actual arrival; a late arrival shifts what follows. */
+    /** Check-in: stamps now as the arrival; a late arrival shifts what follows (Stay.checkIn). */
     fun arrived(stopId: String) {
         viewModelScope.launch {
             writeLock.withLock {
-                val stops = tripRepository.stops(tripId).first()
-                val stop = stops.find { it.id == stopId } ?: return@withLock
-                val today = LocalDate.now()
-                tripRepository.upsertStops(
-                    listOf(stop.copy(state = StopState.DONE, arrivalDate = today)) +
-                        DateCascade.shift(stops, stop.orderIndex, ChronoUnit.DAYS.between(stop.arrivalDate, today)),
-                )
+                tripRepository.upsertStops(Stay.checkIn(tripRepository.stops(tripId).first(), stopId, LocalDateTime.now()))
+            }
+        }
+    }
+
+    /** Check-out: the stay ends today, and the plan behind it moves up (Stay.checkOut). */
+    fun checkOut(stopId: String) {
+        viewModelScope.launch {
+            writeLock.withLock {
+                tripRepository.upsertStops(Stay.checkOut(tripRepository.stops(tripId).first(), stopId, LocalDate.now()))
+            }
+        }
+    }
+
+    /** Takes a check-in back, and keeps the tracker from making it again while you are still there. */
+    fun undoArrival(stopId: String) {
+        viewModelScope.launch {
+            writeLock.withLock {
+                tracker.holdOff(stopId)
+                tripRepository.upsertStops(Stay.undoCheckIn(tripRepository.stops(tripId).first(), stopId))
             }
         }
     }
@@ -284,7 +298,8 @@ class TripDetailViewModel(
         viewModelScope.launch {
             writeLock.withLock {
                 val stop = freshStop(stopId) ?: return@withLock
-                tripRepository.upsertStop(stop.copy(state = state))
+                // Skipped, or planned again: not arrived at.
+                tripRepository.upsertStop(stop.copy(state = state, arrivalTime = null))
             }
         }
     }

--- a/app/src/main/java/com/nuelto/etappli/ui/tripedit/StopEditViewModel.kt
+++ b/app/src/main/java/com/nuelto/etappli/ui/tripedit/StopEditViewModel.kt
@@ -284,6 +284,9 @@ class StopEditViewModel(
                 )
                 val parsed = parseDecimal(state.campingCost)
                 val nights = if (state.isStay) state.nights else 0
+                // The date as the user set it — or, left alone, the stop's own: the tracker
+                // may have checked it in meanwhile, on another day than the one loaded.
+                val arrivalDate = if (old != null && state.arrivalDate == existing?.arrivalDate) old.arrivalDate else state.arrivalDate
                 // No parseable price means "estimate at the kind's default rate" —
                 // except kinds free by nature, and unchanged legacy known-zero stops.
                 val costKnown = parsed != null ||
@@ -291,7 +294,7 @@ class StopEditViewModel(
                     (old != null && old.costKnown && old.campingCostTotal == 0.0 && old.kind == state.kind)
                 val saved = base.copy(
                     name = state.savedName(),
-                    arrivalDate = state.arrivalDate,
+                    arrivalDate = arrivalDate,
                     nights = nights,
                     campingCostTotal = if (state.isStay) parsed ?: 0.0 else 0.0,
                     location = state.location,
@@ -313,7 +316,7 @@ class StopEditViewModel(
                     // A moved departure shifts the downstream planned schedule along.
                     val days = ChronoUnit.DAYS.between(
                         old.arrivalDate.plusDays(old.nights.toLong()),
-                        state.arrivalDate.plusDays(nights.toLong()),
+                        arrivalDate.plusDays(nights.toLong()),
                     )
                     listOf(saved) + DateCascade.shift(stops, old.orderIndex, days)
                 }

--- a/app/src/test/java/com/nuelto/etappli/domain/RouteTrackerTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/RouteTrackerTest.kt
@@ -9,7 +9,11 @@ import com.nuelto.etappli.data.model.StopState
 import com.nuelto.etappli.data.model.TransitRide
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
+import java.time.Duration
 import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -22,13 +26,21 @@ import org.junit.Test
 class RouteTrackerTest {
 
     private val today = LocalDate.of(2026, 9, 4)
+    private val zone = ZoneId.of("Europe/Zurich")
+    private var now = today.atTime(16, 0).atZone(zone)
     private val here = LatLng(46.8709, 8.2492)
     private val there = LatLng(46.1591, 8.7853)
     private val repository = InMemoryTripRepository(seed = false)
     private val asked = mutableListOf<Pair<LatLng, LatLng>>()
     private var answer: RoutedLeg? = RoutedLeg("", 90_000, 5_400)
 
-    private fun tracker() = RouteTracker(repository, { from, to -> asked += from to to; answer }, { today })
+    private fun tracker() = RouteTracker(repository, { from, to -> asked += from to to; answer }, { now })
+
+    /** A fix [minutes] after the last one. */
+    private suspend fun RouteTracker.fixAfter(minutes: Long, point: LatLng, tripId: String? = null) {
+        now += Duration.ofMinutes(minutes)
+        fix(point, tripId)
+    }
 
     /** [meters] north of [from], close enough that a degree of latitude is a straight ruler. */
     private fun north(from: LatLng, meters: Double) =
@@ -45,10 +57,11 @@ class RouteTrackerTest {
         state: StopState = StopState.PLANNED,
         nights: Int = 1,
         leg: StopLeg? = null,
+        arrival: LocalDate = today,
     ) = repository.upsertStop(
         Stop(
             id = id, tripId = tripId, name = id, orderIndex = order, location = location,
-            state = state, nights = nights, arrivalDate = today, leg = leg,
+            state = state, nights = nights, arrivalDate = arrival, leg = leg,
         ),
     )
 
@@ -300,6 +313,284 @@ class RouteTrackerTest {
         assertEquals(later, tracker.state.value.lastFix)
         assertEquals(listOf(here), track("t", "s1"))
         assertEquals(1, asked.size)
+    }
+
+    // --- check-in ------------------------------------------------------------
+
+    @Test
+    fun `ten minutes at the stop check you in, stamped with the first fix there`() = runTest {
+        trip("t")
+        stop("t", "s1", 0)
+        stop("t", "s2", 1, arrival = today.plusDays(1))
+        val tracker = tracker()
+        tracker.fix(here)
+        // Inside the 150 m that already count as arrived: the dwell must run before that return.
+        val atStop = north(there, 50.0)
+        tracker.fixAfter(5, atStop)
+        tracker.fixAfter(5, atStop)
+        tracker.fixAfter(4, atStop)
+        assertEquals(StopState.PLANNED, stop("t", "s1").state)
+        tracker.fixAfter(1, atStop)
+        val s1 = stop("t", "s1")
+        assertEquals(StopState.DONE, s1.state)
+        assertEquals(today, s1.arrivalDate)
+        assertEquals(LocalTime.of(16, 5), s1.arrivalTime)
+        assertEquals(today.plusDays(1), stop("t", "s2").arrivalDate)
+        assertNull(tracker.state.value.drive)
+        assertEquals(listOf(here), track("t", "s1"))
+        assertEquals(1, asked.size)
+    }
+
+    @Test
+    fun `a fix away from the stop starts the dwell over, one for another trip is not a move`() = runTest {
+        trip("t")
+        stop("t", "s1", 0)
+        val tracker = tracker()
+        tracker.fix(north(there, 100.0))
+        tracker.fixAfter(5, north(there, 1_200.0))
+        tracker.fixAfter(5, north(there, 100.0))
+        tracker.fixAfter(4, north(there, 400.0))
+        tracker.fixAfter(5, north(there, 400.0))
+        assertEquals(StopState.PLANNED, stop("t", "s1").state)
+        tracker.fixAfter(1, north(there, 400.0))
+        assertEquals(LocalTime.of(16, 10), stop("t", "s1").arrivalTime)
+
+        repository.upsertStops(Stay.undoCheckIn(repository.stops("t").first(), "s1"))
+        tracker.fixAfter(1, north(there, 1_200.0))
+        tracker.fixAfter(1, north(there, 100.0))
+        tracker.fixAfter(2, north(there, 100.0))
+        tracker.fixAfter(1, north(there, 100.0), tripId = "other")
+        tracker.fixAfter(1, north(there, 100.0))
+        assertEquals(StopState.PLANNED, stop("t", "s1").state)
+        tracker.fixAfter(4, north(there, 100.0))
+        tracker.fixAfter(2, north(there, 100.0))
+        assertEquals(LocalTime.of(16, 22), stop("t", "s1").arrivalTime)
+    }
+
+    @Test
+    fun `a fix between near and left neither adds to the stay nor breaks it`() = runTest {
+        trip("t")
+        stop("t", "s1", 0)
+        val tracker = tracker()
+        tracker.fix(north(there, 100.0))
+        tracker.fixAfter(2, north(there, 700.0))
+        tracker.fixAfter(2, north(there, 100.0))
+        tracker.fixAfter(2, north(there, 700.0))
+        tracker.fixAfter(2, north(there, 100.0))
+        // Ten minutes on, but this one is not at the stop.
+        tracker.fixAfter(2, north(there, 700.0))
+        assertEquals(StopState.PLANNED, stop("t", "s1").state)
+        tracker.fixAfter(1, north(there, 100.0))
+        assertEquals(LocalTime.of(16, 0), stop("t", "s1").arrivalTime)
+    }
+
+    @Test
+    fun `too long on the edge of the site is a gap like any other`() = runTest {
+        trip("t")
+        stop("t", "s1", 0)
+        val tracker = tracker()
+        tracker.fix(north(there, 100.0))
+        tracker.fixAfter(2, north(there, 700.0))
+        tracker.fixAfter(2, north(there, 700.0))
+        tracker.fixAfter(3, north(there, 700.0))
+        tracker.fixAfter(1, north(there, 100.0))
+        tracker.fixAfter(2, north(there, 100.0))
+        assertEquals(StopState.PLANNED, stop("t", "s1").state)
+        tracker.fixAfter(4, north(there, 100.0))
+        tracker.fixAfter(4, north(there, 100.0))
+        assertEquals(LocalTime.of(16, 8), stop("t", "s1").arrivalTime)
+    }
+
+    @Test
+    fun `fixes at the stop further apart than the fix gap are two visits, not a stay`() = runTest {
+        trip("t")
+        stop("t", "s1", 0)
+        val tracker = tracker()
+        tracker.fix(north(there, 100.0))
+        tracker.fixAfter(2, north(there, 100.0))
+        tracker.fixAfter(7, north(there, 100.0))
+        tracker.fixAfter(3, north(there, 100.0))
+        assertEquals(StopState.PLANNED, stop("t", "s1").state)
+        tracker.fixAfter(4, north(there, 100.0))
+        tracker.fixAfter(3, north(there, 100.0))
+        assertEquals(LocalTime.of(16, 9), stop("t", "s1").arrivalTime)
+    }
+
+    @Test
+    fun `the ten minutes are real minutes on the night the clocks go back`() = runTest {
+        val night = LocalDate.of(2026, 10, 25)
+        now = LocalDateTime.of(2026, 10, 25, 2, 55).atZone(zone)
+        trip("t", start = night)
+        stop("t", "s1", 0, arrival = night)
+        val tracker = tracker()
+        tracker.fix(north(there, 100.0))
+        tracker.fixAfter(4, north(there, 100.0))
+        tracker.fixAfter(4, north(there, 100.0))
+        assertEquals(StopState.PLANNED, stop("t", "s1").state)
+        tracker.fixAfter(2, north(there, 100.0))
+        assertEquals(LocalTime.of(2, 55), stop("t", "s1").arrivalTime)
+        assertEquals("02:05", now.toLocalTime().toString())
+    }
+
+    @Test
+    fun `a late arrival is still an arrival, and the plan behind it moves`() = runTest {
+        trip("t", start = today.minusDays(1))
+        stop("t", "s1", 0, arrival = today.minusDays(1))
+        stop("t", "s2", 1, arrival = today)
+        val tracker = tracker()
+        tracker.fix(north(there, 100.0))
+        tracker.fixAfter(5, north(there, 100.0))
+        tracker.fixAfter(5, north(there, 100.0))
+        val s1 = stop("t", "s1")
+        assertEquals(StopState.DONE, s1.state)
+        assertEquals(today, s1.arrivalDate)
+        assertEquals(today.plusDays(1), stop("t", "s2").arrivalDate)
+    }
+
+    @Test
+    fun `a day early, before the tour, or at a stop with no pin, standing there is not arriving`() = runTest {
+        trip("early")
+        stop("early", "e", 0, arrival = today.plusDays(1))
+        val early = tracker()
+        early.fix(north(there, 100.0))
+        early.fixAfter(5, north(there, 100.0))
+        early.fixAfter(5, north(there, 100.0))
+        assertEquals(StopState.PLANNED, stop("early", "e").state)
+        repository.deleteTrip("early")
+
+        trip("ahead", start = today.plusDays(1))
+        stop("ahead", "a", 0)
+        val ahead = tracker()
+        ahead.fix(north(there, 100.0))
+        ahead.fixAfter(5, north(there, 100.0))
+        ahead.fixAfter(5, north(there, 100.0))
+        assertEquals(StopState.PLANNED, stop("ahead", "a").state)
+        repository.deleteTrip("ahead")
+
+        trip("pinless")
+        stop("pinless", "p", 0, location = null)
+        val pinless = tracker()
+        pinless.fix(north(there, 100.0))
+        pinless.fixAfter(5, north(there, 100.0))
+        pinless.fixAfter(5, north(there, 100.0))
+        assertEquals(StopState.PLANNED, stop("pinless", "p").state)
+    }
+
+    @Test
+    fun `the first fix at the stop is the arrival even across midnight`() = runTest {
+        now = today.atTime(23, 55).atZone(zone)
+        trip("t")
+        stop("t", "s1", 0)
+        stop("t", "s2", 1, arrival = today.plusDays(1))
+        val tracker = tracker()
+        tracker.fix(north(there, 100.0))
+        tracker.fixAfter(5, north(there, 100.0))
+        tracker.fixAfter(5, north(there, 100.0))
+        val s1 = stop("t", "s1")
+        assertEquals(today, s1.arrivalDate)
+        assertEquals(LocalTime.of(23, 55), s1.arrivalTime)
+        assertEquals(today.plusDays(1), stop("t", "s2").arrivalDate)
+    }
+
+    @Test
+    fun `a visit checked in hands the heading on, and the next stop needs its own ten minutes`() = runTest {
+        trip("t")
+        stop("t", "s1", 0, nights = 0)
+        stop("t", "s2", 1, location = north(there, 200.0))
+        val tracker = tracker()
+        tracker.fix(north(there, 100.0))
+        tracker.fixAfter(5, north(there, 100.0))
+        tracker.fixAfter(5, north(there, 100.0))
+        assertEquals(StopState.DONE, stop("t", "s1").state)
+        assertEquals(StopState.PLANNED, stop("t", "s2").state)
+        assertEquals("s2", tracker.heading().first()!!.stop.id)
+        tracker.fixAfter(2, north(there, 150.0))
+        tracker.fixAfter(4, north(there, 150.0))
+        tracker.fixAfter(4, north(there, 150.0))
+        assertEquals(StopState.PLANNED, stop("t", "s2").state)
+        tracker.fixAfter(2, north(there, 150.0))
+        assertEquals(LocalTime.of(16, 12), stop("t", "s2").arrivalTime)
+    }
+
+    @Test
+    fun `a check-in taken back is not made again until a fix has left the stop`() = runTest {
+        trip("t")
+        stop("t", "s1", 0)
+        val tracker = tracker()
+        tracker.fix(north(there, 100.0))
+        tracker.fixAfter(5, north(there, 100.0))
+        tracker.fixAfter(5, north(there, 100.0))
+        assertEquals(StopState.DONE, stop("t", "s1").state)
+        // Taken back on the timeline: the tracker holds itself off after its own check-in.
+        repository.upsertStops(Stay.undoCheckIn(repository.stops("t").first(), "s1"))
+        tracker.fixAfter(2, north(there, 100.0))
+        // A wander to the far edge of the site is not leaving.
+        tracker.fixAfter(2, north(there, 700.0))
+        tracker.fixAfter(2, north(there, 100.0))
+        tracker.fixAfter(4, north(there, 100.0))
+        tracker.fixAfter(4, north(there, 100.0))
+        tracker.fixAfter(2, north(there, 100.0))
+        assertEquals(StopState.PLANNED, stop("t", "s1").state)
+        // Gone and back: the stop counts again.
+        tracker.fixAfter(3, north(there, 1_200.0))
+        tracker.fixAfter(2, north(there, 100.0))
+        tracker.fixAfter(5, north(there, 100.0))
+        tracker.fixAfter(5, north(there, 100.0))
+        assertEquals(LocalTime.of(16, 31), stop("t", "s1").arrivalTime)
+    }
+
+    @Test
+    fun `held off, a stop checked in by hand and taken back is left alone while you stay`() = runTest {
+        trip("t")
+        stop("t", "s1", 0)
+        val tracker = tracker()
+        tracker.fix(north(there, 100.0))
+        repository.upsertStops(Stay.checkIn(repository.stops("t").first(), "s1", now.toLocalDateTime()))
+        repository.upsertStops(Stay.undoCheckIn(repository.stops("t").first(), "s1"))
+        tracker.holdOff("s1")
+        tracker.fixAfter(4, north(there, 100.0))
+        tracker.fixAfter(4, north(there, 100.0))
+        tracker.fixAfter(4, north(there, 100.0))
+        assertEquals(StopState.PLANNED, stop("t", "s1").state)
+        tracker.fixAfter(1, north(there, 1_200.0))
+        tracker.fixAfter(1, north(there, 100.0))
+        tracker.fixAfter(5, north(there, 100.0))
+        tracker.fixAfter(5, north(there, 100.0))
+        assertEquals(StopState.DONE, stop("t", "s1").state)
+    }
+
+    @Test
+    fun `taking a check-in back puts the drive to the stop on again`() = runTest {
+        trip("t")
+        stop("t", "s1", 0)
+        val tracker = tracker()
+        tracker.fix(north(there, 100.0))
+        assertTrue(asked.isEmpty())
+        assertTrue(track("t", "s1").isEmpty())
+        tracker.holdOff("s1")
+        // The pin was wrong: what follows is a drive, routed and recorded.
+        repository.upsertStop(stop("t", "s1").copy(location = here))
+        val fix = north(there, 100.0)
+        tracker.fixAfter(1, fix)
+        assertEquals(listOf(fix), track("t", "s1"))
+        assertEquals(listOf(fix to here), asked)
+    }
+
+    @Test
+    fun `a dwell interrupted by a check-in and its undo starts over`() = runTest {
+        trip("t")
+        stop("t", "s1", 0)
+        val tracker = tracker()
+        tracker.fix(north(there, 100.0))
+        repository.upsertStops(Stay.checkIn(repository.stops("t").first(), "s1", now.toLocalDateTime()))
+        tracker.fixAfter(5, north(there, 100.0))
+        assertNull(tracker.state.value.drive)
+        repository.upsertStops(Stay.undoCheckIn(repository.stops("t").first(), "s1"))
+        tracker.fixAfter(7, north(there, 100.0))
+        assertEquals(StopState.PLANNED, stop("t", "s1").state)
+        tracker.fixAfter(5, north(there, 100.0))
+        tracker.fixAfter(5, north(there, 100.0))
+        assertEquals(LocalTime.of(16, 12), stop("t", "s1").arrivalTime)
     }
 
     @Test

--- a/app/src/test/java/com/nuelto/etappli/domain/StayTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/StayTest.kt
@@ -1,0 +1,177 @@
+package com.nuelto.etappli.domain
+
+import com.nuelto.etappli.data.model.LatLng
+import com.nuelto.etappli.data.model.Stop
+import com.nuelto.etappli.data.model.StopState
+import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StayTest {
+
+    private val today = LocalDate.of(2026, 9, 4)
+    private val pin = LatLng(46.1591, 8.7853)
+
+    private fun stop(
+        id: String,
+        order: Int,
+        arrival: LocalDate = today,
+        nights: Int = 3,
+        state: StopState = StopState.PLANNED,
+        location: LatLng? = pin,
+        time: LocalTime? = null,
+    ) = Stop(id = id, orderIndex = order, arrivalDate = arrival, nights = nights, state = state, location = location, arrivalTime = time)
+
+    /** [meters] north of [from], close enough that a degree of latitude is a straight ruler. */
+    private fun north(from: LatLng, meters: Double) = LatLng(from.latitude + meters / 111_195.0, from.longitude)
+
+    // --- checkIn -------------------------------------------------------------
+
+    @Test
+    fun `check-in stamps the day and the minute, and leaves an on-time plan alone`() {
+        val stops = listOf(stop("a", 0), stop("b", 1, arrival = today.plusDays(3)))
+        val written = Stay.checkIn(stops, "a", today.atTime(16, 42, 37))
+        val a = written.single()
+        assertEquals(StopState.DONE, a.state)
+        assertEquals(today, a.arrivalDate)
+        assertEquals(LocalTime.of(16, 42), a.arrivalTime)
+    }
+
+    @Test
+    fun `a late check-in moves the plan behind it back, an early one forward`() {
+        val stops = listOf(stop("a", 0), stop("b", 1, arrival = today.plusDays(3)), stop("c", 2, arrival = today.plusDays(5), state = StopState.SKIPPED))
+        val late = Stay.checkIn(stops, "a", today.plusDays(1).atTime(9, 0))
+        assertEquals(listOf("a", "b"), late.map { it.id })
+        assertEquals(today.plusDays(1), late[0].arrivalDate)
+        assertEquals(today.plusDays(4), late[1].arrivalDate)
+        val early = Stay.checkIn(stops, "a", today.minusDays(1).atTime(9, 0))
+        assertEquals(today.minusDays(1), early[0].arrivalDate)
+        assertEquals(today.plusDays(2), early[1].arrivalDate)
+    }
+
+    @Test
+    fun `only a planned stop can be checked in, and only once`() {
+        val done = stop("a", 0, state = StopState.DONE, time = LocalTime.of(16, 0))
+        assertTrue(Stay.checkIn(listOf(done), "a", today.atTime(17, 0)).isEmpty())
+        assertTrue(Stay.checkIn(listOf(stop("a", 0, state = StopState.SKIPPED)), "a", today.atTime(17, 0)).isEmpty())
+        assertTrue(Stay.checkIn(listOf(stop("a", 0)), "nope", today.atTime(17, 0)).isEmpty())
+    }
+
+    // --- undoCheckIn ---------------------------------------------------------
+
+    @Test
+    fun `undoing a check-in plans the stop again for the day it was stamped with`() {
+        val done = stop("a", 0, arrival = today.plusDays(1), state = StopState.DONE, time = LocalTime.of(16, 0))
+        val undone = Stay.undoCheckIn(listOf(done, stop("b", 1, arrival = today.plusDays(4))), "a").single()
+        assertEquals(StopState.PLANNED, undone.state)
+        assertNull(undone.arrivalTime)
+        assertEquals(today.plusDays(1), undone.arrivalDate)
+        assertEquals(3, undone.nights)
+        assertTrue(Stay.undoCheckIn(listOf(stop("a", 0)), "a").isEmpty())
+        assertTrue(Stay.undoCheckIn(listOf(done), "nope").isEmpty())
+    }
+
+    // --- checkOut ------------------------------------------------------------
+
+    @Test
+    fun `check-out keeps the nights slept and pulls the plan behind it forward`() {
+        val stops = listOf(
+            stop("a", 0, arrival = today.minusDays(1), state = StopState.DONE),
+            stop("b", 1, arrival = today.plusDays(2)),
+            stop("c", 2, arrival = today.plusDays(4)),
+        )
+        val written = Stay.checkOut(stops, "a", today)
+        assertEquals(listOf("a", "b", "c"), written.map { it.id })
+        assertEquals(1, written[0].nights)
+        assertEquals(today, written[1].arrivalDate)
+        assertEquals(today.plusDays(2), written[2].arrivalDate)
+    }
+
+    @Test
+    fun `checking out on the day you arrived leaves no nights`() {
+        val written = Stay.checkOut(listOf(stop("a", 0, state = StopState.DONE), stop("b", 1, arrival = today.plusDays(3))), "a", today)
+        assertEquals(0, written[0].nights)
+        assertEquals(today, written[1].arrivalDate)
+    }
+
+    @Test
+    fun `a check-out never lengthens a stay, and needs a checked-in stop`() {
+        val done = stop("a", 0, arrival = today.minusDays(3), state = StopState.DONE)
+        assertTrue(Stay.checkOut(listOf(done), "a", today).isEmpty())
+        assertTrue(Stay.checkOut(listOf(done), "a", today.plusDays(2)).isEmpty())
+        assertTrue(Stay.checkOut(listOf(stop("a", 0, arrival = today.minusDays(1))), "a", today).isEmpty())
+        assertTrue(Stay.checkOut(listOf(done), "nope", today).isEmpty())
+    }
+
+    // --- near ----------------------------------------------------------------
+
+    @Test
+    fun `near is inside five hundred metres of the pin, on or after the day`() {
+        val a = stop("a", 0)
+        assertTrue(Stay.near(north(pin, 499.0), a, today))
+        assertFalse(Stay.near(north(pin, 501.0), a, today))
+        assertTrue(Stay.near(pin, a, today.plusDays(1)))
+        assertFalse(Stay.near(pin, a, today.minusDays(1)))
+        assertFalse(Stay.near(pin, stop("a", 0, location = null), today))
+    }
+
+    // --- dwell ---------------------------------------------------------------
+
+    private val zone = ZoneId.of("Europe/Zurich")
+    private val at = today.atTime(16, 0).atZone(zone)
+
+    @Test
+    fun `a dwell grows with fixes at the same stop, and checks in after ten minutes`() {
+        val first = Stay.dwell(null, "a", at)
+        assertEquals(Stay.Dwell("a", at, at), first)
+        val later = Stay.dwell(first, "a", at.plusMinutes(5))
+        assertEquals(Stay.Dwell("a", at, at.plusMinutes(5)), later)
+        assertFalse(Stay.dwell(later, "a", at.plusMinutes(9)).checksIn)
+        assertTrue(Stay.dwell(later, "a", at.plusMinutes(10)).checksIn)
+    }
+
+    @Test
+    fun `another stop, or a gap longer than three fixes, is a fresh dwell`() {
+        val first = Stay.dwell(null, "a", at)
+        assertEquals(Stay.Dwell("b", at.plusMinutes(1), at.plusMinutes(1)), Stay.dwell(first, "b", at.plusMinutes(1)))
+        assertEquals(at, Stay.dwell(first, "a", at.plusMinutes(6)).since)
+        assertEquals(at.plusMinutes(7), Stay.dwell(first, "a", at.plusMinutes(7)).since)
+    }
+
+    @Test
+    fun `left is a kilometre from the pin, or no pin at all`() {
+        val a = stop("a", 0)
+        assertFalse(Stay.left(north(pin, 999.0), a))
+        assertTrue(Stay.left(north(pin, 1_001.0), a))
+        assertTrue(Stay.left(pin, stop("a", 0, location = null)))
+    }
+
+    @Test
+    fun `the minutes of a dwell are real minutes when the clocks go back`() {
+        val before = LocalDateTime.of(2026, 10, 25, 2, 55).atZone(zone)
+        val after = before.plus(Duration.ofMinutes(10))
+        assertEquals(LocalTime.of(2, 5), after.toLocalTime())
+        val halfway = Stay.dwell(Stay.dwell(null, "a", before), "a", before.plus(Duration.ofMinutes(5)))
+        assertTrue(Stay.dwell(halfway, "a", after).checksIn)
+    }
+
+    // --- progress ------------------------------------------------------------
+
+    @Test
+    fun `progress counts the nights slept and the nights ahead`() {
+        val a = stop("a", 0, arrival = today.minusDays(1), state = StopState.DONE)
+        assertEquals(Stay.Progress(0, 3, today.plusDays(2)), Stay.progress(a, today.minusDays(1)))
+        assertEquals(Stay.Progress(1, 2, today.plusDays(2)), Stay.progress(a, today))
+        assertEquals(Stay.Progress(3, 0, today.plusDays(2)), Stay.progress(a, today.plusDays(2)))
+        // Never past the stay, never before it.
+        assertEquals(Stay.Progress(3, 0, today.plusDays(2)), Stay.progress(a, today.plusDays(9)))
+        assertEquals(Stay.Progress(0, 3, today.plusDays(2)), Stay.progress(a, today.minusDays(9)))
+    }
+}

--- a/app/src/test/java/com/nuelto/etappli/domain/TripStarterTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/domain/TripStarterTest.kt
@@ -11,6 +11,7 @@ import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
 import com.nuelto.etappli.data.model.UserSettings
 import java.time.LocalDate
+import java.time.LocalTime
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -173,7 +174,7 @@ class TripStarterTest {
     }
 
     @Test
-    fun `plan again leaves the way driven behind`() = runTest {
+    fun `plan again leaves the way driven and the arrival behind`() = runTest {
         val driven = listOf(LatLng(46.0, 7.0), LatLng(46.5, 7.5))
         val doneId = repo.upsertTrip(
             Trip(id = "done", name = "Driven", startDate = LocalDate.of(2025, 9, 12), status = TripStatus.DONE),
@@ -181,12 +182,20 @@ class TripStarterTest {
         repo.upsertStop(
             Stop(
                 id = "d1", tripId = doneId, name = "Durance", arrivalDate = LocalDate.of(2025, 9, 12),
-                orderIndex = 0, state = StopState.DONE, track = driven,
+                orderIndex = 0, state = StopState.DONE, track = driven, arrivalTime = LocalTime.of(16, 0),
             ),
         )
         val newId = TripStarter.planAgain(repo, doneId, LocalDate.of(2026, 9, 12))
-        assertTrue(repo.stops(newId).first().single().track.isEmpty())
+        val copy = repo.stops(newId).first().single()
+        assertTrue(copy.track.isEmpty())
+        assertNull(copy.arrivalTime)
         assertEquals(driven, repo.stops(doneId).first().single().track)
+        // The same for a tour started as a copy of a plan that was once driven.
+        val startedId = TripStarter.start(repo, newId, LocalDate.of(2026, 9, 12), keepPlanAsTemplate = true, settings = settings)
+        repo.upsertStop(repo.stops(newId).first().single().copy(arrivalTime = LocalTime.of(9, 0)))
+        val again = TripStarter.start(repo, newId, LocalDate.of(2026, 9, 12), keepPlanAsTemplate = true, settings = settings)
+        assertNotEquals(startedId, again)
+        assertNull(repo.stops(again).first().single().arrivalTime)
     }
 
     @Test

--- a/app/src/test/java/com/nuelto/etappli/ui/FormatTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/FormatTest.kt
@@ -7,6 +7,7 @@ import com.nuelto.etappli.data.model.TravelMode
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
 import com.nuelto.etappli.domain.DriveFromHere
+import com.nuelto.etappli.domain.Stay
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -213,6 +214,24 @@ class FormatTest {
             "arrive ${at(22, 30)} on ${formatDate(LocalDate.of(2026, 9, 3))}",
             formatArrival(2 * 24 * 3_600, evening),
         )
+    }
+
+    @Test
+    fun `the arrival is the day, with the time of day once recorded`() {
+        val day = LocalDate.of(2026, 9, 4)
+        assertEquals("Arrived ${formatDate(day)}", formatArrived(day, null))
+        val stamped = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM, FormatStyle.SHORT).format(day.atTime(16, 42))
+        assertEquals("Arrived $stamped", formatArrived(day, LocalTime.of(16, 42)))
+        assertTrue(stamped.contains("Sep 4, 2026"))
+    }
+
+    @Test
+    fun `the stay reads as the night ahead of you, and on the last morning as the leaving`() {
+        val leaving = LocalDate.of(2026, 9, 7)
+        assertEquals("Night 1 of 3 · leaving ${formatDate(leaving)}", formatStay(Stay.Progress(0, 3, leaving)))
+        assertEquals("Night 2 of 3 · leaving ${formatDate(leaving)}", formatStay(Stay.Progress(1, 2, leaving)))
+        assertEquals("Night 1 of 1 · leaving ${formatDate(leaving)}", formatStay(Stay.Progress(0, 1, leaving)))
+        assertEquals("Leaving ${formatDate(leaving)}", formatStay(Stay.Progress(3, 0, leaving)))
     }
 
     @Test

--- a/app/src/test/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreenTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/tripdetail/TripDetailScreenTest.kt
@@ -49,10 +49,14 @@ import com.nuelto.etappli.data.model.TripStatus
 import com.nuelto.etappli.testutil.TestCamperApp
 import com.nuelto.etappli.ui.map.LocalMapProvider
 import com.nuelto.etappli.ui.map.PlaceholderMapProvider
+import com.nuelto.etappli.domain.Stay
+import com.nuelto.etappli.ui.formatArrived
 import com.nuelto.etappli.ui.formatDate
+import com.nuelto.etappli.ui.formatStay
 import com.nuelto.etappli.ui.formatDriveFromHere
 import java.time.LocalDateTime
 import java.time.LocalDate
+import java.time.LocalTime
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -1012,9 +1016,124 @@ class TripDetailScreenTest {
         }
         setContent("a1", locatingViewModel(LatLng(46.9, 8.5), RoutedLeg("", 47_000, 3_300)))
         compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
-        compose.onNodeWithText("Checked in", useUnmergedTree = true).assertIsDisplayed()
+        compose.onNodeWithText("CHECKED IN", useUnmergedTree = true).assertIsDisplayed()
         compose.onAllNodesWithText("from here", substring = true).assertCountEquals(0)
-        compose.onAllNodesWithText("arrive", substring = true).assertCountEquals(0)
+        compose.onAllNodesWithText("arrive ", substring = true).assertCountEquals(0)
+    }
+
+    // --- checked in ------------------------------------------------------------------
+
+    /** Tonight's stop arrived at [daysAgo], with or without the time of day; the plan behind it follows. */
+    private fun checkIn(daysAgo: Long, time: LocalTime? = LocalTime.of(16, 42)) = runBlocking {
+        val stops = tripRepository.stops("a1").first()
+        val cur = stops.first { it.id == "cur" }.copy(state = StopState.DONE, arrivalDate = LocalDate.now().minusDays(daysAgo), arrivalTime = time)
+        val up = stops.first { it.id == "up" }.copy(arrivalDate = cur.arrivalDate.plusDays(cur.nights.toLong()))
+        tripRepository.upsertStops(listOf(cur, up))
+        cur
+    }
+
+    @Test
+    fun `the checked-in card says when you arrived, which night it is, and when you leave`() {
+        seedActive()
+        val cur = checkIn(daysAgo = 1)
+        setContent("a1")
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
+        compose.onNodeWithText("CHECKED IN").assertIsDisplayed()
+        compose.onNodeWithText(formatArrived(cur.arrivalDate, LocalTime.of(16, 42))).assertIsDisplayed()
+        compose.onNodeWithText("Night 2 of 3 · leaving ${formatDate(cur.arrivalDate.plusDays(3))}").assertIsDisplayed()
+        compose.onNodeWithText("Check out").assertIsDisplayed()
+        compose.onNodeWithText("Undo check-in").assertIsDisplayed()
+        compose.onAllNodesWithText("✓ Arrived").assertCountEquals(0)
+        compose.onAllNodesWithText("TONIGHT").assertCountEquals(0)
+        // The date is on the arrival line, not in front of the stepper.
+        compose.onAllNodesWithText("${formatDate(cur.arrivalDate)} ·").assertCountEquals(0)
+        compose.onNodeWithContentDescription("One night more").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a stop checked in before the time was recorded shows the day`() {
+        seedActive()
+        val cur = checkIn(daysAgo = 0, time = null)
+        setContent("a1")
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Camp Current"))
+        compose.onNodeWithText("Arrived ${formatDate(cur.arrivalDate)}").assertIsDisplayed()
+        compose.onNodeWithText(formatStay(Stay.progress(cur, LocalDate.now()))).assertIsDisplayed()
+    }
+
+    @Test
+    fun `check out moves on to the next stop`() {
+        seedActive()
+        checkIn(daysAgo = 1)
+        setContent("a1")
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Check out"))
+        compose.onNodeWithText("Check out").performClick()
+        compose.onNodeWithText("TONIGHT").assertIsDisplayed()
+        compose.onNodeWithText("✓ Arrived").assertIsDisplayed()
+        runBlocking {
+            val stops = tripRepository.stops("a1").first()
+            assertEquals(1, stops.single { it.id == "cur" }.nights)
+            assertEquals(LocalDate.now(), stops.single { it.id == "up" }.arrivalDate)
+        }
+        // A stay checked out is history, not a check-in to take back.
+        compose.onAllNodesWithContentDescription("Undo check-in").assertCountEquals(0)
+    }
+
+    @Test
+    fun `undo check-in makes it tonight's stop to arrive at again`() {
+        seedActive()
+        checkIn(daysAgo = 0)
+        setContent("a1")
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Undo check-in"))
+        compose.onNodeWithText("Undo check-in").performClick()
+        compose.onNodeWithText("TONIGHT").assertIsDisplayed()
+        compose.onNodeWithText("✓ Arrived").assertIsDisplayed()
+        runBlocking {
+            val cur = tripRepository.stops("a1").first().single { it.id == "cur" }
+            assertEquals(StopState.PLANNED, cur.state)
+            assertEquals(null, cur.arrivalTime)
+        }
+    }
+
+    @Test
+    fun `a visit the tracker checked in can be taken back from its row`() {
+        runBlocking {
+            tripRepository.upsertTrip(Trip(id = "a2", name = "Loop", startDate = LocalDate.now(), status = TripStatus.ACTIVE))
+            tripRepository.upsertStop(
+                Stop(id = "out", tripId = "a2", name = "Luzern", orderIndex = 0, nights = 0, kind = StopKind.HOME, state = StopState.DONE, arrivalDate = LocalDate.now()),
+            )
+            tripRepository.upsertStop(
+                Stop(
+                    id = "v", tripId = "a2", name = "Rütli", orderIndex = 1, nights = 0, kind = StopKind.VISIT,
+                    state = StopState.DONE, arrivalDate = LocalDate.now(), arrivalTime = LocalTime.of(12, 10),
+                ),
+            )
+            tripRepository.upsertStop(Stop(id = "up", tripId = "a2", name = "Brunnen", orderIndex = 2, nights = 1, arrivalDate = LocalDate.now()))
+        }
+        setContent("a2")
+        compose.onNodeWithTag("timeline").performScrollToNode(hasContentDescription("Undo check-in"))
+        compose.onNodeWithContentDescription("Undo check-in").performClick()
+        runBlocking {
+            val v = tripRepository.stops("a2").first().single { it.id == "v" }
+            assertEquals(StopState.PLANNED, v.state)
+            assertEquals(null, v.arrivalTime)
+        }
+        // Planned again it is the card, and the home it set out from has no arrival to take back.
+        compose.onNodeWithText("NEXT").assertIsDisplayed()
+        compose.onAllNodesWithContentDescription("Undo check-in").assertCountEquals(0)
+    }
+
+    @Test
+    fun `an estimated price on the checked-in card opens the price prompt, a known one does not`() {
+        seedActive()
+        checkIn(daysAgo = 0)
+        setContent("a1")
+        compose.onNodeWithTag("timeline").performScrollToNode(hasText("Check out"))
+        compose.onNodeWithText("≈ CHF135.00").performClick()
+        compose.onNodeWithText("Arrived at Camp Current").assertIsDisplayed()
+        compose.onNodeWithText("Price for the stay").performTextInput("120")
+        compose.onNodeWithText("Save price").performClick()
+        compose.onNodeWithText("CHF120.00").performClick()
+        compose.onAllNodesWithText("Arrived at Camp Current").assertCountEquals(0)
     }
 
     @Test
@@ -1103,6 +1222,6 @@ class TripDetailScreenTest {
         compose.onNodeWithText("TONIGHT").assertIsDisplayed()
         compose.onNodeWithText("Navigate").assertIsDisplayed()
         compose.onNodeWithText("Track this drive", useUnmergedTree = true).assertIsDisplayed()
-        compose.onAllNodesWithText("Checked in", useUnmergedTree = true).assertCountEquals(0)
+        compose.onAllNodesWithText("CHECKED IN", useUnmergedTree = true).assertCountEquals(0)
     }
 }

--- a/app/src/test/java/com/nuelto/etappli/ui/tripdetail/TripDetailViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/tripdetail/TripDetailViewModelTest.kt
@@ -21,7 +21,10 @@ import com.nuelto.etappli.domain.RoutedLeg
 import com.nuelto.etappli.domain.RouteRefresher
 import com.nuelto.etappli.domain.RouteTracker
 import com.nuelto.etappli.testutil.MainDispatcherRule
+import java.time.Duration
 import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZonedDateTime
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -235,8 +238,60 @@ class TripDetailViewModelTest {
         val s1 = stops().first { it.id == "s1" }
         assertEquals(StopState.DONE, s1.state)
         assertEquals(today, s1.arrivalDate)
+        assertNotNull(s1.arrivalTime)
         // One day late -> tomorrow instead of today.
         assertEquals(today.plusDays(1), stops().first { it.id == "s2" }.arrivalDate)
+    }
+
+    @Test
+    fun `check-out ends the stay today and pulls the plan forward`() = runTest {
+        val today = LocalDate.now()
+        tripRepository.upsertTrip(
+            Trip(id = "t1", name = "Now", startDate = today.minusDays(1), status = TripStatus.ACTIVE),
+        )
+        tripRepository.upsertStop(
+            Stop(
+                id = "s1", tripId = "t1", name = "A", nights = 3, arrivalDate = today.minusDays(1), orderIndex = 0,
+                state = StopState.DONE, arrivalTime = LocalTime.of(16, 0),
+            ),
+        )
+        tripRepository.upsertStop(
+            Stop(id = "s2", tripId = "t1", name = "B", nights = 1, arrivalDate = today.plusDays(2), orderIndex = 1),
+        )
+        val vm = hotViewModel()
+        assertEquals("s1", vm.uiState.value.currentStopId)
+        vm.checkOut("s1")
+        assertEquals(1, stops().first { it.id == "s1" }.nights)
+        assertEquals(today, stops().first { it.id == "s2" }.arrivalDate)
+        assertEquals("s2", vm.uiState.value.currentStopId)
+    }
+
+    @Test
+    fun `undoing a check-in plans the stop again and holds the tracker off it`() = runTest {
+        val today = LocalDate.now()
+        tripRepository.upsertTrip(Trip(id = "t1", name = "Now", startDate = today, status = TripStatus.ACTIVE))
+        tripRepository.upsertStop(
+            Stop(
+                id = "s1", tripId = "t1", name = "A", nights = 2, arrivalDate = today, orderIndex = 0,
+                location = hereFix, state = StopState.DONE, arrivalTime = LocalTime.of(16, 0),
+            ),
+        )
+        var clock = ZonedDateTime.now()
+        val tracker = RouteTracker(tripRepository, now = { clock })
+        val vm = locatingViewModel({ hereFix }, tracker = tracker) { _, _ -> null }
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { vm.uiState.collect { } }
+        vm.undoArrival("s1")
+        val s1 = stops().single()
+        assertEquals(StopState.PLANNED, s1.state)
+        assertNull(s1.arrivalTime)
+        assertEquals(today, s1.arrivalDate)
+        // Standing there for as long as you like changes nothing now — without the hold-off,
+        // these fixes would check the stop in again.
+        repeat(4) {
+            vm.refreshDriveFromHere()
+            clock += Duration.ofMinutes(4)
+        }
+        assertEquals(StopState.PLANNED, stops().single().state)
     }
 
     @Test
@@ -247,6 +302,15 @@ class TripDetailViewModelTest {
         val s1 = stops().first { it.id == "s1" }
         assertEquals(96.0, s1.campingCostTotal, 1e-9)
         assertTrue(s1.costKnown)
+    }
+
+    @Test
+    fun `a stop skipped is not arrived at`() = runTest {
+        seedTrip(status = TripStatus.ACTIVE)
+        tripRepository.upsertStop(stops().first { it.id == "s1" }.copy(state = StopState.DONE, arrivalTime = LocalTime.of(16, 0)))
+        val vm = hotViewModel()
+        vm.skip("s1")
+        assertNull(stops().first { it.id == "s1" }.arrivalTime)
     }
 
     @Test

--- a/app/src/test/java/com/nuelto/etappli/ui/tripedit/StopEditViewModelTest.kt
+++ b/app/src/test/java/com/nuelto/etappli/ui/tripedit/StopEditViewModelTest.kt
@@ -13,9 +13,11 @@ import com.nuelto.etappli.data.model.StopState
 import com.nuelto.etappli.data.model.Trip
 import com.nuelto.etappli.data.model.TripStatus
 import com.nuelto.etappli.data.model.UserSettings
+import com.nuelto.etappli.domain.Stay
 import com.nuelto.etappli.testutil.FakePlaceNameResolver
 import com.nuelto.etappli.testutil.MainDispatcherRule
 import java.time.LocalDate
+import java.time.LocalTime
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -609,6 +611,36 @@ class StopEditViewModelTest {
         val stops = tripRepository.stops("t1").first()
         assertEquals(track, stops.single { it.name == "Spontan" }.track)
         assertTrue(stops.single { it.id == "up" }.track.isEmpty())
+    }
+
+    @Test
+    fun `a check-in landing while the editor is open survives a save that left the date alone`() = runTest {
+        val today = LocalDate.now()
+        tripRepository.upsertTrip(Trip(id = "t1", name = "Trip", startDate = today.minusDays(1), status = TripStatus.ACTIVE))
+        tripRepository.upsertStop(
+            Stop(id = "a", tripId = "t1", name = "A", orderIndex = 0, arrivalDate = today.minusDays(1), nights = 1, location = LatLng(46.0, 7.0)),
+        )
+        tripRepository.upsertStop(Stop(id = "b", tripId = "t1", name = "B", orderIndex = 1, arrivalDate = today))
+        val vm = StopEditViewModel(
+            SavedStateHandle(mapOf("tripId" to "t1", "stopId" to "a")), tripRepository, settingsRepository, resolver,
+        )
+        // A day late, and checked in by the tracker while the notes were being typed.
+        tripRepository.upsertStops(Stay.checkIn(tripRepository.stops("t1").first(), "a", today.atTime(16, 5)))
+        vm.setNotes("Quiet")
+        vm.save {}
+        var stops = tripRepository.stops("t1").first()
+        val a = stops.single { it.id == "a" }
+        assertEquals(StopState.DONE, a.state)
+        assertEquals(today, a.arrivalDate)
+        assertEquals(LocalTime.of(16, 5), a.arrivalTime)
+        assertEquals("Quiet", a.notes)
+        assertEquals(today.plusDays(1), stops.single { it.id == "b" }.arrivalDate)
+        // A date the user did set still wins.
+        vm.setArrivalDate(today.plusDays(2))
+        vm.save {}
+        stops = tripRepository.stops("t1").first()
+        assertEquals(today.plusDays(2), stops.single { it.id == "a" }.arrivalDate)
+        assertEquals(today.plusDays(3), stops.single { it.id == "b" }.arrivalDate)
     }
 
     @Test


### PR DESCRIPTION
Closes #28.

## What changed

- **Automatic check-in.** Ten minutes of GPS fixes within 500 m of the stop an active trip is heading for, on or after the day it is planned for, check it in — the same write as ✓ Arrived (`domain/Stay`, run from `RouteTracker.fix`). The arrival is stamped with the *first* of those fixes; a late arrival shifts the plan behind as before. Only a fix a kilometre away resets the clock (a pitch on the edge of the site does not), and fixes further apart than three intervals (6 min) count as two visits, not a stay.
- **Check out** on the checked-in card ends the stay today and pulls the plan behind it forward (the stepper's −1, as many times as it takes).
- **The checked-in card** shows "Arrived Sep 4, 2026, 4:40 PM", "Night 2 of 3 · leaving Sep 7, 2026", the stepper, Check out and Undo check-in. Its ≈ price opens the price prompt, since a background check-in never shows one.
- **Undo check-in** takes a wrong automatic check-in back and holds the tracker off that stop until a fix has left it. A zero-night stop (visit, home) checked in by the tracker gets the undo on its timeline row, because it never has a card.
- **Model:** `Stop.arrivalTime: LocalTime?` next to `arrivalDate` (Firestore: seconds-of-day Long, null for old docs), so editing the date cannot split the two. Cleared wherever a stop becomes planned again.

## Why these choices

- The tracking service's location request **loses its 30 m distance filter**: a parked phone otherwise never delivers the fixes the dwell needs. Cost: one GPS wake per 2 min while parked with a heading underway (an unplanned night, an early arrival). Fixes worse than 250 m accuracy are dropped.
- A day-early arrival is deliberately not automatic (issue: "planned for today"); tap ✓ Arrived, or the service checks you in just after midnight.
- The dwell clock is zoned, so the ten minutes are real minutes on the night the clocks change.
- The stop editor now only writes the arrival date the user changed, so a check-in landing while the editor is open survives the save.

## Reviewer notes

- `./gradlew test :app:coverageVerify :app:pitest` all green (100 % line coverage, 94 % mutations killed).
- Verified twice on the emulator (local-only build): checked out of the demo stay, skipped the visit, fed fixes at Stellplatz Brunnen at the service's cadence — checked in ten minutes after the first delivered fix, stamped with it, notification gone. Row undo checked by hand.
- Accepted edge cases (in the commit message and CLAUDE.md): a sub-second race between the tracker's whole-stop write and a stepper tap (same class as every other whole-stop writer); a card left open past midnight shows a dead Check out until the next emission; the hold-off after an undo is in memory, so a process restart at the same spot checks you in again.
- `Tracks.MAX_ACCURACY_METERS` (250 m) and `Stay.FIX_GAP` (3 × the fix interval) are judgement calls on a Pixel; adjust if the real phone disagrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)